### PR TITLE
de: pre-translate-from Git

### DIFF
--- a/po/documentation.de.po
+++ b/po/documentation.de.po
@@ -11,7 +11,7 @@ msgstr ""
 "Project-Id-Version: git documentation\n"
 "Report-Msgid-Bugs-To: jn.avila@free.fr\n"
 "POT-Creation-Date: 2019-08-27 18:53+0200\n"
-"PO-Revision-Date: 2019-08-26 10:54+0000\n"
+"PO-Revision-Date: 2019-09-06 22:06+0200\n"
 "Last-Translator: Matthias Aßhauer <mha1993@live.de>\n"
 "Language-Team: Matthias Aßhauer <mha1993@live.de>\n"
 "Language: de\n"
@@ -2207,9 +2207,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/config.txt:143
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "`gitdir/i`"
-msgstr ""
+msgstr "`gitdir`"
 
 #. type: Plain text
 #: en/config.txt:146
@@ -2717,9 +2717,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/config/merge.txt:99
-#, no-wrap, priority:240
+#, fuzzy, no-wrap, priority:240
 msgid "merge.<driver>.driver"
-msgstr ""
+msgstr "merge.renameLimit"
 
 #. type: Plain text
 #: en/config/merge.txt:102
@@ -3655,9 +3655,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:36
-#, no-wrap, priority:280
+#, fuzzy, no-wrap, priority:280
 msgid "-U<n>"
-msgstr ""
+msgstr "-<n>"
 
 #. type: Labeled list
 #: en/diff-options.txt:37
@@ -4320,9 +4320,9 @@ msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:322
-#, no-wrap, priority:280
+#, fuzzy, no-wrap, priority:280
 msgid "\tIt can be set by the `diff.colorMovedWS` configuration setting.\n"
-msgstr ""
+msgstr "The remote configuration is achieved using the `remote.origin.url` and `remote.origin.fetch` configuration variables.  (See linkgit:git-config[1]).  Die Konfiguration entfernter Repositories wird durch die Konfigurationsvariablen `remote.origin.url` und `remote.origin.fetch` erreicht. (Siehe linkgit:git-config[1])."
 
 #. type: Plain text
 #: en/diff-options.txt:324
@@ -4338,9 +4338,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:328 en/merge-strategies.txt:61
-#, no-wrap, priority:280
+#, fuzzy, no-wrap, priority:280
 msgid "ignore-space-at-eol"
-msgstr ""
+msgstr "--ignore-space-at-eol"
 
 #. type: Plain text
 #: en/diff-options.txt:330 en/diff-options.txt:665
@@ -4350,9 +4350,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:330 en/merge-strategies.txt:59
-#, no-wrap, priority:280
+#, fuzzy, no-wrap, priority:280
 msgid "ignore-space-change"
-msgstr ""
+msgstr "--ignore-space-change"
 
 #. type: Plain text
 #: en/diff-options.txt:334 en/diff-options.txt:671
@@ -4362,9 +4362,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:334 en/merge-strategies.txt:60
-#, no-wrap, priority:280
+#, fuzzy, no-wrap, priority:280
 msgid "ignore-all-space"
-msgstr ""
+msgstr "--ignore-all-space"
 
 #. type: Plain text
 #: en/diff-options.txt:337
@@ -4423,9 +4423,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:362
-#, no-wrap, priority:280
+#, fuzzy, no-wrap, priority:280
 msgid "porcelain"
-msgstr ""
+msgstr "--porcelain"
 
 #. type: Plain text
 #: en/diff-options.txt:369
@@ -4611,9 +4611,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:472
-#, no-wrap, priority:280
+#, fuzzy, no-wrap, priority:280
 msgid "-M[<n>]"
-msgstr ""
+msgstr "-M[<Anz>]"
 
 #. type: Labeled list
 #: en/diff-options.txt:473 en/git-status.txt:143
@@ -4653,9 +4653,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:492
-#, no-wrap, priority:280
+#, fuzzy, no-wrap, priority:280
 msgid "-C[<n>]"
-msgstr ""
+msgstr "-C[<Anz>]"
 
 #. type: Labeled list
 #: en/diff-options.txt:493
@@ -5608,9 +5608,9 @@ msgstr "--progress"
 
 #. type: Plain text
 #: en/fetch-options.txt:218 en/git-pack-objects.txt:156 en/git-push.txt:376
-#, priority:220
+#, fuzzy, priority:220
 msgid "Progress status is reported on the standard error stream by default when it is attached to a terminal, unless -q is specified. This flag forces progress status even if the standard error stream is not directed to a terminal."
-msgstr ""
+msgstr "Der Fortschritt wird nur standardmäßig auf der Standardfehlerausgabe angezeigt, wenn dieser an ein Terminal angebunden ist. Dieses Flag erlaubt die Fortschrittsanzeige auch ohne Terminalanbindung. `--progress` kann nicht zusammen mit `--porcelain` oder `--incremental` verwendet werden."
 
 #. type: Labeled list
 #: en/fetch-options.txt:219 en/git-ls-remote.txt:73 en/git-push.txt:215
