### PR TITLE
Simplify generation of po4a.conf

### DIFF
--- a/create_po4a_conf.sh
+++ b/create_po4a_conf.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
-(cat <<EOF
+cat <<EOF >po4a.conf
 [po4a_langs] fr
 [po4a_paths] po/documentation.pot \$lang:po/documentation.\$lang.po
 [options] opt: " -k 80"
 
 EOF
-) >po4a.conf 
 
 for f in $(cat sources.txt)
 do

--- a/po/documentation.fr.po
+++ b/po/documentation.fr.po
@@ -5,8 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: git documentation\n"
-"POT-Creation-Date: 2019-01-03 17:18+0100\n"
-"PO-Revision-Date: 2019-01-03 18:48+0100\n"
+"POT-Creation-Date: 2019-01-03 23:03+0100\n"
+"PO-Revision-Date: 2019-01-04 21:32+0100\n"
 "Last-Translator: Jean-Noël Avila <jn.avila@free.fr>\n"
 "Language-Team: Jean-Noël Avila <jn.avila@free.fr>\n"
 "Language: fr\n"
@@ -146,14 +146,14 @@ msgstr ""
 #: en/git-svn.txt:641 en/git.txt:591
 #, no-wrap
 msgid "-p"
-msgstr ""
+msgstr "-p"
 
 #. type: Labeled list
 #: en/blame-options.txt:40 en/git-commit.txt:109 en/git-push.txt:121
 #: en/git-worktree.txt:115
 #, no-wrap
 msgid "--porcelain"
-msgstr ""
+msgstr "--porcelain"
 
 #. type: Plain text
 #: en/blame-options.txt:42
@@ -13165,17 +13165,6 @@ msgstr "<spécificateur de chemin>..."
 
 #. type: Plain text
 #: en/git-add.txt:64
-#, fuzzy
-#| msgid ""
-#| "Files to add content from.  Fileglobs (e.g. `*.c`) can be given to add "
-#| "all matching files.  Also a leading directory name (e.g. `dir` to add "
-#| "`dir/file1` and `dir/file2`) can be given to update the index to match "
-#| "the current state of the directory as a whole (e.g.  specifying `dir` "
-#| "will record not just a file `dir/file1` modified in the working tree, a "
-#| "file `dir/file2` added to the working tree, but also a file `dir/file3` "
-#| "removed from the working tree).  Note that older versions of Git used to "
-#| "ignore removed files; use `--no-all` option if you want to add modified "
-#| "or new files but ignore removed ones."
 msgid ""
 "Files to add content from.  Fileglobs (e.g. `*.c`) can be given to add all "
 "matching files.  Also a leading directory name (e.g. `dir` to add `dir/"
@@ -13225,7 +13214,7 @@ msgstr "-i"
 #. type: Labeled list
 #: en/git-add.txt:79 en/git-am.txt:123 en/git-clean.txt:43
 #: en/git-rebase.txt:374 en/git-svn.txt:281
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "--interactive"
 msgstr "--interactive"
 
@@ -13243,7 +13232,6 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-add.txt:91
-#, fuzzy
 msgid ""
 "Interactively choose hunks of patch between the index and the work tree and "
 "add them to the index. This gives the user a chance to review the difference "
@@ -13786,18 +13774,14 @@ msgstr "Update>> -2\n"
 #
 #. type: Plain text
 #: en/git-add.txt:287
-#, fuzzy
 msgid ""
 "After making the selection, answer with an empty line to stage the contents "
 "of working tree files for selected paths in the index."
-msgstr ""
-"Après sélection, répondez avec une ligne vide pour indexer le contenu des "
-"fichiers sélectionnés de l'arbre de travail."
+msgstr "Après sélection, répondez avec une ligne vide pour indexer le contenu des fichiers sélectionnés de l'arbre de travail."
 
 #. type: Labeled list
 #: en/git-add.txt:288
-#, fuzzy, no-wrap
-#| msgid "revert"
+#, no-wrap
 msgid "revert"
 msgstr "revert"
 
@@ -14150,10 +14134,6 @@ msgstr "VOIR AUSSI"
 #
 #. type: Plain text
 #: en/git-add.txt:413
-#, fuzzy
-#| msgid ""
-#| "linkgit:git-status[1] linkgit:git-rm[1] linkgit:git-reset[1] linkgit:git-"
-#| "mv[1] linkgit:git-commit[1] linkgit:git-update-index[1]"
 msgid ""
 "linkgit:git-status[1] linkgit:git-rm[1] linkgit:git-reset[1] linkgit:git-"
 "mv[1] linkgit:git-commit[1] linkgit:git-update-index[1]"
@@ -18151,16 +18131,20 @@ msgid ""
 "the number of references and objects that may be packaged."
 msgstr ""
 
+#. type: Labeled list
+#: en/git-bundle.txt:71
+#, fuzzy, no-wrap
+#| msgid "<file>..."
+msgid "[<refname>...]"
+msgstr "<fichier>..."
+
 #. type: Plain text
 #: en/git-bundle.txt:77
-#, no-wrap
 msgid ""
-"[<refname>...]::\n"
-"\tA list of references used to limit the references reported as\n"
-"\tavailable. This is principally of use to 'git fetch', which\n"
-"\texpects to receive only those references asked for and not\n"
-"\tnecessarily everything in the pack (in this case, 'git bundle' acts\n"
-"\tlike 'git fetch-pack').\n"
+"A list of references used to limit the references reported as available. "
+"This is principally of use to 'git fetch', which expects to receive only "
+"those references asked for and not necessarily everything in the pack (in "
+"this case, 'git bundle' acts like 'git fetch-pack')."
 msgstr ""
 
 #. type: Title -
@@ -22737,7 +22721,7 @@ msgstr ""
 #: en/git-commit-tree.txt:63 en/git-commit.txt:332
 #, no-wrap
 msgid "--no-gpg-sign"
-msgstr ""
+msgstr "--no-gpg-sign"
 
 #. type: Plain text
 #: en/git-commit-tree.txt:66
@@ -22966,7 +22950,10 @@ msgstr ""
 msgid ""
 "Tell the command to automatically stage files that have been modified and "
 "deleted, but new files you have not told Git about are not affected."
-msgstr "Indiquer à la commande d'indexer automatiquement les fichiers qui ont été modifiés ou supprimés, mais les nouveaux fichiers dont vous n'avez pas signalé la présence à Git ne sont pas affectés."
+msgstr ""
+"Indiquer à la commande d'indexer automatiquement les fichiers qui ont été "
+"modifiés ou supprimés, mais les nouveaux fichiers dont vous n'avez pas "
+"signalé la présence à Git ne sont pas affectés."
 
 #. type: Plain text
 #: en/git-commit.txt:71
@@ -23017,7 +23004,9 @@ msgstr ""
 msgid ""
 "Like '-C', but with `-c` the editor is invoked, so that the user can further "
 "edit the commit message."
-msgstr "Comme '-C', mais avec '-c', l'éditeur est appelé pour permettre à l'utilisateur de modifier le message de validation."
+msgstr ""
+"Comme '-C', mais avec '-c', l'éditeur est appelé pour permettre à "
+"l'utilisateur de modifier le message de validation."
 
 #. type: Labeled list
 #: en/git-commit.txt:83
@@ -23032,7 +23021,11 @@ msgid ""
 "Construct a commit message for use with `rebase --autosquash`.  The commit "
 "message will be the subject line from the specified commit with a prefix of "
 "\"fixup! \".  See linkgit:git-rebase[1] for details."
