### PR TITLE
translate cmds-*.txt to german

### DIFF
--- a/po/documentation.de.po
+++ b/po/documentation.de.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: git documentation\n"
 "POT-Creation-Date: 2019-01-04 23:29+0100\n"
-"PO-Revision-Date: 2019-01-14 18:55+0100\n"
+"PO-Revision-Date: 2019-01-14 19:08+0100\n"
 "Last-Translator: Matthias Aßhauer <mha1993@live.de>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: de\n"
@@ -647,7 +647,7 @@ msgstr "linkgit:git-archimport[1]"
 #. type: Plain text
 #: en/cmds-foreignscminterface.txt:3
 msgid "Import an Arch repository into Git."
-msgstr ""
+msgstr "Ein Arch-Repository in Git importieren."
 
 #. type: Labeled list
 #: en/cmds-foreignscminterface.txt:4
@@ -658,7 +658,7 @@ msgstr "linkgit:git-cvsexportcommit[1]"
 #. type: Plain text
 #: en/cmds-foreignscminterface.txt:6
 msgid "Export a single commit to a CVS checkout."
-msgstr ""
+msgstr "Einzelnen Commit zu einem ausgecheckten CSV-Repository exportieren."
 
 #. type: Labeled list
 #: en/cmds-foreignscminterface.txt:7
@@ -669,7 +669,7 @@ msgstr "linkgit:git-cvsimport[1]"
 #. type: Plain text
 #: en/cmds-foreignscminterface.txt:9
 msgid "Salvage your data out of another SCM people love to hate."
-msgstr ""
+msgstr "Ihre Daten aus einem anderen SCM übernehmen."
 
 #. type: Labeled list
 #: en/cmds-foreignscminterface.txt:10
@@ -680,7 +680,7 @@ msgstr "linkgit:git-cvsserver[1]"
 #. type: Plain text
 #: en/cmds-foreignscminterface.txt:12
 msgid "A CVS server emulator for Git."
-msgstr ""
+msgstr "Ein CVS-Server-Emulator für Git"
 
 #. type: Labeled list
 #: en/cmds-foreignscminterface.txt:13
@@ -692,6 +692,8 @@ msgstr "linkgit:git-imap-send[1]"
 #: en/cmds-foreignscminterface.txt:15
 msgid "Send a collection of patches from stdin to an IMAP folder."
 msgstr ""
+"Eine Sammlung von Patches von der Standard-Eingabe an einen IMAP-Ordner "
+"senden."
 
 #. type: Labeled list
 #: en/cmds-foreignscminterface.txt:16
@@ -701,10 +703,8 @@ msgstr "linkgit:git-p4[1]"
 
 #. type: Plain text
 #: en/cmds-foreignscminterface.txt:18
-#, fuzzy
-#| msgid "git-remote - manage set of tracked repositories"
 msgid "Import from and submit to Perforce repositories."
-msgstr "git-remote - Einen Satz entfernter Repositories verwalten"
+msgstr "Repositories aus Perforce importieren und an diese senden."
 
 #. type: Labeled list
 #: en/cmds-foreignscminterface.txt:19
@@ -715,7 +715,7 @@ msgstr "linkgit:git-quiltimport[1]"
 #. type: Plain text
 #: en/cmds-foreignscminterface.txt:21
 msgid "Applies a quilt patchset onto the current branch."
-msgstr ""
+msgstr "Patches aus quilt auf aktuellen Branch anwenden."
 
 #. type: Labeled list
 #: en/cmds-foreignscminterface.txt:22
@@ -726,7 +726,7 @@ msgstr "linkgit:git-request-pull[1]"
 #. type: Plain text
 #: en/cmds-foreignscminterface.txt:24
 msgid "Generates a summary of pending changes."
-msgstr ""
+msgstr "Eine Übersicht über ausstehende Änderungen generieren."
 
 #. type: Labeled list
 #: en/cmds-foreignscminterface.txt:25
@@ -737,7 +737,7 @@ msgstr "linkgit:git-send-email[1]"
 #. type: Plain text
 #: en/cmds-foreignscminterface.txt:27
 msgid "Send a collection of patches as emails."
-msgstr ""
+msgstr "Eine Sammlung von Patches als E-Mails versenden."
 
 #. type: Labeled list
 #: en/cmds-foreignscminterface.txt:28
@@ -749,6 +749,7 @@ msgstr "linkgit:git-svn[1]"
 #: en/cmds-foreignscminterface.txt:30
 msgid "Bidirectional operation between a Subversion repository and Git."
 msgstr ""
+"Bidirektionale Operationen zwischen einem Subversion-Repository und Git."
 
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:1 en/git-rm.txt:185
@@ -25997,7 +25998,7 @@ msgstr "git-cvsexportcommit(1)"
 #. type: Plain text
 #: en/git-cvsexportcommit.txt:7
 msgid "git-cvsexportcommit - Export a single commit to a CVS checkout"
-msgstr ""
+msgstr "git-cvsexportcommit - Einzelnen Commit zu einem ausgecheckten CSV-Repository exportieren."
 
 #. type: Plain text
 #: en/git-cvsexportcommit.txt:14

--- a/po/documentation.de.po
+++ b/po/documentation.de.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: git documentation\n"
 "POT-Creation-Date: 2019-01-04 23:29+0100\n"
-"PO-Revision-Date: 2019-01-14 13:20+0100\n"
+"PO-Revision-Date: 2019-01-14 13:51+0100\n"
 "Last-Translator: Matthias Aßhauer <mha1993@live.de>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: de\n"
@@ -332,7 +332,7 @@ msgstr "linkgit:git-annotate[1]"
 #. type: Plain text
 #: en/cmds-ancillaryinterrogators.txt:3
 msgid "Annotate file lines with commit information."
-msgstr ""
+msgstr "Zeilen der Datei mit Commit-Informationen versehen und anzeigen."
 
 #. type: Plain text
 #: en/cmds-ancillaryinterrogators.txt:4 en/git-annotate.txt:31
@@ -344,6 +344,8 @@ msgstr "linkgit:git-blame[1]"
 #: en/cmds-ancillaryinterrogators.txt:6
 msgid "Show what revision and author last modified each line of a file."
 msgstr ""
+"Anzeigen, durch welchen Commit und Autor die jeweiligen Zeilen"
+"einer Datei zuletzt geändert wurden."
 
 #. type: Labeled list
 #: en/cmds-ancillaryinterrogators.txt:7
@@ -355,6 +357,7 @@ msgstr "linkgit:git-cherry[1]"
 #: en/cmds-ancillaryinterrogators.txt:9
 msgid "Find commits yet to be applied to upstream."
 msgstr ""
+"Commits finden, die noch auf dem Upstream-Branch angewendet werden müssen."
 
 #. type: Labeled list
 #: en/cmds-ancillaryinterrogators.txt:10
@@ -365,7 +368,7 @@ msgstr "linkgit:git-count-objects[1]"
 #. type: Plain text
 #: en/cmds-ancillaryinterrogators.txt:12
 msgid "Count unpacked number of objects and their disk consumption."
-msgstr ""
+msgstr "Anzahl und Speicherverbrauch ungepackter Objekte zählen."
 
 #. type: Labeled list
 #: en/cmds-ancillaryinterrogators.txt:13
@@ -376,7 +379,7 @@ msgstr "linkgit:git-difftool[1]"
 #. type: Plain text
 #: en/cmds-ancillaryinterrogators.txt:15
 msgid "Show changes using common diff tools."
-msgstr ""
+msgstr "Änderungen mittels den allgemeinen Diff-Tools anzeigen."
 
 #. type: Labeled list
 #: en/cmds-ancillaryinterrogators.txt:16
@@ -386,14 +389,9 @@ msgstr "linkgit:git-fsck[1]"
 
 #. type: Plain text
 #: en/cmds-ancillaryinterrogators.txt:18 en/git-fsck.txt:20
-#, fuzzy
-#| msgid ""
-#| "git-fsck-objects - Verifies the connectivity and validity of the objects in "
-#| "the database"
 msgid "Verifies the connectivity and validity of the objects in the database."
 msgstr ""