@@ -6452,9 +6452,9 @@ msgstr "git-am(1)"
 
 #. type: Plain text
 #: en/git-am.txt:7
-#, priority:100
+#, fuzzy, priority:100
 msgid "git-am - Apply a series of patches from a mailbox"
-msgstr ""
+msgstr "Eine Serie von Patches von einer Mailbox anwenden."
 
 #. type: Plain text
 #: en/git-am.txt:20
@@ -6684,15 +6684,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-am.txt:110 en/git-apply.txt:129 en/git-rebase.txt:337
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "-C<n>"
-msgstr ""
+msgstr "-<n>"
 
 #. type: Labeled list
 #: en/git-am.txt:111 en/git-apply.txt:123
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "-p<n>"
-msgstr ""
+msgstr "-<n>"
 
 #. type: Labeled list
 #: en/git-am.txt:112
@@ -7241,9 +7241,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-apply.txt:166
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "--exclude=<path-pattern>"
-msgstr ""
+msgstr "--exclude=<Glob-Muster>"
 
 #. type: Plain text
 #: en/git-apply.txt:170
@@ -7253,9 +7253,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-apply.txt:171
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "--include=<path-pattern>"
-msgstr ""
+msgstr "--exclude=<Glob-Muster>"
 
 #. type: Plain text
 #: en/git-apply.txt:175
@@ -7752,9 +7752,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-archive.txt:73
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "--exec=<git-upload-archive>"
-msgstr ""
+msgstr "-u <upload-pack>"
 
 #. type: Plain text
 #: en/git-archive.txt:76
@@ -8011,15 +8011,15 @@ msgstr "git-bisect(1)"
 
 #. type: Plain text
 #: en/git-bisect.txt:7
-#, priority:100
+#, fuzzy, priority:100
 msgid "git-bisect - Use binary search to find the commit that introduced a bug"
-msgstr ""
+msgstr "Binärsuche verwenden, um den Commit zu finden, der einen Fehler verursacht hat."
 
 #. type: Plain text
 #: en/git-bisect.txt:13
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "'git bisect' <subcommand> <options>\n"
-msgstr ""
+msgstr "'git log' <option>..."
 
 #. type: Plain text
 #: en/git-bisect.txt:18 en/git-reflog.txt:18
@@ -8098,9 +8098,9 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-bisect.txt:74
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "$ git bisect good\n"
-msgstr ""
+msgstr "$ git bisect bad\n"
 
 #. type: Plain text
 #: en/git-bisect.txt:77
@@ -8308,9 +8308,9 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-bisect.txt:205
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "$ git bisect visualize\n"
-msgstr ""
+msgstr "$ git bisect bad\n"
 
 #. type: Plain text
 #: en/git-bisect.txt:210
@@ -8784,9 +8784,9 @@ msgstr "git-blame(1)"
 
 #. type: Plain text
 #: en/git-blame.txt:7
-#, priority:100
+#, fuzzy, priority:100
 msgid "git-blame - Show what revision and author last modified each line of a file"
-msgstr ""
+msgstr "Anzeigen, durch welchen Commit und Autor die jeweiligen Zeilen einer Datei zuletzt geändert wurden."
 
 #. type: Plain text
 #: en/git-blame.txt:16
@@ -9712,9 +9712,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-branch.txt:293 en/git-tag.txt:158
-#, no-wrap, priority:240
+#, fuzzy, no-wrap, priority:240
 msgid "--points-at <object>"
-msgstr ""
+msgstr "--contains <commit>"
 
 #. type: Plain text
 #: en/git-branch.txt:295
@@ -10192,9 +10192,9 @@ msgstr "git-cat-file(1)"
 
 #. type: Plain text
 #: en/git-cat-file.txt:7
-#, priority:100
+#, fuzzy, priority:100
 msgid "git-cat-file - Provide content or type and size information for repository objects"
-msgstr ""
+msgstr "Inhalt oder Informationen zu Typ und Größe für Repository-Objekte bereitstellen."
 
 #. type: Plain text
 #: en/git-cat-file.txt:14
@@ -10224,9 +10224,9 @@ msgstr "<Objekt>"
 
 #. type: Plain text
 #: en/git-cat-file.txt:35
-#, priority:100
+#, fuzzy, priority:100
 msgid "The name of the object to show.  For a more complete list of ways to spell object names, see the \"SPECIFYING REVISIONS\" section in linkgit:gitrevisions[7]."
-msgstr ""
+msgstr "Stellt nur Commits zwischen den angegebenen Commits dar.  Wird <von> oder <bis> weggelassen, entspricht dies der Angabe von `HEAD`. Eine detaillierte Liste, wie <von> und <bis> angegeben werden können, findet sich unter \"REVISIONEN SPEZIFIZIEREN\" in linkgit::git-rev-parse[1]."
 
 #. type: Plain text
 #: en/git-cat-file.txt:39
@@ -10302,9 +10302,9 @@ msgstr "--batch"
 
 #. type: Labeled list
 #: en/git-cat-file.txt:78
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "--batch=<format>"
-msgstr ""
+msgstr "--patch-format"
 
 #. type: Plain text
 #: en/git-cat-file.txt:84