-msgstr "Construire un message de validation pour une utilisation avec `rebase --autosquash`. Le message de validation sera la ligne de titre du commit spécifié préfixé de « fixup!  ». Référez-vous à linkgit:git-rebase[1] pour de plus amples détails."
+msgstr ""
+"Construire un message de validation pour une utilisation avec `rebase --"
+"autosquash`. Le message de validation sera la ligne de titre du commit "
+"spécifié préfixé de « fixup!  ». Référez-vous à linkgit:git-rebase[1] pour "
+"de plus amples détails."
 
 #. type: Labeled list
 #: en/git-commit.txt:89
@@ -23047,7 +23040,12 @@ msgid ""
 "message subject line is taken from the specified commit with a prefix of "
 "\"squash! \".  Can be used with additional commit message options (`-m`/`-c`/"
 "`-C`/`-F`). See linkgit:git-rebase[1] for details."
-msgstr "Construire un message de validation pour une utilisation avec `rebase --autosquash`. La ligne de titre du message de validation est tirée du commit spécifié préfixé par « squash! ». Peut être utilisé avec d'autres options de 'commit' (`-m`/`-c`/`-C`/`-F`). Référez-vous à linkgit:git-rebase[1] pour plus de détails."
+msgstr ""
+"Construire un message de validation pour une utilisation avec `rebase --"
+"autosquash`. La ligne de titre du message de validation est tirée du commit "
+"spécifié préfixé par « squash! ». Peut être utilisé avec d'autres options de "
+"'commit' (`-m`/`-c`/`-C`/`-F`). Référez-vous à linkgit:git-rebase[1] pour "
+"plus de détails."
 
 #. type: Labeled list
 #: en/git-commit.txt:96
@@ -23061,7 +23059,10 @@ msgid ""
 "When used with -C/-c/--amend options, or when committing after a a "
 "conflicting cherry-pick, declare that the authorship of the resulting commit "
 "now belongs to the committer. This also renews the author timestamp."
-msgstr "Utilisé avec les options -C/-c/--amend ou lors de validation après un picorage conflictuel, déclarer que la paternité du commit résultant appartient à présent au validateur avec un horodatage mis à jour."
+msgstr ""
+"Utilisé avec les options -C/-c/--amend ou lors de validation après un "
+"picorage conflictuel, déclarer que la paternité du commit résultant "
+"appartient à présent au validateur avec un horodatage mis à jour."
 
 #. type: Labeled list
 #: en/git-commit.txt:102 en/git-rev-parse.txt:139 en/git-status.txt:28
@@ -23075,7 +23076,9 @@ msgstr "--short"
 msgid ""
 "When doing a dry-run, give the output in the short-format. See linkgit:git-"
 "status[1] for details. Implies `--dry-run`."
-msgstr "Seulement avec '--dry-run', fournir la sortie en format court. Voir linkgit:git-status[1] pour plus de détails."
+msgstr ""
+"Seulement avec '--dry-run', fournir la sortie en format court. Voir linkgit:"
+"git-status[1] pour plus de détails."
 
 #. type: Labeled list
 #: en/git-commit.txt:106 en/git-status.txt:32 en/git-submodule.txt:280
@@ -23086,14 +23089,17 @@ msgstr "--branch"
 #. type: Plain text
 #: en/git-commit.txt:108 en/git-status.txt:34
 msgid "Show the branch and tracking info even in short-format."
-msgstr "Montrer la branche et l'information de suivi, y compris en format court."
+msgstr ""
+"Montrer la branche et l'information de suivi, y compris en format court."
 
 #. type: Plain text
 #: en/git-commit.txt:113
 msgid ""
 "When doing a dry-run, give the output in a porcelain-ready format. See "
 "linkgit:git-status[1] for details. Implies `--dry-run`."
-msgstr "Seulement avec '--dry-run', donner la sortie en format compatible porcelaine. Voir linkgit:git-status[1] pour plus de détails."
+msgstr ""
+"Seulement avec '--dry-run', donner la sortie en format compatible "
+"porcelaine. Voir linkgit:git-status[1] pour plus de détails."
 
 #. type: Labeled list
 #: en/git-commit.txt:114 en/git-describe.txt:74 en/git-ls-tree.txt:52
@@ -23123,7 +23129,12 @@ msgid ""
 "given, implies the `--porcelain` output format.  Without the `-z` option, "
 "filenames with \"unusual\" characters are quoted as explained for the "
 "configuration variable `core.quotePath` (see linkgit:git-config[1])."
-msgstr "Avec les sorties de status `short` ou `porcelain`, afficher le nom du fichier verbatim et terminer par NUL, au lieu de LF. Si aucun format n'est spécifié, implique `--porcelain`. Sans l'option `-z`, les noms de fichier contenant des caractères « inusuels » sont cités selon la variable de configuration `core.quotePath` (voir linkgit:git-config[1]). "
+msgstr ""
+"Avec les sorties de status `short` ou `porcelain`, afficher le nom du "
+"fichier verbatim et terminer par NUL, au lieu de LF. Si aucun format n'est "
+"spécifié, implique `--porcelain`. Sans l'option `-z`, les noms de fichier "
+"contenant des caractères « inusuels » sont cités selon la variable de "
+"configuration `core.quotePath` (voir linkgit:git-config[1]). "
 
 #. type: Labeled list
 #: en/git-commit.txt:128 en/git-notes.txt:141 en/git-tag.txt:139
@@ -23154,7 +23165,12 @@ msgid ""
 "pattern and is used to search for an existing commit by that author (i.e. "
 "rev-list --all -i --author=<author>); the commit author is then copied from "
 "the first such commit found."
-msgstr "Surcharger l'auteur du commit. Spécifier un auteur explicite avec le format standard `A U Teur <auteur@exemple.com>`. Sinon <auteur> est considéré comme un patron utilisé pour chercher un commit existant par cet auteur (c-à-d rev-list --all -i --author=<auteur>) ; l'auteur du commit est alors copié depuis le premier commit trouvé."
+msgstr ""
+"Surcharger l'auteur du commit. Spécifier un auteur explicite avec le format "
+"standard `A U Teur <auteur@exemple.com>`. Sinon <auteur> est considéré comme "
+"un patron utilisé pour chercher un commit existant par cet auteur (c-à-d rev-"
+"list --all -i --author=<auteur>) ; l'auteur du commit est alors copié depuis "
+"le premier commit trouvé."
 
 #. type: Labeled list
 #: en/git-commit.txt:139
@@ -23185,7 +23201,9 @@ msgstr "--message=<msg>"
 msgid ""
 "Use the given <msg> as the commit message.  If multiple `-m` options are "
 "given, their values are concatenated as separate paragraphs."
-msgstr "Utiliser le <msg> fourni comme message de validation. Si plusieurs options `-m` sont fournies, leurs valeurs sont concaténées comme paragraphes séparés."
+msgstr ""
+"Utiliser le <msg> fourni comme message de validation. Si plusieurs options `-"
+"m` sont fournies, leurs valeurs sont concaténées comme paragraphes séparés."
 
 #. type: Labeled list
 #: en/git-commit.txt:148
@@ -23209,7 +23227,15 @@ msgid ""
 "the message in what order.  If the user exits the editor without editing the "
 "message, the commit is aborted.  This has no effect when a message is given "
 "by other means, e.g. with the `-m` or `-F` options."