-"git-fsck-objects - überprüft die Verbundenheit und Korrektheit der Objekte "
-"in der Datenbank"
+"Stellt die Verbundenheit und Gültigkeit der Objekte in der Datenbank sicher."
 
 #. type: Labeled list
 #: en/cmds-ancillaryinterrogators.txt:19
@@ -405,6 +403,7 @@ msgstr "linkgit:git-get-tar-commit-id[1]"
 #: en/cmds-ancillaryinterrogators.txt:21
 msgid "Extract commit ID from an archive created using git-archive."
 msgstr ""
+"Commit-ID eines Archivs extrahieren, welches mit git-archive erstellt wurde."
 
 #. type: Labeled list
 #: en/cmds-ancillaryinterrogators.txt:22
@@ -414,10 +413,8 @@ msgstr "linkgit:git-help[1]"
 
 #. type: Plain text
 #: en/cmds-ancillaryinterrogators.txt:24
-#, fuzzy
-#| msgid "Gives some information about the remote <name>."
 msgid "Display help information about Git."
-msgstr "Gibt Informationen über das entfernte Repository <Name> aus."
+msgstr "Hilfsinformationen über Git anzeigen."
 
 #. type: Labeled list
 #: en/cmds-ancillaryinterrogators.txt:25
@@ -427,10 +424,8 @@ msgstr "linkgit:git-instaweb[1]"
 
 #. type: Plain text
 #: en/cmds-ancillaryinterrogators.txt:27
-#, fuzzy
-#| msgid "Initialized empty Git repository in .git/\n"
 msgid "Instantly browse your working repository in gitweb."
-msgstr "Initialized empty Git repository in .git/\n"
+msgstr "Ihr aktuelles Repository sofort in gitweb betrachten."
 
 #. type: Labeled list
 #: en/cmds-ancillaryinterrogators.txt:28
@@ -441,7 +436,7 @@ msgstr "linkgit:git-merge-tree[1]"
 #. type: Plain text
 #: en/cmds-ancillaryinterrogators.txt:30
 msgid "Show three-way merge without touching index."
-msgstr ""
+msgstr "3-Wege-Merge anzeigen ohne den Index zu verändern."
 
 #. type: Labeled list
 #: en/cmds-ancillaryinterrogators.txt:31
@@ -452,7 +447,7 @@ msgstr "linkgit:git-rerere[1]"
 #. type: Plain text
 #: en/cmds-ancillaryinterrogators.txt:33
 msgid "Reuse recorded resolution of conflicted merges."
-msgstr ""
+msgstr "Aufgezeichnete Auflösung von Merge-Konflikten wiederverwenden."
 
 #. type: Labeled list
 #: en/cmds-ancillaryinterrogators.txt:34
@@ -463,7 +458,7 @@ msgstr "linkgit:git-rev-parse[1]"
 #. type: Plain text
 #: en/cmds-ancillaryinterrogators.txt:36
 msgid "Pick out and massage parameters."
-msgstr ""
+msgstr "Parameter herauspicken und ändern."
 
 #. type: Labeled list
 #: en/cmds-ancillaryinterrogators.txt:37
@@ -473,10 +468,8 @@ msgstr "linkgit:git-show-branch[1]"
 
 #. type: Plain text
 #: en/cmds-ancillaryinterrogators.txt:39
-#, fuzzy
-#| msgid "Shows the commit logs."
 msgid "Show branches and their commits."
-msgstr "Zeigt die Geschichte des Projekts"
+msgstr "Branches und ihre Commits ausgeben."
 
 #. type: Labeled list
 #: en/cmds-ancillaryinterrogators.txt:40
@@ -486,10 +479,8 @@ msgstr "linkgit:git-verify-commit[1]"
 
 #. type: Plain text
 #: en/cmds-ancillaryinterrogators.txt:42
-#, fuzzy
-#| msgid "git-verify-tag - Check the GPG signature of tags"
 msgid "Check the GPG signature of commits."
-msgstr "git-verify-tag - Die GPG-Signaturen von Markierungs überprüfen"
+msgstr "Die GPG-Signatur von Commits prüfen."
 
 #. type: Labeled list
 #: en/cmds-ancillaryinterrogators.txt:43
@@ -499,10 +490,8 @@ msgstr "linkgit:git-verify-tag[1]"
 
 #. type: Plain text
 #: en/cmds-ancillaryinterrogators.txt:45
-#, fuzzy
-#| msgid "git-verify-tag - Check the GPG signature of tags"
 msgid "Check the GPG signature of tags."
-msgstr "git-verify-tag - Die GPG-Signaturen von Markierungs überprüfen"
+msgstr "Die GPG-Signatur von Tags prüfen."
 
 #. type: Labeled list
 #: en/cmds-ancillaryinterrogators.txt:46
@@ -513,19 +502,18 @@ msgstr "linkgit:git-whatchanged[1]"
 #. type: Plain text
 #: en/cmds-ancillaryinterrogators.txt:48
 msgid "Show logs with difference each commit introduces."
-msgstr ""
+msgstr "Logs mit dem Unterschied, den jeder Commit einführt, anzeigen."
 
 #. type: Plain text
 #: en/cmds-ancillaryinterrogators.txt:49 en/git-instaweb.txt:90
-#, fuzzy, no-wrap
-#| msgid "linkgit:git-add[1]"
+#, no-wrap, ignore-translated
 msgid "linkgit:gitweb[1]"
-msgstr "linkgit:git-add[1]"
+msgstr "linkgit:gitweb[1]"
 
 #. type: Plain text
 #: en/cmds-ancillaryinterrogators.txt:51
 msgid "Git web interface (web frontend to Git repositories)."
-msgstr ""
+msgstr "Git Web Interface (Web-Frontend für Git-Repositories)."
 
 #. type: Labeled list
 #: en/cmds-ancillarymanipulators.txt:1 en/git-difftool.txt:142

--- a/po/documentation.de.po
+++ b/po/documentation.de.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: git documentation\n"
 "POT-Creation-Date: 2019-01-04 23:29+0100\n"
-"PO-Revision-Date: 2019-01-13 20:24+0100\n"
+"PO-Revision-Date: 2019-01-14 13:20+0100\n"
 "Last-Translator: Matthias Aßhauer <mha1993@live.de>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: de\n"
@@ -1589,7 +1589,7 @@ msgstr "linkgit:git-check-attr[1]"
 #. type: Plain text
 #: en/cmds-purehelpers.txt:3
 msgid "Display gitattributes information."
-msgstr ""
+msgstr "gitattributes-Informationen darstellen."
 
 #. type: Labeled list
 #: en/cmds-purehelpers.txt:4
@@ -1600,7 +1600,7 @@ msgstr "linkgit:git-check-ignore[1]"
 #. type: Plain text
 #: en/cmds-purehelpers.txt:6
 msgid "Debug gitignore / exclude files."
-msgstr ""
+msgstr "Fehlersuche in gitignore- / exclude-Dateien."
 
 #. type: Labeled list
 #: en/cmds-purehelpers.txt:7
@@ -1611,7 +1611,7 @@ msgstr "linkgit:git-check-mailmap[1]"
 #. type: Plain text
 #: en/cmds-purehelpers.txt:9
 msgid "Show canonical names and email addresses of contacts."
-msgstr ""
+msgstr "Name und E-Mail-Adresse von Kontakten anzeigen."
 
 #. type: Labeled list
 #: en/cmds-purehelpers.txt:10
@@ -1622,7 +1622,7 @@ msgstr "linkgit:git-check-ref-format[1]"
 #. type: Plain text
 #: en/cmds-purehelpers.txt:12
 msgid "Ensures that a reference name is well formed."
-msgstr ""
+msgstr "Sicherstellen, dass ein Referenzname wohlgeformt ist."
 
 #. type: Labeled list
 #: en/cmds-purehelpers.txt:13
@@ -1633,7 +1633,7 @@ msgstr "linkgit:git-column[1]"
 #. type: Plain text
 #: en/cmds-purehelpers.txt:15
 msgid "Display data in columns."