@@ -10930,9 +10930,9 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-attr.txt:87
-#, priority:100
+#, fuzzy, priority:100
 msgid "Listing multiple attributes for a file:"
-msgstr ""
+msgstr "Zeige alle in der Konfigurationsdatei gesetzten Variablen an."
 
 #. type: delimited block -
 #: en/git-check-attr.txt:92
@@ -11660,9 +11660,9 @@ msgstr "--no-progress"
 
 #. type: Plain text
 #: en/git-checkout.txt:118 en/git-restore.txt:74 en/git-switch.txt:150
-#, priority:240
+#, fuzzy, priority:240
 msgid "Progress status is reported on the standard error stream by default when it is attached to a terminal, unless `--quiet` is specified. This flag enables progress reporting even if not attached to a terminal, regardless of `--quiet`."
-msgstr ""
+msgstr "Der Fortschritt wird nur standardmäßig auf der Standardfehlerausgabe angezeigt, wenn dieser an ein Terminal angebunden ist. Dieses Flag erlaubt die Fortschrittsanzeige auch ohne Terminalanbindung. `--progress` kann nicht zusammen mit `--porcelain` oder `--incremental` verwendet werden."
 
 #. type: Plain text
 #: en/git-checkout.txt:124
@@ -12839,15 +12839,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-cherry-pick.txt:151 en/git-revert.txt:107
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "-X<option>"
-msgstr ""
+msgstr "`option`"
 
 #. type: Labeled list
 #: en/git-cherry-pick.txt:152 en/git-revert.txt:108 en/merge-options.txt:117
-#, no-wrap, priority:240
+#, fuzzy, no-wrap, priority:240
 msgid "--strategy-option=<option>"
-msgstr ""
+msgstr "--stop-at-non-option"
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:155 en/git-revert.txt:111
@@ -13766,7 +13766,7 @@ msgstr ""
 #: en/git-clone.txt:191
 #, no-wrap, priority:300
 msgid "-c <key>=<value>"
-msgstr ""
+msgstr "-c <Name>=<Wert>"
 
 #. type: Labeled list
 #: en/git-clone.txt:192
@@ -14145,9 +14145,9 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-column.txt:61
-#, priority:100
+#, fuzzy, priority:100
 msgid "Format data by rows:"
-msgstr ""
+msgstr "Daten in Spalten anzeigen."
 
 #. type: delimited block -
 #: en/git-column.txt:66
@@ -14747,9 +14747,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-commit.txt:200
-#, no-wrap, priority:280
+#, fuzzy, no-wrap, priority:280
 msgid "whitespace"
-msgstr ""
+msgstr "--whitespace"
 
 #. type: Plain text
 #: en/git-commit.txt:202
@@ -14771,9 +14771,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-commit.txt:204
-#, no-wrap, priority:280
+#, fuzzy, no-wrap, priority:280
 msgid "scissors"
-msgstr ""
+msgstr "--scissors"
 
 #. type: Plain text
 #: en/git-commit.txt:208
@@ -16982,9 +16982,9 @@ msgstr "git-cvsimport(1)"
 
 #. type: Plain text
 #: en/git-cvsimport.txt:7
-#, priority:100
+#, fuzzy, priority:100
 msgid "git-cvsimport - Salvage your data out of another SCM people love to hate"
-msgstr ""
+msgstr "Ihre Daten aus einem anderen SCM übernehmen."
 
 #. type: Plain text
 #: en/git-cvsimport.txt:17
@@ -18473,9 +18473,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-daemon.txt:182
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "--enable=<service>"
-msgstr ""
+msgstr "--file=<file>"
 
 #. type: Labeled list
 #: en/git-daemon.txt:183
@@ -19578,9 +19578,9 @@ msgstr "git-diff - Zeige Unterschiede zwischen Eintragungen (commits), Eintragun
 
 #. type: Plain text
 #: en/git-difftool.txt:143
-#, priority:100
+#, fuzzy, priority:100
 msgid "Run merge conflict resolution tools to resolve merge conflicts"
-msgstr ""
+msgstr "Ausführen von Tools zur Auflösung von Merge-Konflikten zur Behebung dieser."
 
 #. type: Plain text
 #: en/git-difftool.txt:146
@@ -19597,9 +19597,9 @@ msgstr "git-diff-tree(1)"
 
 #. type: Plain text
 #: en/git-diff-tree.txt:7
-#, priority:100
+#, fuzzy, priority:100
 msgid "git-diff-tree - Compares the content and mode of blobs found via two tree objects"
-msgstr ""
+msgstr "Den Inhalt und Modus von Blobs aus zwei Verzeichnisobjekten vergleichen."
 
 #. type: Plain text
 #: en/git-diff-tree.txt:15
@@ -19612,9 +19612,9 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-tree.txt:19
-#, priority:100
+#, fuzzy, priority:100
 msgid "Compares the content and mode of the blobs found via two tree objects."
-msgstr ""
+msgstr "Den Inhalt und Modus von Blobs aus zwei Verzeichnisobjekten vergleichen."
 
 #. type: Plain text
 #: en/git-diff-tree.txt:22
