### PR TITLE
ignore po4a/ as long as po4a project is not mature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Gemfile.lock
 */*.dep+
 !en/*.txt
 po/*.mo
+po4a/


### PR DESCRIPTION
Pour ignorer le dossier po4a/ tant que le projet po4a n'est pas mature et qu'on utilise ta version patchée.