-msgstr ""
+msgstr "Daten in Spalten anzeigen."
 
 #. type: Labeled list
 #: en/cmds-purehelpers.txt:16
@@ -1644,7 +1644,7 @@ msgstr "linkgit:git-credential[1]"
 #. type: Plain text
 #: en/cmds-purehelpers.txt:18
 msgid "Retrieve and store user credentials."
-msgstr ""
+msgstr "Zugangsdaten des Benutzers abrufen und speichern."
 
 #. type: Labeled list
 #: en/cmds-purehelpers.txt:19
@@ -1656,6 +1656,7 @@ msgstr "linkgit:git-credential-cache[1]"
 #: en/cmds-purehelpers.txt:21
 msgid "Helper to temporarily store passwords in memory."
 msgstr ""
+"Hilfsprogramm zum temporären Speichern von Zugangsdaten im Hauptspeicher."
 
 #. type: Labeled list
 #: en/cmds-purehelpers.txt:22
@@ -1666,7 +1667,7 @@ msgstr "linkgit:git-credential-store[1]"
 #. type: Plain text
 #: en/cmds-purehelpers.txt:24
 msgid "Helper to store credentials on disk."
-msgstr ""
+msgstr "Hilfsprogramm zum Speichern von Zugangsdaten auf der Festplatte."
 
 #. type: Labeled list
 #: en/cmds-purehelpers.txt:25
@@ -1676,10 +1677,8 @@ msgstr "linkgit:git-fmt-merge-msg[1]"
 
 #. type: Plain text
 #: en/cmds-purehelpers.txt:27
-#, fuzzy
-#| msgid "Suppress commit summary message."
 msgid "Produce a merge commit message."
-msgstr "Unterdrücke die zusammenfassende Nachricht über die Eintragung."
+msgstr "Beschreibung eines Merge-Commits erzeugen."
 
 #. type: Labeled list
 #: en/cmds-purehelpers.txt:28
@@ -1690,7 +1689,7 @@ msgstr "linkgit:git-interpret-trailers[1]"
 #. type: Plain text
 #: en/cmds-purehelpers.txt:30
 msgid "add or parse structured information in commit messages."
-msgstr ""
+msgstr "Strukturierte Informationen in Commit-Beschreibungen hinzufügen oder parsen."
 
 #. type: Labeled list
 #: en/cmds-purehelpers.txt:31
@@ -1701,7 +1700,7 @@ msgstr "linkgit:git-mailinfo[1]"
 #. type: Plain text
 #: en/cmds-purehelpers.txt:33
 msgid "Extracts patch and authorship from a single e-mail message."
-msgstr ""
+msgstr "Patch und Urheberschaft aus einer einzelnen E-Mail-Nachricht extrahieren."
 
 #. type: Labeled list
 #: en/cmds-purehelpers.txt:34
@@ -1712,7 +1711,7 @@ msgstr "linkgit:git-mailsplit[1]"
 #. type: Plain text
 #: en/cmds-purehelpers.txt:36
 msgid "Simple UNIX mbox splitter program."
-msgstr ""
+msgstr "Einfaches UNIX mbox Splitter-Programm."
 
 #. type: Labeled list
 #: en/cmds-purehelpers.txt:37
@@ -1722,13 +1721,8 @@ msgstr "linkgit:git-merge-one-file[1]"
 
 #. type: Plain text
 #: en/cmds-purehelpers.txt:39
-#, fuzzy
-#| msgid ""
-#| "git-merge-one-file - The standard helper program to use with git-merge-index"
 msgid "The standard helper program to use with git-merge-index."
-msgstr ""
-"git-merge-one-file - Das Standardhilfsprogramm welches in Kombination mit "
-"git-merge-index verwendet wird"
+msgstr "Das Standard-Hilfsprogramm für die Verwendung mit git-merge-index."
 
 #. type: Plain text
 #: en/cmds-purehelpers.txt:40 en/git-cherry.txt:142
@@ -1739,7 +1733,7 @@ msgstr "linkgit:git-patch-id[1]"
 #. type: Plain text
 #: en/cmds-purehelpers.txt:42
 msgid "Compute unique ID for a patch."
-msgstr ""
+msgstr "Eindeutige ID für einen Patch berechnen."
 
 #. type: Labeled list
 #: en/cmds-purehelpers.txt:43
@@ -1750,7 +1744,7 @@ msgstr "linkgit:git-sh-i18n[1]"
 #. type: Plain text
 #: en/cmds-purehelpers.txt:45
 msgid "Git's i18n setup code for shell scripts."
-msgstr ""
+msgstr "Git's i18n-Konfigurationscode für Shell-Skripte."
 
 #. type: Labeled list
 #: en/cmds-purehelpers.txt:46
@@ -1761,7 +1755,7 @@ msgstr "linkgit:git-sh-setup[1]"
 #. type: Plain text
 #: en/cmds-purehelpers.txt:48
 msgid "Common Git shell script setup code."
-msgstr ""
+msgstr "Allgemeiner Git Shell-Skript Konfigurationscode."
 
 #. type: Labeled list
 #: en/cmds-purehelpers.txt:49
@@ -1772,7 +1766,7 @@ msgstr "linkgit:git-stripspace[1]"
 #. type: Plain text
 #: en/cmds-purehelpers.txt:51
 msgid "Remove unnecessary whitespace."
-msgstr ""
+msgstr "Nicht erforderlichen Whitespace entfernen."
 
 #. type: Labeled list
 #: en/cmds-synchelpers.txt:1

--- a/po/documentation.de.po
+++ b/po/documentation.de.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: git documentation\n"
 "POT-Creation-Date: 2019-01-04 23:29+0100\n"
-"PO-Revision-Date: 2019-01-11 17:12+0100\n"
+"PO-Revision-Date: 2019-01-13 18:09+0100\n"
 "Last-Translator: Matthias Aßhauer <mha1993@live.de>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: de\n"
@@ -775,10 +775,8 @@ msgstr "linkgit:git-add[1]"
 
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:3
-#, fuzzy
-#| msgid "git-add - Add file contents to the index"
 msgid "Add file contents to the index."
-msgstr "git-add - Füge Dateiinhalte zum Index hinzu."
+msgstr "Füge Dateiinhalte zum Index hinzu."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:4
@@ -821,11 +819,9 @@ msgstr "linkgit:git-branch[1]"
 
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:15
-#, fuzzy
-#| msgid "git-branch - List, create, or delete branches"
 msgid "List, create, or delete branches."
 msgstr ""
-"git-branch - Auflisten, Erzeugen oder Löschen von Entwicklungszweigen "
+"Auflisten, Erzeugen oder Löschen von Entwicklungszweigen "
 "(branches)"
 
 #. type: Labeled list
@@ -869,10 +865,8 @@ msgstr "linkgit:git-citool[1]"
 
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:27
-#, fuzzy
-#| msgid "git-citool - Graphical alternative to git-commit"
 msgid "Graphical alternative to git-commit."
-msgstr "git-gitool - Graphische Alternative zu git-commit"
+msgstr "Graphische Alternative zu git-commit."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:28
@@ -882,11 +876,8 @@ msgstr "linkgit:git-clean[1]"
 
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:30
-#, fuzzy
-#| msgid ""
-#| "git-rm - Remove files from the working tree and from the index"
 msgid "Remove untracked files from the working tree."
-msgstr "git-rm - Entferne Dateien aus dem Arbeitsbereich und dem Index"
+msgstr "Entferne Dateien aus dem Arbeitsbereich und dem Index."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:31
@@ -896,11 +887,9 @@ msgstr "linkgit:git-clone[1]"
 
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:33
-#, fuzzy
-#| msgid "git-clone - Clone a repository into a new directory"
 msgid "Clone a repository into a new directory."
 msgstr ""
-"git-clone - Klone ein Projektarchiv (repository) in ein neues Verzeichnis."
+"Klone ein Projektarchiv (repository) in ein neues Verzeichnis."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:34
@@ -910,10 +899,8 @@ msgstr "linkgit:git-commit[1]"
 
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:36
-#, fuzzy
-#| msgid "git-commit - Record changes to the repository"
 msgid "Record changes to the repository."