@@ -22093,9 +22093,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-import.txt:1082
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "no-relative-marks"
-msgstr ""
+msgstr "--[no-]relative-marks"
 
 #. type: Plain text
 #: en/git-fast-import.txt:1083 en/git-fast-import.txt:1150
@@ -22130,15 +22130,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-import.txt:1098
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "get-mark"
-msgstr ""
+msgstr "`get-mark`"
 
 #. type: Labeled list
 #: en/git-fast-import.txt:1099
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "cat-blob"
-msgstr ""
+msgstr "`cat-blob`"
 
 #. type: Labeled list
 #: en/git-fast-import.txt:1100
@@ -23260,9 +23260,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fetch.txt:221 en/git-push.txt:440
-#, no-wrap, priority:220
+#, fuzzy, no-wrap, priority:220
 msgid "summary"
-msgstr ""
+msgstr "--summary"
 
 #. type: Plain text
 #: en/git-fetch.txt:226
@@ -24401,9 +24401,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-for-each-ref.txt:126
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "objecttype"
-msgstr ""
+msgstr "`objecttype`"
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:128
@@ -24413,9 +24413,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-for-each-ref.txt:129
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "objectsize"
-msgstr ""
+msgstr "`objectsize`"
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:133
@@ -24425,9 +24425,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-for-each-ref.txt:133
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "objectname"
-msgstr ""
+msgstr "`objectname`"
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:139
@@ -24529,9 +24529,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-for-each-ref.txt:211
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "symref"
-msgstr ""
+msgstr "--symref"
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:216
@@ -25864,9 +25864,9 @@ msgstr "die Commits an, die im Zweig \"experimentell\" aber nicht im Zweig \"sta
 
 #. type: delimited block -
 #: en/git-format-patch.txt:648
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "$ git format-patch origin\n"
-msgstr ""
+msgstr "bob$ git branch -r\n  origin/master\n"
 
 #. type: Plain text
 #: en/git-format-patch.txt:651
@@ -26127,9 +26127,9 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fsck.txt:106
-#, priority:100
+#, fuzzy, priority:100
 msgid "Progress status is reported on the standard error stream by default when it is attached to a terminal, unless --no-progress or --verbose is specified. --progress forces progress status even if the standard error stream is not directed to a terminal."
-msgstr ""
+msgstr "Der Fortschritt wird nur standardmäßig auf der Standardfehlerausgabe angezeigt, wenn dieser an ein Terminal angebunden ist. Dieses Flag erlaubt die Fortschrittsanzeige auch ohne Terminalanbindung. `--progress` kann nicht zusammen mit `--porcelain` oder `--incremental` verwendet werden."
 
 #. type: Plain text
 #: en/git-fsck.txt:121
@@ -26278,9 +26278,9 @@ msgstr "git-gc(1)"
 
 #. type: Plain text
 #: en/git-gc.txt:7
-#, priority:100
+#, fuzzy, priority:100
 msgid "git-gc - Cleanup unnecessary files and optimize the local repository"
-msgstr ""
+msgstr "Nicht benötigte Dateien entfernen und das lokale Repository optimieren."
 
 #. type: Plain text
 #: en/git-gc.txt:13
@@ -27240,9 +27240,9 @@ msgstr "git-gui(1)"
 
 #. type: Plain text
 #: en/git-gui.txt:7
-#, priority:100
+#, fuzzy, priority:100
 msgid "git-gui - A portable graphical interface to Git"
-msgstr ""
+msgstr "Eine portable grafische Schnittstelle zu Git."
 
 #. type: Plain text
 #: en/git-gui.txt:12
@@ -27288,9 +27288,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-gui.txt:36
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "browser"
-msgstr ""
+msgstr "--browser"
 
 #. type: Plain text
 #: en/git-gui.txt:40
@@ -27313,9 +27313,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-gui.txt:47
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "version"
-msgstr ""
+msgstr "--version"
 
 #. type: Plain text
 #: en/git-gui.txt:49
@@ -27441,9 +27441,9 @@ msgstr ""
 
 #. type: Title -
 #: en/git-gui.txt:110
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "Other"
-msgstr ""
+msgstr "Sonstiges"
 
 #. type: Plain text
 #: en/git-gui.txt:114
@@ -27483,9 +27483,9 @@ msgstr "git-hash-object(1)"
 
 #. type: Plain text
 #: en/git-hash-object.txt:7
-#, priority:100
+#, fuzzy, priority:100
 msgid "git-hash-object - Compute object ID and optionally creates a blob from a file"
-msgstr ""
+msgstr "Von einer Datei die Objekt-ID berechnen und optional ein Blob erstellen."
 
 #. type: Plain text
 #: en/git-hash-object.txt:14
@@ -28627,9 +28627,9 @@ msgstr "git-imap-send(1)"
 
 #. type: Plain text
 #: en/git-imap-send.txt:7
-#, priority:100
+#, fuzzy, priority:100
 msgid "git-imap-send - Send a collection of patches from stdin to an IMAP folder"