-msgstr "À l'édition du message de validation, démarrer l'éditeur avec le contenu du fichier indiqué. La variable de configuration `commit.template` est souvent utilisée pour fournir implicitement cette option à la commande. Ce mécanisme peut être utilisé par les projets qui souhaitent guider les collaborateurs avec une aide sur ce qu'il faut écrire dans le message et dans quel ordre. Si l'utilisateur sort de l'éditeur sans changer le message, la validation est annulée. Ceci n'a aucun effet quand un message est fourni par un autre moyen, par exemple par les options `-m` ou `-F`."
+msgstr ""
+"À l'édition du message de validation, démarrer l'éditeur avec le contenu du "
+"fichier indiqué. La variable de configuration `commit.template` est souvent "
+"utilisée pour fournir implicitement cette option à la commande. Ce mécanisme "
+"peut être utilisé par les projets qui souhaitent guider les collaborateurs "
+"avec une aide sur ce qu'il faut écrire dans le message et dans quel ordre. "
+"Si l'utilisateur sort de l'éditeur sans changer le message, la validation "
+"est annulée. Ceci n'a aucun effet quand un message est fourni par un autre "
+"moyen, par exemple par les options `-m` ou `-F`."
 
 #. type: Plain text
 #: en/git-commit.txt:167
@@ -23219,7 +23245,12 @@ msgid ""
 "certifies that committer has the rights to submit this work under the same "
 "license and agrees to a Developer Certificate of Origin (see http://"
 "developercertificate.org/ for more information)."
-msgstr "Ajouter une ligne Signed-off-by du validateur à la fin du message de validation. La signification de signoff dépend du projet, mais ceci certifie typiquement que le validateur a les droits de soumettre son travail sous la même licence et accepte un Certificat d'Origine de Développeur (voir http://developercertificate.org/ pour plus d'information). "
+msgstr ""
+"Ajouter une ligne Signed-off-by du validateur à la fin du message de "
+"validation. La signification de signoff dépend du projet, mais ceci certifie "
+"typiquement que le validateur a les droits de soumettre son travail sous la "
+"même licence et accepte un Certificat d'Origine de Développeur (voir http://"
+"developercertificate.org/ pour plus d'information). "
 
 #. type: Labeled list
 #: en/git-commit.txt:169 en/git-rebase.txt:322
@@ -23232,7 +23263,9 @@ msgstr "--no-verify"
 msgid ""
 "This option bypasses the pre-commit and commit-msg hooks.  See also linkgit:"
 "githooks[5]."
-msgstr "Cette option court-circuite les crochets pre-commit et commit-msg. Voir aussi linkgit:githooks[5]."
+msgstr ""
+"Cette option court-circuite les crochets pre-commit et commit-msg. Voir "
+"aussi linkgit:githooks[5]."
 
 #. type: Plain text
 #: en/git-commit.txt:178
@@ -23241,7 +23274,11 @@ msgid ""
 "commit is a mistake, and the command prevents you from making such a "
 "commit.  This option bypasses the safety, and is primarily for use by "
 "foreign SCM interface scripts."
-msgstr "Généralement enregistrer un commit qui pointe sur la même version que son unique parent est une erreur et la commande vous empêche de créer un tel commit. Cette option court-circuite cette sécurité et sert principalement dans les scripts d'interface avec d'autres SCM."
+msgstr ""
+"Généralement enregistrer un commit qui pointe sur la même version que son "
+"unique parent est une erreur et la commande vous empêche de créer un tel "
+"commit. Cette option court-circuite cette sécurité et sert principalement "
+"dans les scripts d'interface avec d'autres SCM."
 
 #. type: Plain text
 #: en/git-commit.txt:184
@@ -23249,7 +23286,11 @@ msgid ""
 "Like --allow-empty this command is primarily for use by foreign SCM "
 "interface scripts. It allows you to create a commit with an empty commit "
 "message without using plumbing commands like linkgit:git-commit-tree[1]."
-msgstr "Comme --allow-empty cette commande est principalement utilisée par les scripts d'interface d'autres SCM. Elle vous permet de créer un commit avec un message vide sans utiliser de commande de plomberie telle que linkgit:git-commit-tree[1]."
+msgstr ""
+"Comme --allow-empty cette commande est principalement utilisée par les "
+"scripts d'interface d'autres SCM. Elle vous permet de créer un commit avec "
+"un message vide sans utiliser de commande de plomberie telle que linkgit:git-"
+"commit-tree[1]."
 
 #. type: Labeled list
 #: en/git-commit.txt:185 en/git-tag.txt:145
@@ -23263,7 +23304,10 @@ msgid ""
 "This option determines how the supplied commit message should be cleaned up "
 "before committing.  The '<mode>' can be `strip`, `whitespace`, `verbatim`, "
 "`scissors` or `default`."
-msgstr "Cette option détermine comment le message fourni doit être nettoyé avant la validation. Le '<mode>' peut être `strip`, `whitespace`, `verbatim`, `scissors` ou `default`."
+msgstr ""
+"Cette option détermine comment le message fourni doit être nettoyé avant la "
+"validation. Le '<mode>' peut être `strip`, `whitespace`, `verbatim`, "
+"`scissors` ou `default`."
 
 #. type: Labeled list
 #: en/git-commit.txt:191
@@ -23355,7 +23399,11 @@ msgid ""
 "commit object with `-C` are usually used as the commit log message "
 "unmodified. This option lets you further edit the message taken from these "
 "sources."
-msgstr "Le message tiré d'un fichier avec `-F`, ou de la ligne de commande avec `-m`, ou depuis un objet commit avec `-C` est généralement utilisé sans modification. Cette option permet d'éditer au passage le message tiré de ces sources."
+msgstr ""
+"Le message tiré d'un fichier avec `-F`, ou de la ligne de commande avec `-"
+"m`, ou depuis un objet commit avec `-C` est généralement utilisé sans "
+"modification. Cette option permet d'éditer au passage le message tiré de ces "
+"sources."
 
 #. type: Labeled list
 #: en/git-commit.txt:219 en/git-revert.txt:65 en/merge-options.txt:12
@@ -23369,7 +23417,10 @@ msgid ""
 "Use the selected commit message without launching an editor.  For example, "
 "`git commit --amend --no-edit` amends a commit without changing its commit "
 "message."
-msgstr "Utiliser le message de validation sélectionné sans lancer d'éditeur. Par exemple, `git commit --amend --no-edit` corrige un commit sans changer son message de validation."
+msgstr ""
+"Utiliser le message de validation sélectionné sans lancer d'éditeur. Par "
+"exemple, `git commit --amend --no-edit` corrige un commit sans changer son "
+"message de validation."
 
 #. type: Labeled list
 #: en/git-commit.txt:224
@@ -23388,7 +23439,15 @@ msgid ""
 "specified from the command line via options such as `-m`, `-F`, `-c`, etc.  "
 "The new commit has the same parents and author as the current one (the `--"
 "reset-author` option can countermand this)."
-msgstr "Remplacer le sommet de la branche actuelle en créant un nouveau commit. L'arbre enregistré est préparé comme d'habitude (incluant l'effet des options `-i` et `-o` et les spécificateurs explicites de chemin) et le message du commit originel est utilisé comme point de départ au lieu d'un message vide, quand aucun autre message n'est spécifié à la ligne de commande via des options telles que `-m`, `-F`, `-c`, etc. Le nouveau commit a les mêmes parents et auteur que l'originel (l'option `--reset-author` peut modifier l'auteur)."
+msgstr ""
+"Remplacer le sommet de la branche actuelle en créant un nouveau commit. "
+"L'arbre enregistré est préparé comme d'habitude (incluant l'effet des "
+"options `-i` et `-o` et les spécificateurs explicites de chemin) et le "
+"message du commit originel est utilisé comme point de départ au lieu d'un "
+"message vide, quand aucun autre message n'est spécifié à la ligne de "
+"commande via des options telles que `-m`, `-F`, `-c`, etc. Le nouveau commit "
+"a les mêmes parents et auteur que l'originel (l'option `--reset-author` peut "
+"modifier l'auteur)."
 
 #. type: Plain text
 #: en/git-commit.txt:237