-msgstr "git-commit - Trage Änderungen im Projektarchiv (repository) ein"
+msgstr "Trage Änderungen im Projektarchiv (repository) ein."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:37
@@ -934,13 +921,10 @@ msgstr "linkgit:git-diff[1]"
 
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:42
-#, fuzzy
-#| msgid ""
-#| "git-diff - Show changes between commits, commit and working tree, etc"
 msgid "Show changes between commits, commit and working tree, etc."
 msgstr ""
-"git-diff - Zeige Unterschiede zwischen Eintragungen (commits), Eintragung "
-"und Arbeitsbereich, etc"
+"Zeige Unterschiede zwischen Eintragungen (commits), Eintragung "
+"und Arbeitsbereich, etc."
 
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:43 en/git-fetch-pack.txt:129
@@ -1016,10 +1000,8 @@ msgstr "linkgit:git-log[1]"
 
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:63
-#, fuzzy
-#| msgid "Shows the commit logs."
 msgid "Show commit logs."
-msgstr "Zeigt die Geschichte des Projekts"
+msgstr "Zeigt die Geschichte des Projekts."
 
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:64 en/git-fmt-merge-msg.txt:75
@@ -1040,12 +1022,10 @@ msgstr "linkgit:git-mv[1]"
 
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:69
-#, fuzzy
-#| msgid "git-mv - Move or rename a file, a directory, or a symlink"
 msgid "Move or rename a file, a directory, or a symlink."
 msgstr ""
-"git-mv - Eine Datei, ein Verzeichnis oder einen Symlink verschieben oder "
-"umbenennen"
+"Eine Datei, ein Verzeichnis oder einen Symlink verschieben oder "
+"umbenennen."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:70
@@ -1121,11 +1101,8 @@ msgstr "linkgit:git-rm[1]"
 
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:90
-#, fuzzy
-#| msgid ""
-#| "git-rm - Remove files from the working tree and from the index"
 msgid "Remove files from the working tree and from the index."
-msgstr "git-rm - Entferne Dateien aus dem Arbeitsbereich und dem Index"
+msgstr "Entferne Dateien aus dem Arbeitsbereich und dem Index."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:91
@@ -1206,10 +1183,8 @@ msgstr ""
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:112 en/git-gui.txt:104
-#, fuzzy, no-wrap
-#| msgid "linkgit:git-add[1]"
 msgid "linkgit:gitk[1]"
-msgstr "linkgit:git-add[1]"
+msgstr "linkgit:gitk[1]"
 
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:114

--- a/po/documentation.de.po
+++ b/po/documentation.de.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: git documentation\n"
 "POT-Creation-Date: 2019-01-04 23:29+0100\n"
-"PO-Revision-Date: 2019-01-13 20:14+0100\n"
+"PO-Revision-Date: 2019-01-13 20:24+0100\n"
 "Last-Translator: Matthias Aßhauer <mha1993@live.de>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: de\n"
@@ -535,11 +535,9 @@ msgstr "linkgit:git-config[1]"
 
 #. type: Plain text
 #: en/cmds-ancillarymanipulators.txt:3
-#, fuzzy
-#| msgid "git-config - Get and set repository or global options"
 msgid "Get and set repository or global options."
 msgstr ""
-"git-config - Repositoryeigene oder globale Optionen auslesen und setzen"
+"Repositoryweite oder globale Optionen lesen und setzen."
 
 #. type: Plain text
 #: en/cmds-ancillarymanipulators.txt:4 en/git-fast-import.txt:1472
@@ -550,7 +548,7 @@ msgstr "linkgit:git-fast-export[1]"
 #. type: Plain text
 #: en/cmds-ancillarymanipulators.txt:6
 msgid "Git data exporter."
-msgstr ""
+msgstr "Export-Tool für Git-Daten."
 
 #. type: Plain text
 #: en/cmds-ancillarymanipulators.txt:7 en/git-fast-export.txt:215
@@ -561,7 +559,7 @@ msgstr "linkgit:git-fast-import[1]"
 #. type: Plain text
 #: en/cmds-ancillarymanipulators.txt:9
 msgid "Backend for fast Git data importers."
-msgstr ""
+msgstr "Backend für schnelle Git-Datenimport-Tools."
 
 #. type: Labeled list
 #: en/cmds-ancillarymanipulators.txt:10
@@ -571,10 +569,8 @@ msgstr "linkgit:git-filter-branch[1]"
 
 #. type: Plain text
 #: en/cmds-ancillarymanipulators.txt:12
-#, fuzzy
-#| msgid "switch branch"
 msgid "Rewrite branches."
-msgstr "switch branch"
+msgstr "Branches umschreiben."
 
 #. type: Labeled list
 #: en/cmds-ancillarymanipulators.txt:13 en/git-difftool.txt:139
@@ -586,6 +582,7 @@ msgstr "linkgit:git-mergetool[1]"
 #: en/cmds-ancillarymanipulators.txt:15
 msgid "Run merge conflict resolution tools to resolve merge conflicts."
 msgstr ""
+"Ausführen von Tools zur Auflösung von Merge-Konflikten zur Behebung dieser."
 
 #. type: Labeled list
 #: en/cmds-ancillarymanipulators.txt:16
@@ -596,7 +593,7 @@ msgstr "linkgit:git-pack-refs[1]"
 #. type: Plain text
 #: en/cmds-ancillarymanipulators.txt:18
 msgid "Pack heads and tags for efficient repository access."
-msgstr ""
+msgstr "Branches und Tags für effizienten Zugriff auf das Repository packen."
 
 #. type: Labeled list
 #: en/cmds-ancillarymanipulators.txt:19
@@ -607,7 +604,7 @@ msgstr "linkgit:git-prune[1]"
 #. type: Plain text
 #: en/cmds-ancillarymanipulators.txt:21
 msgid "Prune all unreachable objects from the object database."
-msgstr ""
+msgstr "Alle nicht erreichbaren Objekte von der Objektdatenbank entfernen."
 
 #. type: Labeled list
 #: en/cmds-ancillarymanipulators.txt:22
@@ -618,7 +615,7 @@ msgstr "linkgit:git-reflog[1]"
 #. type: Plain text
 #: en/cmds-ancillarymanipulators.txt:24
 msgid "Manage reflog information."
-msgstr ""
+msgstr "Reflog-Informationen verwalten."
 
 #. type: Labeled list
 #: en/cmds-ancillarymanipulators.txt:25
@@ -628,10 +625,8 @@ msgstr "linkgit:git-remote[1]"
 
 #. type: Plain text
 #: en/cmds-ancillarymanipulators.txt:27
-#, fuzzy
-#| msgid "git-remote - manage set of tracked repositories"
 msgid "Manage set of tracked repositories."
-msgstr "git-remote - Einen Satz entfernter Repositories verwalten"
+msgstr "Einen Satz entfernter Repositories verwalten."
 
 #. type: Labeled list
 #: en/cmds-ancillarymanipulators.txt:28
@@ -642,7 +637,7 @@ msgstr "linkgit:git-repack[1]"
 #. type: Plain text
 #: en/cmds-ancillarymanipulators.txt:30
 msgid "Pack unpacked objects in a repository."
-msgstr ""
+msgstr "Ungepackte Objekte in einem Repository packen."
 
 #. type: Labeled list
 #: en/cmds-ancillarymanipulators.txt:31
@@ -653,7 +648,7 @@ msgstr "linkgit:git-replace[1]"
 #. type: Plain text
 #: en/cmds-ancillarymanipulators.txt:33
 msgid "Create, list, delete refs to replace objects."
-msgstr ""
+msgstr "Referenzen für ersetzende Objekte erstellen, auflisten, löschen."
 
 #. type: Labeled list
 #: en/cmds-foreignscminterface.txt:1

--- a/po/documentation.de.po
+++ b/po/documentation.de.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: git documentation\n"
 "POT-Creation-Date: 2019-01-04 23:29+0100\n"