-msgstr ""
+msgstr "Eine Sammlung von Patches von der Standard-Eingabe an einen IMAP-Ordner senden."
 
 #. type: Plain text
 #: en/git-imap-send.txt:13
@@ -28933,9 +28933,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-index-pack.txt:83 en/git-pack-objects.txt:239 en/git-repack.txt:102
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "--threads=<n>"
-msgstr ""
+msgstr "--threads <Anz>"
 
 #. type: Plain text
 #: en/git-index-pack.txt:92
@@ -29037,9 +29037,9 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-init.txt:32
-#, priority:300
+#, fuzzy, priority:300
 msgid "If the object storage directory is specified via the `$GIT_OBJECT_DIRECTORY` environment variable then the sha1 directories are created underneath - otherwise the default `$GIT_DIR/objects` directory is used."
-msgstr ""
+msgstr "Wenn das Objektverzeichnis über diese Umgebungsvariable angegeben wird werden die SHA1-Verzeichnisse darunter angelegt, ansonsten wird standardmäßig Das Verzeichnis`$GIT_DIR/objects` verwendet."
 
 #. type: Plain text
 #: en/git-init.txt:37
@@ -29055,9 +29055,9 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-init.txt:50
-#, priority:300
+#, fuzzy, priority:300
 msgid "Create a bare repository. If `GIT_DIR` environment is not set, it is set to the current working directory."
-msgstr ""
+msgstr "Das Repository als Bare-Repository behandeln. Wenn die Umgebungsvariable GIT_DIR nicht gestezt ist, wird sie auf das aktuelle Arbeitsverzeichnis gesetzt."
 
 #. type: Plain text
 #: en/git-init.txt:55
@@ -29263,9 +29263,9 @@ msgstr "git-instaweb(1)"
 
 #. type: Plain text
 #: en/git-instaweb.txt:7
-#, priority:100
+#, fuzzy, priority:100
 msgid "git-instaweb - Instantly browse your working repository in gitweb"
-msgstr ""
+msgstr "Ihr aktuelles Repository sofort in gitweb betrachten."
 
 #. type: Plain text
 #: en/git-instaweb.txt:14
@@ -29374,9 +29374,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-instaweb.txt:64
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "restart"
-msgstr ""
+msgstr "--restart"
 
 #. type: Labeled list
 #: en/git-instaweb.txt:65
@@ -30540,9 +30540,9 @@ msgstr "git-ls-files(1)"
 
 #. type: Plain text
 #: en/git-ls-files.txt:7
-#, priority:100
+#, fuzzy, priority:100
 msgid "git-ls-files - Show information about files in the index and the working tree"
-msgstr ""
+msgstr "Informationen über Dateien in dem Index und im Arbeitsverzeichnis anzeigen."
 
 #. type: Plain text
 #: en/git-ls-files.txt:23
@@ -31320,9 +31320,9 @@ msgstr "git-mailinfo(1)"
 
 #. type: Plain text
 #: en/git-mailinfo.txt:7
-#, priority:100
+#, fuzzy, priority:100
 msgid "git-mailinfo - Extracts patch and authorship from a single e-mail message"
-msgstr ""
+msgstr "Patch und Urheberschaft aus einer einzelnen E-Mail-Nachricht extrahieren."
 
 #. type: Plain text
 #: en/git-mailinfo.txt:13
@@ -32310,9 +32310,9 @@ msgstr "git-mergetool(1)"
 
 #. type: Plain text
 #: en/git-mergetool.txt:7
-#, priority:240
+#, fuzzy, priority:240
 msgid "git-mergetool - Run merge conflict resolution tools to resolve merge conflicts"
-msgstr ""
+msgstr "Ausführen von Tools zur Auflösung von Merge-Konflikten zur Behebung dieser."
 
 #. type: Plain text
 #: en/git-mergetool.txt:12
@@ -32472,9 +32472,9 @@ msgstr "git-merge(1)"
 
 #. type: Plain text
 #: en/git-merge.txt:7
-#, priority:240
+#, fuzzy, priority:240
 msgid "git-merge - Join two or more development histories together"
-msgstr ""
+msgstr "Zwei oder mehr Entwicklungszweige zusammenführen."
 
 #. type: Plain text
 #: en/git-merge.txt:17
@@ -33397,9 +33397,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-notes.txt:87
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "append"
-msgstr ""
+msgstr "--append"
 
 #. type: Plain text
 #: en/git-notes.txt:90
@@ -33454,9 +33454,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-notes.txt:112 en/git-worktree.txt:105
-#, no-wrap, priority:240
+#, fuzzy, no-wrap, priority:240
 msgid "remove"
-msgstr ""
+msgstr "--remove"
 
 #. type: Plain text
 #: en/git-notes.txt:117
@@ -36347,9 +36347,9 @@ msgstr "git-pull(1)"
 
 #. type: Plain text
 #: en/git-pull.txt:7
-#, priority:220
+#, fuzzy, priority:220
 msgid "git-pull - Fetch from and integrate with another repository or a local branch"
-msgstr ""
+msgstr "Objekte von einem externen Repository anfordern und sie mit einem anderen Repository oder einem lokalen Branch zusammenführen."
 
 #. type: Plain text
 #: en/git-pull.txt:13