@@ -23446,7 +23505,11 @@ msgid ""
 "Before making a commit out of staged contents so far, stage the contents of "
 "paths given on the command line as well.  This is usually not what you want "
 "unless you are concluding a conflicted merge."
-msgstr "Avant de créer un commit à partir du contenu indexé jusqu'à présent, indexer aussi les contenus des chemins fournis sur la ligne de commande. Cela n'est habituellement pas ce que vous souhaitez, à part si vous terminez une fusion conflictuelle."
+msgstr ""
+"Avant de créer un commit à partir du contenu indexé jusqu'à présent, indexer "
+"aussi les contenus des chemins fournis sur la ligne de commande. Cela n'est "
+"habituellement pas ce que vous souhaitez, à part si vous terminez une fusion "
+"conflictuelle."
 
 #. type: Labeled list
 #: en/git-commit.txt:261
@@ -23466,7 +23529,16 @@ msgid ""
 "commit without committing changes that have already been staged. If used "
 "together with `--allow-empty` paths are also not required, and an empty "
 "commit will be created."
-msgstr "Réaliser une validation en prenant le contenu de l'arbre de travail des chemins spécifiés sur la ligne de commande, en ignorant tout contenu d'autres chemins déjà indexé. C'est le mode d'opération par défaut de 'git commit' si des chemins sont fournis sur la ligne de commande, auquel cas l'option peut être omise. Si cette option est spécifiée en même temps que `--amend`, alors il n'est pas nécessaire de spécifier des chemins, ce qui peut être utile pour corriger le dernier commit sans valider les modifications qui ont déjà été indexées. Si utilisé avec `--allow-empty`, les chemins ne sont pas nécessaires non plus et un commit vide sera créé."
+msgstr ""
+"Réaliser une validation en prenant le contenu de l'arbre de travail des "
+"chemins spécifiés sur la ligne de commande, en ignorant tout contenu "
+"d'autres chemins déjà indexé. C'est le mode d'opération par défaut de 'git "
+"commit' si des chemins sont fournis sur la ligne de commande, auquel cas "
+"l'option peut être omise. Si cette option est spécifiée en même temps que `--"
+"amend`, alors il n'est pas nécessaire de spécifier des chemins, ce qui peut "
+"être utile pour corriger le dernier commit sans valider les modifications "
+"qui ont déjà été indexées. Si utilisé avec `--allow-empty`, les chemins ne "
+"sont pas nécessaires non plus et un commit vide sera créé."
 
 #. type: Labeled list
 #: en/git-commit.txt:274 en/git-status.txt:55
@@ -23538,7 +23610,13 @@ msgid ""
 "doesn't have its lines prefixed with '#'. This diff will not be a part of "
 "the commit message. See the `commit.verbose` configuration variable in "
 "linkgit:git-config[1]."
-msgstr "Afficher en bas du modèle de message de validation un diff unifié entre le commit HEAD et ce qui serait validé pour aider l'utilisateur à décrire le commit en lui rappelant les modifications qui seront validées. Veuillez noter que cette sortie de diff n'est pas préfixée par des '#'. Elle ne fera pas pour autant partie du message de validation. Référez-vous à la variable de configuration `commit.verbose` dans linkgit:git-config[1]. "
+msgstr ""
+"Afficher en bas du modèle de message de validation un diff unifié entre le "
+"commit HEAD et ce qui serait validé pour aider l'utilisateur à décrire le "
+"commit en lui rappelant les modifications qui seront validées. Veuillez "
+"noter que cette sortie de diff n'est pas préfixée par des '#'. Elle ne fera "
+"pas pour autant partie du message de validation. Référez-vous à la variable "
+"de configuration `commit.verbose` dans linkgit:git-config[1]. "
 
 #. type: Plain text
 #: en/git-commit.txt:305
@@ -23561,7 +23639,10 @@ msgid ""
 "Do not create a commit, but show a list of paths that are to be committed, "
 "paths with local changes that will be left uncommitted and paths that are "
 "untracked."
-msgstr "Ne pas créer de commit, mais montrer une liste des chemins qui seront validés, une de ceux contenant des modifications locales et qui ne seront pas validés, et une de ceux non-suivis."
+msgstr ""
+"Ne pas créer de commit, mais montrer une liste des chemins qui seront "
+"validés, une de ceux contenant des modifications locales et qui ne seront "
+"pas validés, et une de ceux non-suivis."
 
 #. type: Labeled list
 #: en/git-commit.txt:315
@@ -23575,7 +23656,11 @@ msgid ""
 "Include the output of linkgit:git-status[1] in the commit message template "
 "when using an editor to prepare the commit message.  Defaults to on, but can "
 "be used to override configuration variable commit.status."
-msgstr "Inclure la sortie de linkgit:git-status[1] dans le modèle de message de validation lors de l'utilisation d'un éditeur pour préparer le message de validation. Activé par défaut, mais peut surcharger la variable de configuration commit.status."
+msgstr ""
+"Inclure la sortie de linkgit:git-status[1] dans le modèle de message de "
+"validation lors de l'utilisation d'un éditeur pour préparer le message de "
+"validation. Activé par défaut, mais peut surcharger la variable de "
+"configuration commit.status."
 
 #. type: Labeled list
 #: en/git-commit.txt:321
@@ -23588,14 +23673,19 @@ msgstr "--no-status"
 msgid ""
 "Do not include the output of linkgit:git-status[1] in the commit message "
 "template when using an editor to prepare the default commit message."
-msgstr "Ne pas inclure la sortie de linkgit:git-status[1] dans le modèle de message de validation lors de l'utilisation d'un éditeur pour préparer le message de validation par défaut."
+msgstr ""
+"Ne pas inclure la sortie de linkgit:git-status[1] dans le modèle de message "
+"de validation lors de l'utilisation d'un éditeur pour préparer le message de "
+"validation par défaut."
 
 #. type: Plain text
 #: en/git-commit.txt:335
 msgid ""
 "Countermand `commit.gpgSign` configuration variable that is set to force "
 "each and every commit to be signed."
-msgstr "Annuler la variable de configuration `commit.gpgSign` qui force tous les commits à être signés."
+msgstr ""
+"Annuler la variable de configuration `commit.gpgSign` qui force tous les "
+"commits à être signés."
 
 #. type: Labeled list
 #: en/git-commit.txt:339 en/git-rm.txt:29
@@ -23610,7 +23700,11 @@ msgid ""
 "of the named files, without recording the changes already staged.  The "
 "contents of these files are also staged for the next commit on top of what "
 "have been staged before."
-msgstr "Quand des chemins sont fournis sur la ligne de commande, la commande valide le contenu des fichiers spécifiés, sans enregistrer les modifications déjà indexées. Le contenu de ces fichiers est aussi indexé pour le commit suivant par-dessus ce qui a été indexé auparavant."
+msgstr ""
+"Quand des chemins sont fournis sur la ligne de commande, la commande valide "
+"le contenu des fichiers spécifiés, sans enregistrer les modifications déjà "
+"indexées. Le contenu de ces fichiers est aussi indexé pour le commit suivant "
+"par-dessus ce qui a été indexé auparavant."
 
 #. type: Plain text
 #: en/git-commit.txt:362
@@ -23624,7 +23718,18 @@ msgid ""
 "incrementally with these commands, `git commit` (without any pathname "
 "parameter) is used to record what has been staged so far.  This is the most "
 "basic form of the command.  An example:"