-"PO-Revision-Date: 2019-01-13 18:09+0100\n"
+"PO-Revision-Date: 2019-01-13 19:32+0100\n"
 "Last-Translator: Matthias Aßhauer <mha1993@live.de>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: de\n"
@@ -787,7 +787,7 @@ msgstr "linkgit:git-am[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:6
 msgid "Apply a series of patches from a mailbox."
-msgstr ""
+msgstr "Eine Serie von Patches von einer Mailbox anwenden."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:7
@@ -798,7 +798,7 @@ msgstr "linkgit:git-archive[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:9
 msgid "Create an archive of files from a named tree."
-msgstr ""
+msgstr "Dateiarchiv von angegebenem Verzeichnis erstellen."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:10
@@ -810,6 +810,8 @@ msgstr "linkgit:git-bisect[1]"
 #: en/cmds-mainporcelain.txt:12
 msgid "Use binary search to find the commit that introduced a bug."
 msgstr ""
+"Binärsuche verwenden, um den Commit zu finden, der einen Fehler verursacht "
+"hat."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:13
@@ -820,9 +822,7 @@ msgstr "linkgit:git-branch[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:15
 msgid "List, create, or delete branches."
-msgstr ""
-"Auflisten, Erzeugen oder Löschen von Entwicklungszweigen "
-"(branches)"
+msgstr "Branches anzeigen, erstellen oder entfernen."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:16
@@ -833,7 +833,7 @@ msgstr "linkgit:git-bundle[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:18
 msgid "Move objects and refs by archive."
-msgstr ""
+msgstr "Objekte und Referenzen über ein Archiv verteilen."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:19
@@ -844,7 +844,7 @@ msgstr "linkgit:git-checkout[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:21
 msgid "Switch branches or restore working tree files."
-msgstr ""
+msgstr "Branches wechseln oder Dateien im Arbeitsverzeichnis wiederherstellen."
 
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:22 en/git-revert.txt:126
@@ -855,7 +855,7 @@ msgstr "linkgit:git-cherry-pick[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:24
 msgid "Apply the changes introduced by some existing commits."
-msgstr ""
+msgstr "Änderungen eines existierenden Commits anwenden."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:25
@@ -877,7 +877,7 @@ msgstr "linkgit:git-clean[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:30
 msgid "Remove untracked files from the working tree."
-msgstr "Entferne Dateien aus dem Arbeitsbereich und dem Index."
+msgstr "Unversionierte Dateien vom Arbeitsverzeichnis entfernen."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:31
@@ -888,8 +888,7 @@ msgstr "linkgit:git-clone[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:33
 msgid "Clone a repository into a new directory."
-msgstr ""
-"Klone ein Projektarchiv (repository) in ein neues Verzeichnis."
+msgstr "Ein Repository in einem neuen Verzeichnis klonen."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:34
@@ -900,7 +899,7 @@ msgstr "linkgit:git-commit[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:36
 msgid "Record changes to the repository."
-msgstr "Trage Änderungen im Projektarchiv (repository) ein."
+msgstr "Änderungen in das Repository eintragen."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:37
@@ -912,6 +911,8 @@ msgstr "linkgit:git-describe[1]"
 #: en/cmds-mainporcelain.txt:39
 msgid "Give an object a human readable name based on an available ref."
 msgstr ""
+"Einem Objekt einen für Menschen lesbaren Namen basierend auf "
+"einer verfügbaren Referenz geben."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:40 en/git-difftool.txt:136
@@ -923,8 +924,7 @@ msgstr "linkgit:git-diff[1]"
 #: en/cmds-mainporcelain.txt:42
 msgid "Show changes between commits, commit and working tree, etc."
 msgstr ""
-"Zeige Unterschiede zwischen Eintragungen (commits), Eintragung "
-"und Arbeitsbereich, etc."
+"Änderungen zwischen Commits, Commit und Arbeitsverzeichnis, etc. anzeigen."
 
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:43 en/git-fetch-pack.txt:129
@@ -935,7 +935,7 @@ msgstr "linkgit:git-fetch[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:45
 msgid "Download objects and refs from another repository."
-msgstr ""
+msgstr "Objekte und Referenzen von einem anderen Repository herunterladen."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:46
@@ -946,7 +946,7 @@ msgstr "linkgit:git-format-patch[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:48
 msgid "Prepare patches for e-mail submission."
-msgstr ""
+msgstr "Patches für E-Mail-Versand vorbereiten."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:49
@@ -957,7 +957,7 @@ msgstr "linkgit:git-gc[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:51
 msgid "Cleanup unnecessary files and optimize the local repository."
-msgstr ""
+msgstr "Nicht benötigte Dateien entfernen und das lokale Repository optimieren."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:52
@@ -968,7 +968,7 @@ msgstr "linkgit:git-grep[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:54
 msgid "Print lines matching a pattern."
-msgstr ""
+msgstr "Zeilen darstellen, die einem Muster entsprechen."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:55
@@ -979,7 +979,7 @@ msgstr "linkgit:git-gui[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:57
 msgid "A portable graphical interface to Git."
-msgstr ""
+msgstr "Eine portable grafische Schnittstelle zu Git."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:58
@@ -990,7 +990,7 @@ msgstr "linkgit:git-init[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:60
 msgid "Create an empty Git repository or reinitialize an existing one."
-msgstr ""
+msgstr "Ein leeres Git-Repository erstellen oder ein bestehendes neuinitialisieren."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:61
@@ -1001,7 +1001,7 @@ msgstr "linkgit:git-log[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:63
 msgid "Show commit logs."
-msgstr "Zeigt die Geschichte des Projekts."
+msgstr "Commit-Historie anzeigen."
 
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:64 en/git-fmt-merge-msg.txt:75
@@ -1012,7 +1012,7 @@ msgstr "linkgit:git-merge[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:66
 msgid "Join two or more development histories together."
-msgstr ""
+msgstr "Zwei oder mehr Entwicklungszweige zusammenführen."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:67
@@ -1036,7 +1036,7 @@ msgstr "linkgit:git-notes[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:72
 msgid "Add or inspect object notes."
-msgstr ""
+msgstr "Objekt-Notizen hinzufügen oder überprüfen."
 
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:73 en/git-fetch.txt:209
@@ -1048,6 +1048,8 @@ msgstr "linkgit:git-pull[1]"
 #: en/cmds-mainporcelain.txt:75
 msgid "Fetch from and integrate with another repository or a local branch."
 msgstr ""
+"Objekte von einem externen Repository anfordern und sie mit einem anderen "
+"Repository oder einem lokalen Branch zusammenführen."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:76
@@ -1058,7 +1060,7 @@ msgstr "linkgit:git-push[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:78
 msgid "Update remote refs along with associated objects."
-msgstr ""
+msgstr "Remote-Referenzen mitsamt den verbundenen Objekten aktualisieren."
 
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:79 en/git-svn.txt:1133
@@ -1069,7 +1071,7 @@ msgstr "linkgit:git-rebase[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:81
 msgid "Reapply commits on top of another base tip."
-msgstr ""
+msgstr "Wiederholtes Anwenden von Commits auf anderem Basis-Commit."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:82
@@ -1080,7 +1082,7 @@ msgstr "linkgit:git-reset[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:84
 msgid "Reset current HEAD to the specified state."
-msgstr ""
+msgstr "Aktuellen HEAD zu einem spezifizierten Zustand setzen."
 
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:85 en/git-cherry-pick.txt:230
@@ -1091,7 +1093,7 @@ msgstr "linkgit:git-revert[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:87
 msgid "Revert some existing commits."
-msgstr ""
+msgstr "Einige bestehende Commits rückgängig machen."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:88
@@ -1102,7 +1104,7 @@ msgstr "linkgit:git-rm[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:90
 msgid "Remove files from the working tree and from the index."
-msgstr "Entferne Dateien aus dem Arbeitsbereich und dem Index."
+msgstr "Dateien aus dem Arbeitsverzeichnis und dem Index löschen."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:91
@@ -1113,7 +1115,7 @@ msgstr "linkgit:git-shortlog[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:93
 msgid "Summarize 'git log' output."