@@ -36698,9 +36698,9 @@ msgstr "git-push(1)"
 
 #. type: Plain text
 #: en/git-push.txt:7
-#, priority:220
+#, fuzzy, priority:220
 msgid "git-push - Update remote refs along with associated objects"
-msgstr ""
+msgstr "Remote-Referenzen mitsamt den verbundenen Objekten aktualisieren."
 
 #. type: Plain text
 #: en/git-push.txt:18
@@ -37469,9 +37469,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:592
-#, no-wrap, priority:220
+#, fuzzy, no-wrap, priority:220
 msgid "`git push origin :`"
-msgstr ""
+msgstr "`git push origin master`"
 
 #. type: Plain text
 #: en/git-push.txt:596
@@ -37493,9 +37493,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:604
-#, no-wrap, priority:220
+#, fuzzy, no-wrap, priority:220
 msgid "`git push origin HEAD`"
-msgstr ""
+msgstr "`git push origin master`"
 
 #. type: Plain text
 #: en/git-push.txt:607
@@ -37535,9 +37535,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:629
-#, no-wrap, priority:220
+#, fuzzy, no-wrap, priority:220
 msgid "`git push origin HEAD:master`"
-msgstr ""
+msgstr "`git push origin master`"
 
 #. type: Plain text
 #: en/git-push.txt:633
@@ -37572,9 +37572,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:645
-#, no-wrap, priority:220
+#, fuzzy, no-wrap, priority:220
 msgid "`git push origin +dev:master`"
-msgstr ""
+msgstr "`git push origin master`"
 
 #. type: Plain text
 #: en/git-push.txt:650
@@ -37839,9 +37839,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-read-tree.txt:91
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "--exclude-per-directory=<gitignore>"
-msgstr ""
+msgstr "--exclude-per-directory=<Datei>"
 
 #. type: Plain text
 #: en/git-read-tree.txt:105
@@ -37899,9 +37899,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-read-tree.txt:136
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "<tree-ish#>"
-msgstr ""
+msgstr "<Commit-Referenz>"
 
 #. type: Plain text
 #: en/git-read-tree.txt:138
@@ -38760,9 +38760,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rebase.txt:294
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "-X <strategy-option>"
-msgstr ""
+msgstr "--strategy-option"
 
 #. type: Labeled list
 #: en/git-rebase.txt:295
@@ -41594,9 +41594,9 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-replace.txt:48
-#, priority:100
+#, fuzzy, priority:100
 msgid "shows information about commit 'foo', while:"
-msgstr ""
+msgstr "Gibt Informationen über das entfernte Repository <Name> aus."
 
 #. type: delimited block -
 #: en/git-replace.txt:51
@@ -41922,9 +41922,9 @@ msgstr "git-rerere(1)"
 
 #. type: Plain text
 #: en/git-rerere.txt:7
-#, priority:100
+#, fuzzy, priority:100
 msgid "git-rerere - Reuse recorded resolution of conflicted merges"
-msgstr ""
+msgstr "Aufgezeichnete Auflösung von Merge-Konflikten wiederverwenden."
 
 #. type: Plain text
 #: en/git-rerere.txt:12
@@ -42218,9 +42218,9 @@ msgstr "git-reset(1)"
 
 #. type: Plain text
 #: en/git-reset.txt:7
-#, priority:280
+#, fuzzy, priority:280
 msgid "git-reset - Reset current HEAD to the specified state"
-msgstr ""
+msgstr "Aktuellen HEAD zu einem spezifizierten Zustand setzen."
 
 #. type: Plain text
 #: en/git-reset.txt:14
@@ -43766,21 +43766,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:164
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "--branches[=pattern]"
-msgstr ""
+msgstr "--branches[=<Muster>]"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:165
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "--tags[=pattern]"
-msgstr ""
+msgstr "--tags[=<Muster>]"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:166
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "--remotes[=pattern]"
-msgstr ""
+msgstr "--remotes[=<Muster>]"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:170
@@ -44850,9 +44850,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:127
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "--8bit-encoding=<encoding>"
-msgstr ""
+msgstr "--encoding=<Encoding>"
 
 #. type: Plain text
 #: en/git-send-email.txt:133
@@ -45036,9 +45036,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:230
-#, no-wrap, priority:100
+#, fuzzy
 msgid "--smtp-server-option=<option>"
-msgstr ""
+msgstr "--stop-at-non-option"
 
 #. type: Plain text
 #: en/git-send-email.txt:234
@@ -45662,9 +45662,9 @@ msgstr "git-send-pack(1)"
 
 #. type: Plain text
 #: en/git-send-pack.txt:7
-#, priority:100
+#, fuzzy, priority:100
 msgid "git-send-pack - Push objects over Git protocol to another repository"
-msgstr ""
+msgstr "Objekte über das Git Protokoll zu einem anderen Repository übertragen."
 
 #. type: Plain text
 #: en/git-send-pack.txt:16