-msgstr "Lors de l'enregistrement de votre propre travail, le contenu des fichiers modifiés dans votre arbre de travail est temporairement stocké au moyen de `git add` dans une zone de stockage intermédiaire appelée « l'index ». Un fichier peut n'être ramené à son contenu correspondant au dernier commit seulement dans l'index mais pas dans l'arbre de travail grâce à `git reset HEAD -- <fichier>`, ce qui inverse effectivement le 'git add' et empêche les modifications de ce fichier de participer à la prochaine validation. Après avoir construit l'état à valider de manière incrémentale avec ces commandes, `git commit` (sans aucun nom de chemin en paramètre) sert à enregistrer ce qui a été préparé jusqu'ici. C'est la forme la plus simple de la commande. Par exemple :"
+msgstr ""
+"Lors de l'enregistrement de votre propre travail, le contenu des fichiers "
+"modifiés dans votre arbre de travail est temporairement stocké au moyen de "
+"`git add` dans une zone de stockage intermédiaire appelée « l'index ». Un "
+"fichier peut n'être ramené à son contenu correspondant au dernier commit "
+"seulement dans l'index mais pas dans l'arbre de travail grâce à `git reset "
+"HEAD -- <fichier>`, ce qui inverse effectivement le 'git add' et empêche les "
+"modifications de ce fichier de participer à la prochaine validation. Après "
+"avoir construit l'état à valider de manière incrémentale avec ces commandes, "
+"`git commit` (sans aucun nom de chemin en paramètre) sert à enregistrer ce "
+"qui a été préparé jusqu'ici. C'est la forme la plus simple de la commande. "
+"Par exemple :"
 
 #. type: delimited block -
 #: en/git-commit.txt:368
@@ -24380,43 +24485,62 @@ msgid ""
 "will search for configuration options:"
 msgstr ""
 
+#. type: Labeled list
+#: en/git-config.txt:238
+#, no-wrap
+msgid "$(prefix)/etc/gitconfig"
+msgstr ""
+
 #. type: Plain text
 #: en/git-config.txt:240
+msgid "System-wide configuration file."
+msgstr ""
+
+#. type: Labeled list
+#: en/git-config.txt:241
 #, no-wrap
-msgid ""
-"$(prefix)/etc/gitconfig::\n"
-"\tSystem-wide configuration file.\n"
+msgid "$XDG_CONFIG_HOME/git/config"
 msgstr ""
 
 #. type: Plain text
 #: en/git-config.txt:248
-#, no-wrap
 msgid ""
-"$XDG_CONFIG_HOME/git/config::\n"
-"\tSecond user-specific configuration file. If $XDG_CONFIG_HOME is not set\n"
-"\tor empty, `$HOME/.config/git/config` will be used. Any single-valued\n"
-"\tvariable set in this file will be overwritten by whatever is in\n"
-"\t`~/.gitconfig`.  It is a good idea not to create this file if\n"
-"\tyou sometimes use older versions of Git, as support for this\n"
-"\tfile was added fairly recently.\n"
+"Second user-specific configuration file. If $XDG_CONFIG_HOME is not set or "
+"empty, `$HOME/.config/git/config` will be used. Any single-valued variable "
+"set in this file will be overwritten by whatever is in `~/.gitconfig`.  It "
+"is a good idea not to create this file if you sometimes use older versions "
+"of Git, as support for this file was added fairly recently."
 msgstr ""
+
+#. type: Labeled list
+#: en/git-config.txt:249
+#, fuzzy, no-wrap
+#| msgid "git-commit(1)"
+msgid "~/.gitconfig"
+msgstr "git-commit(1)"
 
 #. type: Plain text
 #: en/git-config.txt:252
-#, no-wrap
 msgid ""
-"~/.gitconfig::\n"
-"\tUser-specific configuration file. Also called \"global\"\n"
-"\tconfiguration file.\n"
+"User-specific configuration file. Also called \"global\" configuration file."
+msgstr ""
+
+#. type: Labeled list
+#: en/git-config.txt:253
+#, no-wrap
+msgid "$GIT_DIR/config"
 msgstr ""
 
 #. type: Plain text
 #: en/git-config.txt:255
-#, no-wrap
-msgid ""
-"$GIT_DIR/config::\n"
-"\tRepository specific configuration file.\n"
+#, fuzzy
+#| msgid ""
+#| "by using 'git rm' to remove files from the working tree and the index, "
+#| "again before using the 'commit' command;"
+msgid "Repository specific configuration file."
 msgstr ""
+"en utilisant 'git rm' pour supprimer des fichiers de l'arbre de travail et "
+"de l'index, encore une fois, avant d'utiliser la commande 'commit',"
 
 #. type: Plain text
 #: en/git-config.txt:261
@@ -25061,24 +25185,32 @@ msgid ""
 "credential-store will search for credentials in order of precedence:"
 msgstr ""
 
+#. type: Labeled list
+#: en/git-credential-store.txt:50
+#, fuzzy, no-wrap
+#| msgid "git-commit(1)"
+msgid "~/.git-credentials"
+msgstr "git-commit(1)"
+
 #. type: Plain text
 #: en/git-credential-store.txt:52
+msgid "User-specific credentials file."
+msgstr ""
+
+#. type: Labeled list
+#: en/git-credential-store.txt:53
 #, no-wrap
-msgid ""
-"~/.git-credentials::\n"
-"\tUser-specific credentials file.\n"
+msgid "$XDG_CONFIG_HOME/git/credentials"
 msgstr ""
 
 #. type: Plain text
 #: en/git-credential-store.txt:59
-#, no-wrap
 msgid ""
-"$XDG_CONFIG_HOME/git/credentials::\n"
-"\tSecond user-specific credentials file. If '$XDG_CONFIG_HOME' is not set\n"
-"\tor empty, `$HOME/.config/git/credentials` will be used. Any credentials\n"
-"\tstored in this file will not be used if `~/.git-credentials` has a\n"
-"\tmatching credential as well. It is a good idea not to create this file\n"
-"\tif you sometimes use older versions of Git that do not support it.\n"
+"Second user-specific credentials file. If '$XDG_CONFIG_HOME' is not set or "
+"empty, `$HOME/.config/git/credentials` will be used. Any credentials stored "
+"in this file will not be used if `~/.git-credentials` has a matching "
+"credential as well. It is a good idea not to create this file if you "
+"sometimes use older versions of Git that do not support it."
 msgstr ""
 
 #. type: Plain text
@@ -26634,25 +26766,64 @@ msgstr ""
 msgid "In `dbDriver` and `dbUser` you can use the following variables:"
 msgstr ""
 
+#. type: Labeled list
+#: en/git-cvsserver.txt:293
+#, no-wrap
+msgid "%G"
+msgstr ""
+
+#. type: Plain text
+#: en/git-cvsserver.txt:295
+msgid "Git directory name"
+msgstr ""
+
+#. type: Labeled list
+#: en/git-cvsserver.txt:295
+#, no-wrap
+msgid "%g"
+msgstr ""
+
+#. type: Plain text
+#: en/git-cvsserver.txt:300
+msgid ""
+"Git directory name, where all characters except for alpha-numeric ones, `.`, "
+"and `-` are replaced with `_` (this should make it easier to use the "
+"directory name in a filename if wanted)"
+msgstr ""
+
+#. type: Labeled list
+#: en/git-cvsserver.txt:300
+#, no-wrap
+msgid "%m"
+msgstr ""
+
+#. type: Plain text
+#: en/git-cvsserver.txt:302
+msgid "CVS module/Git head name"
+msgstr ""
+
+#. type: Labeled list
+#: en/git-cvsserver.txt:302
+#, no-wrap
+msgid "%a"
+msgstr ""
+
+#. type: Plain text
+#: en/git-cvsserver.txt:304
+msgid "access method (one of \"ext\" or \"pserver\")"
+msgstr ""
+
+#. type: Labeled list
+#: en/git-cvsserver.txt:304
+#, no-wrap
+msgid "%u"
+msgstr ""
+
 #. type: Plain text
 #: en/git-cvsserver.txt:308
-#, no-wrap
 msgid ""