-msgstr ""
+msgstr "Ausgabe von 'git log' zusammenfassen."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:94
@@ -1124,7 +1126,7 @@ msgstr "linkgit:git-show[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:96
 msgid "Show various types of objects."
-msgstr ""
+msgstr "Verschiedene Arten von Objekten anzeigen."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:97
@@ -1135,7 +1137,7 @@ msgstr "linkgit:git-stash[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:99
 msgid "Stash the changes in a dirty working directory away."
-msgstr ""
+msgstr "Änderungen in einem Arbeitsverzeichnis aufbewahren."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:100
@@ -1146,7 +1148,7 @@ msgstr "linkgit:git-status[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:102
 msgid "Show the working tree status."
-msgstr ""
+msgstr "Den Zustand des Arbeitsverzeichnisses anzeigen."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:103
@@ -1157,7 +1159,7 @@ msgstr "linkgit:git-submodule[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:105
 msgid "Initialize, update or inspect submodules."
-msgstr ""
+msgstr "Submodule initialisieren, aktualisieren oder inspizieren."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:106
@@ -1169,6 +1171,8 @@ msgstr "linkgit:git-tag[1]"
 #: en/cmds-mainporcelain.txt:108
 msgid "Create, list, delete or verify a tag object signed with GPG."
 msgstr ""
+"Ein mit GPG signiertes Tag-Objekt erzeugen, auflisten, löschen oder "
+"verifizieren."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:109
@@ -1179,7 +1183,7 @@ msgstr "linkgit:git-worktree[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:111
 msgid "Manage multiple working trees."
-msgstr ""
+msgstr "Mehrere Arbeitsverzeichnisse verwalten."
 
 #. type: Labeled list
 #: en/cmds-mainporcelain.txt:112 en/git-gui.txt:104
@@ -1189,7 +1193,7 @@ msgstr "linkgit:gitk[1]"
 #. type: Plain text
 #: en/cmds-mainporcelain.txt:114
 msgid "The Git repository browser."
-msgstr ""
+msgstr "Der Git-Repository-Browser."
 
 #. type: Labeled list
 #: en/cmds-plumbinginterrogators.txt:1

--- a/po/documentation.de.po
+++ b/po/documentation.de.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: git documentation\n"
 "POT-Creation-Date: 2019-01-04 23:29+0100\n"
-"PO-Revision-Date: 2019-01-13 20:03+0100\n"
+"PO-Revision-Date: 2019-01-13 20:14+0100\n"
 "Last-Translator: Matthias Aßhauer <mha1993@live.de>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: de\n"
@@ -1788,7 +1788,7 @@ msgstr "linkgit:git-http-fetch[1]"
 #. type: Plain text
 #: en/cmds-synchelpers.txt:3
 msgid "Download from a remote Git repository via HTTP."
-msgstr ""
+msgstr "Von einem Remote-Git-Repository über HTTP herunterladen."
 
 #. type: Labeled list
 #: en/cmds-synchelpers.txt:4
@@ -1799,7 +1799,7 @@ msgstr "linkgit:git-http-push[1]"
 #. type: Plain text
 #: en/cmds-synchelpers.txt:6
 msgid "Push objects over HTTP/DAV to another repository."
-msgstr ""
+msgstr "Objekte über HTTP/DAV zu einem anderen Repository übertragen."
 
 #. type: Labeled list
 #: en/cmds-synchelpers.txt:7
@@ -1811,6 +1811,7 @@ msgstr "linkgit:git-parse-remote[1]"
 #: en/cmds-synchelpers.txt:9
 msgid "Routines to help parsing remote repository access parameters."
 msgstr ""
+"Routinen als Hilfe zum Parsen von Zugriffsparametern von Remote-Repositories."
 
 #. type: Labeled list
 #: en/cmds-synchelpers.txt:10
@@ -1821,7 +1822,7 @@ msgstr "linkgit:git-receive-pack[1]"
 #. type: Plain text
 #: en/cmds-synchelpers.txt:12
 msgid "Receive what is pushed into the repository."
-msgstr ""
+msgstr "Empfangen was in das Repository übertragen wurde."
 
 #. type: Labeled list
 #: en/cmds-synchelpers.txt:13
@@ -1832,7 +1833,7 @@ msgstr "linkgit:git-shell[1]"
 #. type: Plain text
 #: en/cmds-synchelpers.txt:15
 msgid "Restricted login shell for Git-only SSH access."
-msgstr ""
+msgstr "Login-Shell beschränkt für Nur-Git SSH-Zugriff."
 
 #. type: Labeled list
 #: en/cmds-synchelpers.txt:16
@@ -1843,7 +1844,7 @@ msgstr "linkgit:git-upload-archive[1]"
 #. type: Plain text
 #: en/cmds-synchelpers.txt:18
 msgid "Send archive back to git-archive."
-msgstr ""
+msgstr "Archiv zurück zu git-archive senden."
 
 #. type: Labeled list
 #: en/cmds-synchelpers.txt:19
@@ -1854,7 +1855,7 @@ msgstr "linkgit:git-upload-pack[1]"
 #. type: Plain text
 #: en/cmds-synchelpers.txt:21
 msgid "Send objects packed back to git-fetch-pack."
-msgstr ""
+msgstr "Objekte gepackt zurück an git-fetch-pack senden."
 
 #. type: Labeled list
 #: en/cmds-synchingrepositories.txt:1

--- a/po/documentation.de.po
+++ b/po/documentation.de.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: git documentation\n"
 "POT-Creation-Date: 2019-01-04 23:29+0100\n"
-"PO-Revision-Date: 2019-01-13 19:32+0100\n"
+"PO-Revision-Date: 2019-01-13 20:03+0100\n"
 "Last-Translator: Matthias Aßhauer <mha1993@live.de>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: de\n"
@@ -1865,7 +1865,7 @@ msgstr "linkgit:git-daemon[1]"
 #. type: Plain text
 #: en/cmds-synchingrepositories.txt:3
 msgid "A really simple server for Git repositories."
-msgstr ""
+msgstr "Ein wirklich einfacher Server für Git Repositories."
 
 #. type: Labeled list
 #: en/cmds-synchingrepositories.txt:4
@@ -1876,7 +1876,7 @@ msgstr "linkgit:git-fetch-pack[1]"
 #. type: Plain text
 #: en/cmds-synchingrepositories.txt:6
 msgid "Receive missing objects from another repository."
-msgstr ""
+msgstr "Fehlende Objekte von einem anderen Repository empfangen."
 
 #. type: Labeled list
 #: en/cmds-synchingrepositories.txt:7
@@ -1887,7 +1887,7 @@ msgstr "linkgit:git-http-backend[1]"
 #. type: Plain text
 #: en/cmds-synchingrepositories.txt:9
 msgid "Server side implementation of Git over HTTP."
-msgstr ""
+msgstr "Serverseitige Implementierung von Git über HTTP."
 
 #. type: Labeled list
 #: en/cmds-synchingrepositories.txt:10
@@ -1898,7 +1898,7 @@ msgstr "linkgit:git-send-pack[1]"
 #. type: Plain text
 #: en/cmds-synchingrepositories.txt:12
 msgid "Push objects over Git protocol to another repository."
-msgstr ""
+msgstr "Objekte über das Git Protokoll zu einem anderen Repository übertragen."
 
 #. type: Labeled list
 #: en/cmds-synchingrepositories.txt:13
@@ -1909,7 +1909,7 @@ msgstr "linkgit:git-update-server-info[1]"
 #. type: Plain text
 #: en/cmds-synchingrepositories.txt:15
 msgid "Update auxiliary info file to help dumb servers."
-msgstr ""
+msgstr "Hilfsinformationsdatei zur Hilfe von einfachen Servern aktualisieren."
 
 #. type: Title -
 #: en/config.txt:2

--- a/po/documentation.de.po
+++ b/po/documentation.de.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: git documentation\n"
 "POT-Creation-Date: 2019-01-04 23:29+0100\n"