@@ -45793,9 +45793,9 @@ msgstr "git-shell(1)"
 
 #. type: Plain text
 #: en/git-shell.txt:7
-#, priority:100
+#, fuzzy, priority:100
 msgid "git-shell - Restricted login shell for Git-only SSH access"
-msgstr ""
+msgstr "Login-Shell beschränkt für Nur-Git SSH-Zugriff."
 
 #. type: Plain text
 #: en/git-shell.txt:15
@@ -46215,9 +46215,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-show-branch.txt:37
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "<glob>"
-msgstr ""
+msgstr "<Blob>"
 
 #. type: Plain text
 #: en/git-show-branch.txt:42
@@ -47163,9 +47163,9 @@ msgstr "git-stash(1)"
 
 #. type: Plain text
 #: en/git-stash.txt:7
-#, priority:240
+#, fuzzy, priority:240
 msgid "git-stash - Stash the changes in a dirty working directory away"
-msgstr ""
+msgstr "Änderungen in einem Arbeitsverzeichnis aufbewahren."
 
 #. type: Plain text
 #: en/git-stash.txt:22
@@ -48583,9 +48583,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:152
-#, no-wrap, priority:220
+#, fuzzy, no-wrap, priority:220
 msgid "rebase"
-msgstr ""
+msgstr "--rebase"
 
 #. type: Plain text
 #: en/git-submodule.txt:153
@@ -48768,9 +48768,9 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-submodule.txt:264
-#, priority:220
+#, fuzzy, priority:220
 msgid "This option is only valid for add and update commands.  Progress status is reported on the standard error stream by default when it is attached to a terminal, unless -q is specified. This flag forces progress status even if the standard error stream is not directed to a terminal."
-msgstr ""
+msgstr "Der Fortschritt wird nur standardmäßig auf der Standardfehlerausgabe angezeigt, wenn dieser an ein Terminal angebunden ist. Dieses Flag erlaubt die Fortschrittsanzeige auch ohne Terminalanbindung. `--progress` kann nicht zusammen mit `--porcelain` oder `--incremental` verwendet werden."
 
 #. type: Plain text
 #: en/git-submodule.txt:268
@@ -49014,9 +49014,9 @@ msgstr "git-svn(1)"
 
 #. type: Plain text
 #: en/git-svn.txt:7
-#, priority:100
+#, fuzzy, priority:100
 msgid "git-svn - Bidirectional operation between a Subversion repository and Git"
-msgstr ""
+msgstr "Bidirektionale Operationen zwischen einem Subversion-Repository und Git."
 
 #. type: Plain text
 #: en/git-svn.txt:12
@@ -49215,9 +49215,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-svn.txt:106 en/git-svn.txt:186
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "--include-paths=<regex>"
-msgstr ""
+msgstr "--ignore-unmatch"
 
 #. type: Plain text
 #: en/git-svn.txt:110
@@ -49312,9 +49312,9 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:166
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "config key: svn-remote.<name>.ignore-paths\n"
-msgstr ""
+msgstr "% git config --get-all core.gitproxy\n"
 
 #. type: Plain text
 #: en/git-svn.txt:169
@@ -49355,9 +49355,9 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:196
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "config key: svn-remote.<name>.include-paths\n"
-msgstr ""
+msgstr "% git config --get-all core.gitproxy\n"
 
 #. type: Labeled list
 #: en/git-svn.txt:197
@@ -50011,9 +50011,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-svn.txt:515
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "'reset'"
-msgstr ""
+msgstr "`reset`"
 
 #. type: Plain text
 #: en/git-svn.txt:525
@@ -50131,9 +50131,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-svn.txt:583
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "--revision <arg>"
-msgstr ""
+msgstr "--remove-section"
 
 #. type: Plain text
 #: en/git-svn.txt:585
@@ -50262,9 +50262,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-svn.txt:654
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "--authors-prog=<filename>"
-msgstr ""
+msgstr "--file=<file>"
 
 #. type: Plain text
 #: en/git-svn.txt:661
@@ -50292,9 +50292,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-svn.txt:677
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "-s<strategy>"
-msgstr ""
+msgstr "--strategy"
 
 #. type: Plain text
 #: en/git-svn.txt:682
@@ -51393,9 +51393,9 @@ msgstr "git-tag(1)"
 
 #. type: Plain text
 #: en/git-tag.txt:7
-#, priority:240
+#, fuzzy, priority:240
 msgid "git-tag - Create, list, delete or verify a tag object signed with GPG"
-msgstr ""
+msgstr "Ein mit GPG signiertes Tag-Objekt erzeugen, auflisten, löschen oder verifizieren."
 
 #. type: Plain text
 #: en/git-tag.txt:20
@@ -54737,9 +54737,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-update-ref.txt:104
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "delete"
-msgstr ""
+msgstr "--delete"
 
 #. type: Plain text
 #: en/git-update-ref.txt:107
@@ -54762,9 +54762,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-update-ref.txt:112
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "option"
-msgstr ""
+msgstr "`option`"
 
 #. type: Plain text
 #: en/git-update-ref.txt:116
@@ -55053,9 +55053,9 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-var.txt:17
-#, priority:100
+#, fuzzy, priority:100
 msgid "Prints a Git logical variable."