-"%G::\n"
-"\tGit directory name\n"
-"%g::\n"
-"\tGit directory name, where all characters except for\n"
-"\talpha-numeric ones, `.`, and `-` are replaced with\n"
-"\t`_` (this should make it easier to use the directory\n"
-"\tname in a filename if wanted)\n"
-"%m::\n"
-"\tCVS module/Git head name\n"
-"%a::\n"
-"\taccess method (one of \"ext\" or \"pserver\")\n"
-"%u::\n"
-"\tName of the user running 'git-cvsserver'.\n"
-"\tIf no name can be determined, the\n"
-"\tnumeric uid is used.\n"
+"Name of the user running 'git-cvsserver'.  If no name can be determined, the "
+"numeric uid is used."
 msgstr ""
 
 #. type: Plain text
@@ -29303,16 +29474,20 @@ msgid ""
 "specified."
 msgstr ""
 
+#. type: Labeled list
+#: en/git-fast-export.txt:117
+#, fuzzy, no-wrap
+#| msgid "<git-rev-list-args>"
+msgid "[<git-rev-list-args>...]"
+msgstr "<git-rev-list-args>"
+
 #. type: Plain text
 #: en/git-fast-export.txt:123
-#, no-wrap
 msgid ""
-"[<git-rev-list-args>...]::\n"
-"\tA list of arguments, acceptable to 'git rev-parse' and\n"
-"\t'git rev-list', that specifies the specific objects and references\n"
-"\tto export.  For example, `master~10..master` causes the\n"
-"\tcurrent master reference to be exported along with all objects\n"
-"\tadded since its 10th ancestor commit.\n"
+"A list of arguments, acceptable to 'git rev-parse' and 'git rev-list', that "
+"specifies the specific objects and references to export.  For example, "
+"`master~10..master` causes the current master reference to be exported along "
+"with all objects added since its 10th ancestor commit."
 msgstr ""
 
 #. type: delimited block -
@@ -40287,15 +40462,19 @@ msgid ""
 "linkgit:gitrevisions[7]."
 msgstr ""
 
+#. type: Labeled list
+#: en/git-log.txt:86 en/git-shortlog.txt:72
+#, fuzzy, no-wrap
+#| msgid "patch"
+msgid "[\\--] <path>..."
+msgstr "patch"
+
 #. type: Plain text
 #: en/git-log.txt:91
-#, no-wrap
 msgid ""
-"[\\--] <path>...::\n"
-"\tShow only commits that are enough to explain how the files\n"
-"\tthat match the specified paths came to be.  See 'History\n"
-"\tSimplification' below for details and other simplification\n"
-"\tmodes.\n"
+"Show only commits that are enough to explain how the files that match the "
+"specified paths came to be.  See 'History Simplification' below for details "
+"and other simplification modes."
 msgstr ""
 
 #. type: Plain text
@@ -41307,14 +41486,19 @@ msgid ""
 "name."
 msgstr ""
 
+#. type: Labeled list
+#: en/git-ls-tree.txt:76
+#, fuzzy, no-wrap
+#| msgid "patch"
+msgid "[<path>...]"
+msgstr "patch"
+
 #. type: Plain text
 #: en/git-ls-tree.txt:80
-#, no-wrap
 msgid ""
-"[<path>...]::\n"
-"\tWhen paths are given, show them (note that this isn't really raw\n"
-"\tpathnames, but rather a list of patterns to match).  Otherwise\n"
-"\timplicitly uses the root level of the tree as the sole path argument.\n"
+"When paths are given, show them (note that this isn't really raw pathnames, "
+"but rather a list of patterns to match).  Otherwise implicitly uses the root "
+"level of the tree as the sole path argument."
 msgstr ""
 
 #. type: Title -
@@ -56916,11 +57100,9 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-shortlog.txt:75
-#, no-wrap
 msgid ""
-"[\\--] <path>...::\n"
-"\tConsider only commits that are enough to explain how the files\n"
-"\tthat match the specified paths came to be.\n"
+"Consider only commits that are enough to explain how the files that match "
+"the specified paths came to be."
 msgstr ""
 
 #. type: Plain text
@@ -62262,16 +62444,19 @@ msgid ""
 "reset) branches-maxRev and/or tags-maxRev as appropriate."
 msgstr ""
 
+#. type: Labeled list
+#: en/git-svn.txt:1119
+#, no-wrap
+msgid "$GIT_DIR/svn/\\*\\*/.rev_map.*"
+msgstr ""
+
 #. type: Plain text
 #: en/git-svn.txt:1125
-#, no-wrap
 msgid ""
-"$GIT_DIR/svn/\\*\\*/.rev_map.*::\n"
-"\tMapping between Subversion revision numbers and Git commit\n"
-"\tnames.  In a repository where the noMetadata option is not set,\n"
-"\tthis can be rebuilt from the git-svn-id: lines that are at the\n"
-"\tend of every commit (see the 'svn.noMetadata' section above for\n"
-"\tdetails).\n"
+"Mapping between Subversion revision numbers and Git commit names.  In a "
+"repository where the noMetadata option is not set, this can be rebuilt from "
+"the git-svn-id: lines that are at the end of every commit (see the 'svn."
+"noMetadata' section above for details)."
 msgstr ""
 
 #. type: Plain text
@@ -69077,96 +69262,91 @@ msgstr "diff"
 
 #. type: Plain text
 #: en/mergetools-merge.txt:12
-msgid "guiffy"
-msgstr ""
-
-#. type: Plain text
-#: en/mergetools-merge.txt:13
 #, fuzzy
 #| msgid "diff"
 msgid "gvimdiff"
 msgstr "diff"
 
 #. type: Plain text
-#: en/mergetools-merge.txt:14
+#: en/mergetools-merge.txt:13
 #, fuzzy
 #| msgid "diff"
 msgid "gvimdiff2"
 msgstr "diff"
 
 #. type: Plain text
-#: en/mergetools-merge.txt:15
+#: en/mergetools-merge.txt:14
 #, fuzzy
 #| msgid "diff"
 msgid "gvimdiff3"
 msgstr "diff"
 
 #. type: Plain text
-#: en/mergetools-merge.txt:16
+#: en/mergetools-merge.txt:15
 #, fuzzy
 #| msgid "diff"
 msgid "kdiff3"
 msgstr "diff"
 
 #. type: Plain text
-#: en/mergetools-merge.txt:17
+#: en/mergetools-merge.txt:16
 msgid "meld"
 msgstr ""
 
 #. type: Plain text
-#: en/mergetools-merge.txt:18
+#: en/mergetools-merge.txt:17
 #, fuzzy
 #| msgid "diff"
 msgid "opendiff"
 msgstr "diff"
 
 #. type: Plain text
-#: en/mergetools-merge.txt:19
+#: en/mergetools-merge.txt:18
 msgid "p4merge"
 msgstr ""
 
 #. type: Plain text
-#: en/mergetools-merge.txt:20
+#: en/mergetools-merge.txt:19
 #, fuzzy
 #| msgid "diff"
 msgid "tkdiff"
 msgstr "diff"
 
 #. type: Plain text
-#: en/mergetools-merge.txt:21
+#: en/mergetools-merge.txt:20
 msgid "tortoisemerge"
 msgstr ""
 
 #. type: Plain text
-#: en/mergetools-merge.txt:22
+#: en/mergetools-merge.txt:21
 #, fuzzy
 #| msgid "diff"
 msgid "vimdiff"
 msgstr "diff"
 
 #. type: Plain text
-#: en/mergetools-merge.txt:23
+#: en/mergetools-merge.txt:22
 #, fuzzy
 #| msgid "diff"
 msgid "vimdiff2"
 msgstr "diff"
 
 #. type: Plain text