-"PO-Revision-Date: 2019-01-14 13:51+0100\n"
+"PO-Revision-Date: 2019-01-14 18:35+0100\n"
 "Last-Translator: Matthias Aßhauer <mha1993@live.de>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: de\n"
@@ -1188,6 +1188,8 @@ msgstr "linkgit:git-cat-file[1]"
 #: en/cmds-plumbinginterrogators.txt:3
 msgid "Provide content or type and size information for repository objects."
 msgstr ""
+"Inhalt oder Informationen zu Typ und Größe für Repository-Objekte "
+"bereitstellen."
 
 #. type: Labeled list
 #: en/cmds-plumbinginterrogators.txt:4
@@ -1197,11 +1199,8 @@ msgstr "linkgit:git-diff-files[1]"
 
 #. type: Plain text
 #: en/cmds-plumbinginterrogators.txt:6
-#, fuzzy
-#| msgid ""
-#| "git-rm - Remove files from the working tree and from the index"
 msgid "Compares files in the working tree and the index."
-msgstr "git-rm - Entferne Dateien aus dem Arbeitsbereich und dem Index"
+msgstr "Dateien von dem Arbeitsverzeichnis und dem Index vergleichen."
 
 #. type: Labeled list
 #: en/cmds-plumbinginterrogators.txt:7
@@ -1211,10 +1210,8 @@ msgstr "linkgit:git-diff-index[1]"
 
 #. type: Plain text
 #: en/cmds-plumbinginterrogators.txt:9
-#, fuzzy
-#| msgid "Creates a tree object using the current index."
 msgid "Compare a tree to the working tree or index."
-msgstr "Erstellt ein Baumobjekt mit dem aktuellen Index."
+msgstr "Ein Verzeichnis von dem Arbeitsverzeichnis und dem Index vergleichen."
 
 #. type: Labeled list
 #: en/cmds-plumbinginterrogators.txt:10
@@ -1226,6 +1223,7 @@ msgstr "linkgit:git-diff-tree[1]"
 #: en/cmds-plumbinginterrogators.txt:12
 msgid "Compares the content and mode of blobs found via two tree objects."
 msgstr ""
+"Den Inhalt und Modus von Blobs aus zwei Verzeichnisobjekten vergleichen."
 
 #. type: Labeled list
 #: en/cmds-plumbinginterrogators.txt:13
@@ -1236,7 +1234,7 @@ msgstr "linkgit:git-for-each-ref[1]"
 #. type: Plain text
 #: en/cmds-plumbinginterrogators.txt:15
 msgid "Output information on each ref."
-msgstr ""
+msgstr "Informationen für jede Referenz ausgeben."
 
 #. type: Labeled list
 #: en/cmds-plumbinginterrogators.txt:16
@@ -1248,6 +1246,7 @@ msgstr "linkgit:git-ls-files[1]"
 #: en/cmds-plumbinginterrogators.txt:18
 msgid "Show information about files in the index and the working tree."
 msgstr ""
+"Informationen über Dateien in dem Index und im Arbeitsverzeichnis anzeigen."
 
 #. type: Labeled list
 #: en/cmds-plumbinginterrogators.txt:19
@@ -1257,10 +1256,8 @@ msgstr "linkgit:git-ls-remote[1]"
 
 #. type: Plain text
 #: en/cmds-plumbinginterrogators.txt:21
-#, fuzzy
-#| msgid "--reference <repository>"
 msgid "List references in a remote repository."
-msgstr "--reference <repository>"
+msgstr "Referenzen in einem Remote-Repository auflisten."
 
 #. type: Labeled list
 #: en/cmds-plumbinginterrogators.txt:22
@@ -1271,7 +1268,7 @@ msgstr "linkgit:git-ls-tree[1]"
 #. type: Plain text
 #: en/cmds-plumbinginterrogators.txt:24
 msgid "List the contents of a tree object."
-msgstr ""
+msgstr "Inhalte eines Tree-Objektes auflisten."
 
 #. type: Labeled list
 #: en/cmds-plumbinginterrogators.txt:25
@@ -1282,7 +1279,7 @@ msgstr "linkgit:git-merge-base[1]"
 #. type: Plain text
 #: en/cmds-plumbinginterrogators.txt:27
 msgid "Find as good common ancestors as possible for a merge."
-msgstr ""
+msgstr "Bestmöglichen gemeinsamen Vorgänger-Commit für einen Merge finden."
 
 #. type: Labeled list
 #: en/cmds-plumbinginterrogators.txt:28
@@ -1293,7 +1290,7 @@ msgstr "linkgit:git-name-rev[1]"
 #. type: Plain text
 #: en/cmds-plumbinginterrogators.txt:30
 msgid "Find symbolic names for given revs."
-msgstr ""
+msgstr "Symbolische Namen für die gegebenen Commits finden."
 
 #. type: Labeled list
 #: en/cmds-plumbinginterrogators.txt:31
@@ -1304,7 +1301,7 @@ msgstr "linkgit:git-pack-redundant[1]"
 #. type: Plain text
 #: en/cmds-plumbinginterrogators.txt:33
 msgid "Find redundant pack files."
-msgstr ""
+msgstr "Redundante Paketdateien finden."
 
 #. type: Labeled list
 #: en/cmds-plumbinginterrogators.txt:34
@@ -1315,7 +1312,7 @@ msgstr "linkgit:git-rev-list[1]"
 #. type: Plain text
 #: en/cmds-plumbinginterrogators.txt:36
 msgid "Lists commit objects in reverse chronological order."
-msgstr ""
+msgstr "Commit-Objekte chronologisch absteigend sortiert auflisten."
 
 #. type: Labeled list
 #: en/cmds-plumbinginterrogators.txt:37
@@ -1326,7 +1323,7 @@ msgstr "linkgit:git-show-index[1]"
 #. type: Plain text
 #: en/cmds-plumbinginterrogators.txt:39
 msgid "Show packed archive index."
-msgstr ""
+msgstr "Gepackten Archiv-Index anzeigen."
 
 #. type: Plain text
 #: en/cmds-plumbinginterrogators.txt:40 en/git-for-each-ref.txt:341
@@ -1336,10 +1333,8 @@ msgstr "linkgit:git-show-ref[1]"
 
 #. type: Plain text
 #: en/cmds-plumbinginterrogators.txt:42
-#, fuzzy
-#| msgid "--reference <repository>"
 msgid "List references in a local repository."
-msgstr "--reference <repository>"
+msgstr "Referenzen in einem lokalen Repository auflisten."
 
 #. type: Labeled list
 #: en/cmds-plumbinginterrogators.txt:43
@@ -1350,7 +1345,7 @@ msgstr "linkgit:git-unpack-file[1]"
 #. type: Plain text
 #: en/cmds-plumbinginterrogators.txt:45
 msgid "Creates a temporary file with a blob's contents."
-msgstr ""
+msgstr "Eine temporäre Datei mit den Inhalten eines Blobs erstellen."
 
 #. type: Labeled list
 #: en/cmds-plumbinginterrogators.txt:46
@@ -1361,7 +1356,7 @@ msgstr "linkgit:git-var[1]"
 #. type: Plain text
 #: en/cmds-plumbinginterrogators.txt:48
 msgid "Show a Git logical variable."
-msgstr ""
+msgstr "Eine logische Variable von Git anzeigen."
 
 #. type: Labeled list
 #: en/cmds-plumbinginterrogators.txt:49
@@ -1372,7 +1367,7 @@ msgstr "linkgit:git-verify-pack[1]"
 #. type: Plain text
 #: en/cmds-plumbinginterrogators.txt:51
 msgid "Validate packed Git archive files."
-msgstr ""
+msgstr "Gepackte Git-Archivdateien validieren."
 
 #. type: Labeled list
 #: en/cmds-plumbingmanipulators.txt:1

--- a/po/documentation.de.po
+++ b/po/documentation.de.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: git documentation\n"
 "POT-Creation-Date: 2019-01-04 23:29+0100\n"
-"PO-Revision-Date: 2019-01-14 18:35+0100\n"
+"PO-Revision-Date: 2019-01-14 18:55+0100\n"
 "Last-Translator: Matthias Aßhauer <mha1993@live.de>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: de\n"