-msgstr ""
+msgstr "Eine logische Variable von Git anzeigen."
 
 #. type: Plain text
 #: en/git-var.txt:25
@@ -55246,9 +55246,9 @@ msgstr ""
 
 #. type: Title -
 #: en/git-verify-pack.txt:40
-#, no-wrap, priority:100
+#, fuzzy, no-wrap, priority:100
 msgid "OUTPUT FORMAT"
-msgstr ""
+msgstr "DATUMSFORMATE"
 
 #. type: Plain text
 #: en/git-verify-pack.txt:42
@@ -56647,9 +56647,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/merge-options.txt:116
-#, no-wrap, priority:240
+#, fuzzy, no-wrap, priority:240
 msgid "-X <option>"
-msgstr ""
+msgstr "`option`"
 
 #. type: Plain text
 #: en/merge-options.txt:120
@@ -56737,9 +56737,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/merge-strategies.txt:16
-#, no-wrap, priority:240
+#, fuzzy, no-wrap, priority:240
 msgid "recursive"
-msgstr ""
+msgstr "--recursive"
 
 #. type: Plain text
 #: en/merge-strategies.txt:29
@@ -56773,9 +56773,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/merge-strategies.txt:42
-#, no-wrap, priority:240
+#, fuzzy, no-wrap, priority:240
 msgid "theirs"
-msgstr ""
+msgstr "--theirs"
 
 #. type: Plain text
 #: en/merge-strategies.txt:45
@@ -56785,9 +56785,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/merge-strategies.txt:46
-#, no-wrap, priority:240
+#, fuzzy, no-wrap, priority:240
 msgid "patience"
-msgstr ""
+msgstr "--patience"
 
 #. type: Plain text
 #: en/merge-strategies.txt:52
@@ -56840,9 +56840,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/merge-strategies.txt:75
-#, no-wrap, priority:240
+#, fuzzy, no-wrap, priority:240
 msgid "renormalize"
-msgstr ""
+msgstr "--renormalize"
 
 #. type: Plain text
 #: en/merge-strategies.txt:82
@@ -56852,9 +56852,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/merge-strategies.txt:83
-#, no-wrap, priority:240
+#, fuzzy, no-wrap, priority:240
 msgid "no-renormalize"
-msgstr ""
+msgstr "--renormalize"
 
 #. type: Plain text
 #: en/merge-strategies.txt:86
@@ -56913,9 +56913,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/merge-strategies.txt:108
-#, no-wrap, priority:240
+#, fuzzy, no-wrap, priority:240
 msgid "octopus"
-msgstr ""
+msgstr "--octopus"
 
 #. type: Plain text
 #: en/merge-strategies.txt:114
@@ -57388,9 +57388,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/pretty-formats.txt:129
-#, no-wrap, priority:260
+#, fuzzy, no-wrap, priority:260
 msgid "'%m'"
-msgstr ""
+msgstr "'rm'"
 
 #. type: Plain text
 #: en/pretty-formats.txt:130
@@ -58324,9 +58324,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/pretty-options.txt:45
-#, no-wrap, priority:260
+#, fuzzy, no-wrap, priority:260
 msgid "--expand-tabs=<n>"
-msgstr ""
+msgstr "--expand-tabs"
 
 #. type: Labeled list
 #: en/pretty-options.txt:46
@@ -58439,9 +58439,9 @@ msgstr "The remote configuration is achieved using the `remote.origin.url` and `
 
 #. type: Labeled list
 #: en/pull-fetch-param.txt:14
-#, no-wrap, priority:220
+#, fuzzy, no-wrap, priority:220
 msgid "<refspec>"
-msgstr ""
+msgstr "#-#-#-#-#  git-commit-de.po (PACKAGE VERSION)  #-#-#-#-#\n<file>...\n#-#-#-#-#  git-rm-de.po (PACKAGE VERSION)  #-#-#-#-#\n<Datei>..."
 
 #. type: Plain text
 #: en/pull-fetch-param.txt:18
@@ -59155,9 +59155,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/rev-list-options.txt:16
-#, no-wrap, priority:260
+#, fuzzy, no-wrap, priority:260
 msgid "-<number>"
-msgstr ""
+msgstr "--origin <name>"
 
 #. type: Labeled list
 #: en/rev-list-options.txt:17
@@ -59199,9 +59199,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/rev-list-options.txt:25
-#, no-wrap, priority:260
+#, fuzzy, no-wrap, priority:260
 msgid "--after=<date>"
-msgstr ""
+msgstr "--template=<file>"
 
 #. type: Plain text
 #: en/rev-list-options.txt:27
@@ -60534,9 +60534,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/rev-list-options.txt:819
-#, no-wrap, priority:260
+#, fuzzy, no-wrap, priority:260
 msgid "--date=<format>"
-msgstr ""
+msgstr "--date <Format>"
 
 #. type: Plain text
 #: en/rev-list-options.txt:826


### PR DESCRIPTION
As discussed in #22 (among others) I've pretranslated `po/documentation.de.po` from Git's `po/de.po`