-#: en/mergetools-merge.txt:24
+#: en/mergetools-merge.txt:23
 #, fuzzy
 #| msgid "diff"
 msgid "vimdiff3"
 msgstr "diff"
 
 #. type: Plain text
-#: en/mergetools-merge.txt:25
+#: en/mergetools-merge.txt:24
 #, fuzzy
 #| msgid "git-commit(1)"
 msgid "winmerge"
 msgstr "git-commit(1)"
 
 #. type: Plain text
-#: en/mergetools-merge.txt:25
+#: en/mergetools-merge.txt:24
 #, fuzzy
 #| msgid "diff"
 msgid "xxdiff"

--- a/po/documentation.pot
+++ b/po/documentation.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-01-03 17:18+0100\n"
+"POT-Creation-Date: 2019-01-03 23:03+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16811,16 +16811,19 @@ msgid ""
 "limit to the number of references and objects that may be packaged."
 msgstr ""
 
+#. type: Labeled list
+#: en/git-bundle.txt:71
+#, no-wrap
+msgid "[<refname>...]"
+msgstr ""
+
 #. type: Plain text
 #: en/git-bundle.txt:77
-#, no-wrap
 msgid ""
-"[<refname>...]::\n"
-"\tA list of references used to limit the references reported as\n"
-"\tavailable. This is principally of use to 'git fetch', which\n"
-"\texpects to receive only those references asked for and not\n"
-"\tnecessarily everything in the pack (in this case, 'git bundle' acts\n"
-"\tlike 'git fetch-pack').\n"
+"A list of references used to limit the references reported as "
+"available. This is principally of use to 'git fetch', which expects to "
+"receive only those references asked for and not necessarily everything in "
+"the pack (in this case, 'git bundle' acts like 'git fetch-pack')."
 msgstr ""
 
 #. type: Title -
@@ -22710,42 +22713,53 @@ msgid ""
 "will search for configuration options:"
 msgstr ""
 
+#. type: Labeled list
+#: en/git-config.txt:238
+#, no-wrap
+msgid "$(prefix)/etc/gitconfig"
+msgstr ""
+
 #. type: Plain text
 #: en/git-config.txt:240
+msgid "System-wide configuration file."
+msgstr ""
+
+#. type: Labeled list
+#: en/git-config.txt:241
 #, no-wrap
-msgid ""
-"$(prefix)/etc/gitconfig::\n"
-"\tSystem-wide configuration file.\n"
+msgid "$XDG_CONFIG_HOME/git/config"
 msgstr ""
 
 #. type: Plain text
 #: en/git-config.txt:248
-#, no-wrap
 msgid ""
-"$XDG_CONFIG_HOME/git/config::\n"
-"\tSecond user-specific configuration file. If $XDG_CONFIG_HOME is not set\n"
-"\tor empty, `$HOME/.config/git/config` will be used. Any single-valued\n"
-"\tvariable set in this file will be overwritten by whatever is in\n"
-"\t`~/.gitconfig`.  It is a good idea not to create this file if\n"
-"\tyou sometimes use older versions of Git, as support for this\n"
-"\tfile was added fairly recently.\n"
+"Second user-specific configuration file. If $XDG_CONFIG_HOME is not set or "
+"empty, `$HOME/.config/git/config` will be used. Any single-valued variable "
+"set in this file will be overwritten by whatever is in `~/.gitconfig`.  It "
+"is a good idea not to create this file if you sometimes use older versions "
+"of Git, as support for this file was added fairly recently."
+msgstr ""
+
+#. type: Labeled list
+#: en/git-config.txt:249
+#, no-wrap
+msgid "~/.gitconfig"
 msgstr ""
 
 #. type: Plain text
 #: en/git-config.txt:252
+msgid "User-specific configuration file. Also called \"global\" configuration file."
+msgstr ""
+
+#. type: Labeled list
+#: en/git-config.txt:253
 #, no-wrap
-msgid ""
-"~/.gitconfig::\n"
-"\tUser-specific configuration file. Also called \"global\"\n"
-"\tconfiguration file.\n"
+msgid "$GIT_DIR/config"
 msgstr ""
 
 #. type: Plain text
 #: en/git-config.txt:255
-#, no-wrap
-msgid ""
-"$GIT_DIR/config::\n"
-"\tRepository specific configuration file.\n"
+msgid "Repository specific configuration file."
 msgstr ""
 
 #. type: Plain text
@@ -23380,24 +23394,31 @@ msgid ""
 "git-credential-store will search for credentials in order of precedence:"
 msgstr ""
 
+#. type: Labeled list
+#: en/git-credential-store.txt:50
+#, no-wrap
+msgid "~/.git-credentials"
+msgstr ""
+
 #. type: Plain text
 #: en/git-credential-store.txt:52
+msgid "User-specific credentials file."
+msgstr ""
+
+#. type: Labeled list
+#: en/git-credential-store.txt:53
 #, no-wrap
-msgid ""
-"~/.git-credentials::\n"
-"\tUser-specific credentials file.\n"
+msgid "$XDG_CONFIG_HOME/git/credentials"
 msgstr ""
 
 #. type: Plain text
 #: en/git-credential-store.txt:59
-#, no-wrap
 msgid ""
-"$XDG_CONFIG_HOME/git/credentials::\n"
-"\tSecond user-specific credentials file. If '$XDG_CONFIG_HOME' is not set\n"
-"\tor empty, `$HOME/.config/git/credentials` will be used. Any credentials\n"
-"\tstored in this file will not be used if `~/.git-credentials` has a\n"
-"\tmatching credential as well. It is a good idea not to create this file\n"
-"\tif you sometimes use older versions of Git that do not support it.\n"
+"Second user-specific credentials file. If '$XDG_CONFIG_HOME' is not set or "
+"empty, `$HOME/.config/git/credentials` will be used. Any credentials stored "
+"in this file will not be used if `~/.git-credentials` has a matching "
+"credential as well. It is a good idea not to create this file if you "
+"sometimes use older versions of Git that do not support it."
 msgstr ""
 
 #. type: Plain text
@@ -24959,25 +24980,64 @@ msgstr ""
 msgid "In `dbDriver` and `dbUser` you can use the following variables:"
 msgstr ""
 
+#. type: Labeled list
+#: en/git-cvsserver.txt:293
+#, no-wrap
+msgid "%G"
+msgstr ""
+
+#. type: Plain text
+#: en/git-cvsserver.txt:295
+msgid "Git directory name"
+msgstr ""
+
+#. type: Labeled list
+#: en/git-cvsserver.txt:295
+#, no-wrap
+msgid "%g"
+msgstr ""
+
+#. type: Plain text
+#: en/git-cvsserver.txt:300
+msgid ""
+"Git directory name, where all characters except for alpha-numeric ones, `.`, "
+"and `-` are replaced with `_` (this should make it easier to use the "
+"directory name in a filename if wanted)"
+msgstr ""
+
+#. type: Labeled list
+#: en/git-cvsserver.txt:300
+#, no-wrap
+msgid "%m"
+msgstr ""
+
+#. type: Plain text
+#: en/git-cvsserver.txt:302
+msgid "CVS module/Git head name"
+msgstr ""
+
+#. type: Labeled list
+#: en/git-cvsserver.txt:302
+#, no-wrap
+msgid "%a"
+msgstr ""
+
+#. type: Plain text
+#: en/git-cvsserver.txt:304
+msgid "access method (one of \"ext\" or \"pserver\")"
+msgstr ""
+
+#. type: Labeled list
+#: en/git-cvsserver.txt:304
+#, no-wrap
+msgid "%u"
+msgstr ""
+
 #. type: Plain text
 #: en/git-cvsserver.txt:308