@@ -1378,7 +1378,7 @@ msgstr "linkgit:git-apply[1]"
 #. type: Plain text
 #: en/cmds-plumbingmanipulators.txt:3
 msgid "Apply a patch to files and/or to the index."
-msgstr ""
+msgstr "Einen Patch auf Dateien und/oder den Index anwenden."
 
 #. type: Labeled list
 #: en/cmds-plumbingmanipulators.txt:4
@@ -1389,7 +1389,7 @@ msgstr "linkgit:git-checkout-index[1]"
 #. type: Plain text
 #: en/cmds-plumbingmanipulators.txt:6
 msgid "Copy files from the index to the working tree."
-msgstr ""
+msgstr "Dateien von dem Index ins Arbeitsverzeichnis kopieren."
 
 #. type: Labeled list
 #: en/cmds-plumbingmanipulators.txt:7
@@ -1400,7 +1400,7 @@ msgstr "linkgit:git-commit-tree[1]"
 #. type: Plain text
 #: en/cmds-plumbingmanipulators.txt:9
 msgid "Create a new commit object."
-msgstr ""
+msgstr "Ein neues Commit-Objekt erstellen."
 
 #. type: Labeled list
 #: en/cmds-plumbingmanipulators.txt:10
@@ -1412,6 +1412,7 @@ msgstr "linkgit:git-hash-object[1]"
 #: en/cmds-plumbingmanipulators.txt:12
 msgid "Compute object ID and optionally creates a blob from a file."
 msgstr ""
+"Von einer Datei die Objekt-ID berechnen und optional ein Blob erstellen."
 
 #. type: Labeled list
 #: en/cmds-plumbingmanipulators.txt:13
@@ -1422,7 +1423,7 @@ msgstr "linkgit:git-index-pack[1]"
 #. type: Plain text
 #: en/cmds-plumbingmanipulators.txt:15
 msgid "Build pack index file for an existing packed archive."
-msgstr ""
+msgstr "Pack-Index-Datei für ein existierendes gepacktes Archiv erzeugen."
 
 #. type: Labeled list
 #: en/cmds-plumbingmanipulators.txt:16
@@ -1433,7 +1434,7 @@ msgstr "linkgit:git-merge-file[1]"
 #. type: Plain text
 #: en/cmds-plumbingmanipulators.txt:18
 msgid "Run a three-way file merge."
-msgstr ""
+msgstr "Einen 3-Wege-Datei-Merge ausführen."
 
 #. type: Labeled list
 #: en/cmds-plumbingmanipulators.txt:19
@@ -1444,7 +1445,7 @@ msgstr "linkgit:git-merge-index[1]"
 #. type: Plain text
 #: en/cmds-plumbingmanipulators.txt:21
 msgid "Run a merge for files needing merging."
-msgstr ""
+msgstr "Einen Merge für zusammenzuführende Dateien ausführen."
 
 #. type: Labeled list
 #: en/cmds-plumbingmanipulators.txt:22
@@ -1455,7 +1456,7 @@ msgstr "linkgit:git-mktag[1]"
 #. type: Plain text
 #: en/cmds-plumbingmanipulators.txt:24
 msgid "Creates a tag object."
-msgstr ""
+msgstr "Ein Tag-Objekt erstellen."
 
 #. type: Labeled list
 #: en/cmds-plumbingmanipulators.txt:25
@@ -1466,7 +1467,7 @@ msgstr "linkgit:git-mktree[1]"
 #. type: Plain text
 #: en/cmds-plumbingmanipulators.txt:27
 msgid "Build a tree-object from ls-tree formatted text."
-msgstr ""
+msgstr "Tree-Objekt aus ls-tree formattiertem Text erzeugen."
 
 #. type: Labeled list
 #: en/cmds-plumbingmanipulators.txt:28
@@ -1477,7 +1478,7 @@ msgstr "linkgit:git-pack-objects[1]"
 #. type: Plain text
 #: en/cmds-plumbingmanipulators.txt:30
 msgid "Create a packed archive of objects."
-msgstr ""
+msgstr "Ein gepacktes Archiv von Objekten erstellen."
 
 #. type: Labeled list
 #: en/cmds-plumbingmanipulators.txt:31
@@ -1488,7 +1489,7 @@ msgstr "linkgit:git-prune-packed[1]"
 #. type: Plain text
 #: en/cmds-plumbingmanipulators.txt:33
 msgid "Remove extra objects that are already in pack files."
-msgstr ""
+msgstr "Zusätzliche Objekte, die sich bereits in Paketdateien befinden, entfernen."
 
 #. type: Labeled list
 #: en/cmds-plumbingmanipulators.txt:34
@@ -1498,10 +1499,8 @@ msgstr "linkgit:git-read-tree[1]"
 
 #. type: Plain text
 #: en/cmds-plumbingmanipulators.txt:36
-#, fuzzy
-#| msgid "Gives some information about the remote <name>."
 msgid "Reads tree information into the index."
-msgstr "Gibt Informationen über das entfernte Repository <Name> aus."
+msgstr "Verzeichnisinformationen in den Index einlesen."
 
 #. type: Labeled list
 #: en/cmds-plumbingmanipulators.txt:37
@@ -1512,7 +1511,7 @@ msgstr "linkgit:git-symbolic-ref[1]"
 #. type: Plain text
 #: en/cmds-plumbingmanipulators.txt:39
 msgid "Read, modify and delete symbolic refs."
-msgstr ""
+msgstr "Symbolische Referenzen lesen, ändern und löschen."
 
 #. type: Labeled list
 #: en/cmds-plumbingmanipulators.txt:40
@@ -1523,7 +1522,7 @@ msgstr "linkgit:git-unpack-objects[1]"
 #. type: Plain text
 #: en/cmds-plumbingmanipulators.txt:42
 msgid "Unpack objects from a packed archive."
-msgstr ""
+msgstr "Objekte aus einem gepackten Archiv entpacken."
 
 #. type: Labeled list
 #: en/cmds-plumbingmanipulators.txt:43
@@ -1533,11 +1532,8 @@ msgstr "linkgit:git-update-index[1]"
 
 #. type: Plain text
 #: en/cmds-plumbingmanipulators.txt:45
-#, fuzzy
-#| msgid ""
-#| "git-rm - Remove files from the working tree and from the index"
 msgid "Register file contents in the working tree to the index."
-msgstr "git-rm - Entferne Dateien aus dem Arbeitsbereich und dem Index"
+msgstr "Dateiinhalte aus dem Arbeitsverzeichnis im Index registrieren."
 
 #. type: Labeled list
 #: en/cmds-plumbingmanipulators.txt:46
@@ -1548,7 +1544,7 @@ msgstr "linkgit:git-update-ref[1]"
 #. type: Plain text
 #: en/cmds-plumbingmanipulators.txt:48
 msgid "Update the object name stored in a ref safely."
-msgstr ""
+msgstr "Den Objektnamen, der in einer Referenz gespeichert ist, sicher aktualisieren."
 
 #. type: Plain text
 #: en/cmds-plumbingmanipulators.txt:49 en/git-commit-tree.txt:115
@@ -1558,10 +1554,8 @@ msgstr "linkgit:git-write-tree[1]"
 
 #. type: Plain text
 #: en/cmds-plumbingmanipulators.txt:51
-#, fuzzy
-#| msgid "Creates a tree object using the current index."
 msgid "Create a tree object from the current index."
-msgstr "Erstellt ein Baumobjekt mit dem aktuellen Index."
+msgstr "Tree-Objekt vom aktuellen Index erstellen."
 
 #. type: Labeled list
 #: en/cmds-purehelpers.txt:1


### PR DESCRIPTION
Translate all the command lists to german. These lists are used for the main git manpage. I've mostly used the translations for `command-list.h` in [git/git/blob/master/po/de.po](https://github.com/git/git/blob/master/po/de.po) to keep the wordings close to the translation of the main project, but I've reworded some things that sounded odd to me, fixed a typo or two and standardized on capitalized beginnings and periods at the end of each line.