-#, no-wrap
 msgid ""
-"%G::\n"
-"\tGit directory name\n"
-"%g::\n"
-"\tGit directory name, where all characters except for\n"
-"\talpha-numeric ones, `.`, and `-` are replaced with\n"
-"\t`_` (this should make it easier to use the directory\n"
-"\tname in a filename if wanted)\n"
-"%m::\n"
-"\tCVS module/Git head name\n"
-"%a::\n"
-"\taccess method (one of \"ext\" or \"pserver\")\n"
-"%u::\n"
-"\tName of the user running 'git-cvsserver'.\n"
-"\tIf no name can be determined, the\n"
-"\tnumeric uid is used.\n"
+"Name of the user running 'git-cvsserver'.  If no name can be determined, the "
+"numeric uid is used."
 msgstr ""
 
 #. type: Plain text
@@ -27593,16 +27653,19 @@ msgid ""
 "specified."
 msgstr ""
 
+#. type: Labeled list
+#: en/git-fast-export.txt:117
+#, no-wrap
+msgid "[<git-rev-list-args>...]"
+msgstr ""
+
 #. type: Plain text
 #: en/git-fast-export.txt:123
-#, no-wrap
 msgid ""
-"[<git-rev-list-args>...]::\n"
-"\tA list of arguments, acceptable to 'git rev-parse' and\n"
-"\t'git rev-list', that specifies the specific objects and references\n"
-"\tto export.  For example, `master~10..master` causes the\n"
-"\tcurrent master reference to be exported along with all objects\n"
-"\tadded since its 10th ancestor commit.\n"
+"A list of arguments, acceptable to 'git rev-parse' and 'git rev-list', that "
+"specifies the specific objects and references to export.  For example, "
+"`master~10..master` causes the current master reference to be exported along "
+"with all objects added since its 10th ancestor commit."
 msgstr ""
 
 #. type: delimited block -
@@ -38405,15 +38468,18 @@ msgid ""
 "linkgit:gitrevisions[7]."
 msgstr ""
 
+#. type: Labeled list
+#: en/git-log.txt:86 en/git-shortlog.txt:72
+#, no-wrap
+msgid "[\\--] <path>..."
+msgstr ""
+
 #. type: Plain text
 #: en/git-log.txt:91
-#, no-wrap
 msgid ""
-"[\\--] <path>...::\n"
-"\tShow only commits that are enough to explain how the files\n"
-"\tthat match the specified paths came to be.  See 'History\n"
-"\tSimplification' below for details and other simplification\n"
-"\tmodes.\n"
+"Show only commits that are enough to explain how the files that match the "
+"specified paths came to be.  See 'History Simplification' below for details "
+"and other simplification modes."
 msgstr ""
 
 #. type: Plain text
@@ -39406,14 +39472,18 @@ msgid ""
 "--full-name."
 msgstr ""
 
+#. type: Labeled list
+#: en/git-ls-tree.txt:76
+#, no-wrap
+msgid "[<path>...]"
+msgstr ""
+
 #. type: Plain text
 #: en/git-ls-tree.txt:80
-#, no-wrap
 msgid ""
-"[<path>...]::\n"
-"\tWhen paths are given, show them (note that this isn't really raw\n"
-"\tpathnames, but rather a list of patterns to match).  Otherwise\n"
-"\timplicitly uses the root level of the tree as the sole path argument.\n"
+"When paths are given, show them (note that this isn't really raw pathnames, "
+"but rather a list of patterns to match).  Otherwise implicitly uses the root "
+"level of the tree as the sole path argument."
 msgstr ""
 
 #. type: Title -
@@ -54596,11 +54666,9 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-shortlog.txt:75
-#, no-wrap
 msgid ""
-"[\\--] <path>...::\n"
-"\tConsider only commits that are enough to explain how the files\n"
-"\tthat match the specified paths came to be.\n"
+"Consider only commits that are enough to explain how the files that match "
+"the specified paths came to be."
 msgstr ""
 
 #. type: Plain text
@@ -59871,16 +59939,19 @@ msgid ""
 "reset) branches-maxRev and/or tags-maxRev as appropriate."
 msgstr ""
 
+#. type: Labeled list
+#: en/git-svn.txt:1119
+#, no-wrap
+msgid "$GIT_DIR/svn/\\*\\*/.rev_map.*"
+msgstr ""
+
 #. type: Plain text
 #: en/git-svn.txt:1125
-#, no-wrap
 msgid ""
-"$GIT_DIR/svn/\\*\\*/.rev_map.*::\n"
-"\tMapping between Subversion revision numbers and Git commit\n"
-"\tnames.  In a repository where the noMetadata option is not set,\n"
-"\tthis can be rebuilt from the git-svn-id: lines that are at the\n"
-"\tend of every commit (see the 'svn.noMetadata' section above for\n"
-"\tdetails).\n"
+"Mapping between Subversion revision numbers and Git commit names.  In a "
+"repository where the noMetadata option is not set, this can be rebuilt from "
+"the git-svn-id: lines that are at the end of every commit (see the "
+"'svn.noMetadata' section above for details)."
 msgstr ""
 
 #. type: Plain text
@@ -66505,76 +66576,71 @@ msgstr ""
 
 #. type: Plain text
 #: en/mergetools-merge.txt:12
-msgid "guiffy"
-msgstr ""
-
-#. type: Plain text
-#: en/mergetools-merge.txt:13
 msgid "gvimdiff"
 msgstr ""
 
 #. type: Plain text
-#: en/mergetools-merge.txt:14
+#: en/mergetools-merge.txt:13
 msgid "gvimdiff2"
 msgstr ""
 
 #. type: Plain text
-#: en/mergetools-merge.txt:15
+#: en/mergetools-merge.txt:14
 msgid "gvimdiff3"
 msgstr ""
 
 #. type: Plain text
-#: en/mergetools-merge.txt:16
+#: en/mergetools-merge.txt:15
 msgid "kdiff3"
 msgstr ""
 
 #. type: Plain text
-#: en/mergetools-merge.txt:17
+#: en/mergetools-merge.txt:16
 msgid "meld"
 msgstr ""
 
 #. type: Plain text
-#: en/mergetools-merge.txt:18
+#: en/mergetools-merge.txt:17
 msgid "opendiff"
 msgstr ""
 
 #. type: Plain text
-#: en/mergetools-merge.txt:19
+#: en/mergetools-merge.txt:18
 msgid "p4merge"
 msgstr ""
 
 #. type: Plain text
-#: en/mergetools-merge.txt:20
+#: en/mergetools-merge.txt:19
 msgid "tkdiff"
 msgstr ""
 
 #. type: Plain text
-#: en/mergetools-merge.txt:21
+#: en/mergetools-merge.txt:20
 msgid "tortoisemerge"
 msgstr ""
 
 #. type: Plain text
-#: en/mergetools-merge.txt:22
+#: en/mergetools-merge.txt:21
 msgid "vimdiff"
 msgstr ""
 
 #. type: Plain text
-#: en/mergetools-merge.txt:23
+#: en/mergetools-merge.txt:22
 msgid "vimdiff2"
 msgstr ""
 
 #. type: Plain text
-#: en/mergetools-merge.txt:24
+#: en/mergetools-merge.txt:23
 msgid "vimdiff3"
 msgstr ""
 
 #. type: Plain text
-#: en/mergetools-merge.txt:25
+#: en/mergetools-merge.txt:24
 msgid "winmerge"
 msgstr ""
 
 #. type: Plain text
-#: en/mergetools-merge.txt:25
+#: en/mergetools-merge.txt:24
 msgid "xxdiff"
 msgstr ""
 


### PR DESCRIPTION
There is no need to use a subshell for redirection; just redirect the output from the "cat" command directly.