### PR TITLE
pre-translate-po: Allow digits in environment variables

### DIFF
--- a/po/documentation.de.po
+++ b/po/documentation.de.po
@@ -53237,10 +53237,9 @@ msgstr "Falls Curl-Ablaufverfolgung aktiviert ist (sieh `GIT_TRACE_CURL` oben), 
 
 #. type: Labeled list
 #: en/git.txt:685
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2`"
-msgstr "`GIT_TRACE`"
+msgstr "`GIT_TRACE2`"
 
 #. type: Plain text
 #: en/git.txt:689
@@ -53269,10 +53268,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:720
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE_SETUP`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2_EVENT`"
-msgstr "`GIT_TRACE_SETUP`"
+msgstr "`GIT_TRACE2_EVENT`"
 
 #. type: Plain text
 #: en/git.txt:725
@@ -53282,10 +53280,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:726
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE_PERFORMANCE`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2_PERF`"
-msgstr "`GIT_TRACE_PERFORMANCE`"
+msgstr "`GIT_TRACE2_PERF`"
 
 #. type: Plain text
 #: en/git.txt:732

--- a/po/documentation.es_MX.po
+++ b/po/documentation.es_MX.po
@@ -2432,7 +2432,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/config.txt:256
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The value for many variables that specify various sizes can be suffixed with `k`, `M`,... to mean \"scale the number by 1024\", \"by 1024x1024\", etc."
 msgstr ""
 
@@ -2822,7 +2822,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-format.txt:16
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "git-diff-tree [-r] <tree-ish-1> <tree-ish-2> [<pattern>...]"
 msgstr ""
 
@@ -2834,7 +2834,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-format.txt:19
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "git-diff-files [<pattern>...]"
 msgstr ""
 
@@ -3514,7 +3514,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/diff-generate-patch.txt:179
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Unlike the traditional 'unified' diff format, which shows two files A and B with a single column that has `-` (minus -- appears in A but removed in B), `+` (plus -- missing in A but added to B), or `\" \"` (space -- unchanged) prefix, this format compares two or more files file1, file2,... with one file X, and shows how X differs from each of fileN.  One column for each of fileN is prepended to the output line to note how X's line is different from it."
 msgstr ""
 
@@ -3837,7 +3837,7 @@ msgstr "<ancho>[,<nombre-ancho>[,<cantidad>]]"
 
 #. type: Plain text
 #: en/diff-options.txt:137
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Generate a diffstat. By default, as much space as necessary will be used for the filename part, and the rest for the graph part. Maximum width defaults to terminal width, or 80 columns if not connected to a terminal, and can be overridden by `<width>`. The width of the filename part can be limited by giving another width `<name-width>` after a comma. The width of the graph part can be limited by using `--stat-graph-width=<width>` (affects all commands generating a stat graph) or by setting `diff.statGraphWidth=<width>` (does not affect `git format-patch`).  By giving a third parameter `<count>`, you can limit the output to the first `<count>` lines, followed by `...` if there are more."
 msgstr ""
 
@@ -3885,13 +3885,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:161
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "-X[<param1,param2,...>]"
 msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:162
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--dirstat[=<param1,param2,...>]"
 msgstr ""
 
@@ -3981,13 +3981,13 @@ msgstr "sinónimo para '-p --stat'"
 
 #. type: Labeled list
 #: en/diff-options.txt:209
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--dirstat-by-file[=<param1,param2>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:211
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Synonym for --dirstat=files,param1,param2..."
 msgstr ""
 
@@ -4648,13 +4648,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:527
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--diff-filter=[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:538
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Select only files that are Added (`A`), Copied (`C`), Deleted (`D`), Modified (`M`), Renamed (`R`), have their type (i.e. regular file, symlink, submodule, ...) changed (`T`), are Unmerged (`U`), are Unknown (`X`), or have had their pairing Broken (`B`).  Any combination of the filter characters (including none) can be used.  When `*` (All-or-none) is added to the combination, all paths are selected if there is any file that matches other criteria in the comparison; if there is no file that matches other criteria, nothing is selected."
 msgstr ""
 
@@ -4714,7 +4714,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/diff-options.txt:573
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "+    return !regexec(regexp, two->ptr, 1, &regmatch, 0);\n"
 "...\n"
@@ -5637,7 +5637,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-add.txt:15
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "'git add' [--verbose | -v] [--dry-run | -n] [--force | -f] [--interactive | -i] [--patch | -p]\n"
 "\t  [--edit | -e] [--[no-]all | --[no-]ignore-removal | [--update | -u]]\n"
@@ -5695,7 +5695,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-add.txt:52 en/git-grep.txt:308 en/git-status.txt:148
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid "<pathspec>..."
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-add.txt:145
-#, priority:300
+#, ignore-ellipsis, priority:300
 msgid "This option is primarily to help users who are used to older versions of Git, whose \"git add <pathspec>...\" was a synonym for \"git add --no-all <pathspec>...\", i.e. ignored removed files."
 msgstr ""
 
@@ -6337,7 +6337,7 @@ msgstr "Aplicar una serie de parches de un mailbox"
 
 #. type: Plain text
 #: en/git-am.txt:20
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git am' [--signoff] [--keep] [--[no-]keep-cr] [--[no-]utf8]\n"
 "\t [--[no-]3way] [--interactive] [--committer-date-is-author-date]\n"
@@ -6357,7 +6357,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-am.txt:29
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "(<mbox>|<Maildir>)..."
 msgstr ""
 
@@ -6893,7 +6893,7 @@ msgstr "Aplicar un parche a archivos y/o  el índice"
 
 #. type: Plain text
 #: en/git-apply.txt:20
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git apply' [--stat] [--numstat] [--summary] [--check] [--index | --intent-to-add] [--3way]\n"
 "\t  [--apply] [--no-add] [--build-fake-ancestor=<file>] [-R | --reverse]\n"
@@ -6919,7 +6919,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-apply.txt:37
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<patch>..."
 msgstr ""
 
@@ -7333,7 +7333,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-archimport.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git archimport' [-h] [-v] [-o] [-a] [-f] [-T] [-D depth] [-t tempdir]\n"
 "               <archive/branch>[:<git-branch>] ...\n"
@@ -7497,7 +7497,7 @@ msgstr "Crear un archivo o archivos de un árbol nombrado"
 
 #. type: Plain text
 #: en/git-archive.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git archive' [--format=<fmt>] [--list] [--prefix=<prefix>/] [<extra>]\n"
 "\t      [-o <file> | --output=<file>] [--worktree-attributes]\n"
@@ -7885,7 +7885,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bisect.txt:31
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 " git bisect start [--term-{old,good}=<term> --term-{new,bad}=<term>]\n"
 "\t\t  [--no-checkout] [<bad> [<good>...]] [--] [<paths>...]\n"
@@ -8080,7 +8080,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-bisect.txt:158
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git bisect new [<rev>...]\n"
 msgstr ""
 
@@ -8110,7 +8110,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bisect.txt:175
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If you would like to use your own terms instead of \"bad\"/\"good\" or \"new\"/\"old\", you can choose any names you like (except existing bisect subcommands like `reset`, `start`, ...) by starting the bisection using"
 msgstr ""
 
@@ -8550,7 +8550,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-bisect.txt:463
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git bisect start HEAD <known-good-commit> [ <boundary-commit> ... ] --no-checkout\n"
 "$ git bisect run sh -c '\n"
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:26
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git branch' [--color[=<when>] | --no-color] [--show-current]\n"
 "\t[-v [--abbrev=<length> | --no-abbrev]]\n"
@@ -9063,7 +9063,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:61
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "The command's second form creates a new branch head named <branchname> which points to the current `HEAD`, or <start-point> if given. As a special case, for <start-point>, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -9261,7 +9261,7 @@ msgstr "listar ramas de remote-tracking y locales"
 
 #. type: Plain text
 #: en/git-branch.txt:176
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "List branches.  With optional `<pattern>...`, e.g. `git branch --list 'maint-*'`, list only the branches that match the pattern(s)."
 msgstr ""
 
@@ -9507,7 +9507,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:291
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "Sort based on the key given. Prefix `-` to sort in descending order of the value. You may use the --sort=<key> option multiple times, in which case the last key becomes the primary key. The keys supported are the same as those in `git for-each-ref`. Sort order defaults to the value configured for the `branch.sort` variable if exists, or to sorting based on the full refname (including `refs/...` prefix). This lists detached HEAD (if present) first, then local branches and finally remote-tracking branches. See linkgit:git-config[1]."
 msgstr ""
 
@@ -9549,7 +9549,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-branch.txt:317
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git clone git://git.kernel.org/pub/scm/.../linux-2.6 my2.6\n"
 "$ cd my2.6\n"
@@ -9571,7 +9571,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-branch.txt:329
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git clone git://git.kernel.org/.../git.git my.git\n"
 "$ cd my.git\n"
@@ -9685,7 +9685,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bundle.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git bundle' create <file> <git-rev-list-args>\n"
 "'git bundle' verify <file>\n"
@@ -9761,7 +9761,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-bundle.txt:71
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<refname>...]"
 msgstr ""
 
@@ -10537,7 +10537,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-attr.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git check-attr' [-a | --all | <attr>...] [--] <pathname>...\n"
 "'git check-attr' --stdin [-z] [-a | --all | <attr>...]\n"
@@ -10778,7 +10778,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-ignore.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git check-ignore' [<options>] <pathname>...\n"
 "'git check-ignore' [<options>] --stdin\n"
@@ -10954,7 +10954,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-mailmap.txt:13
-#, fuzzy, no-wrap, priority:100
+#, fuzzy, ignore-ellipsis, no-wrap, priority:100
 msgid "'git check-mailmap' [<options>] <contact>...\n"
 msgstr "git check-mailmap [<opciones>] <contacto>..."
 
@@ -10990,7 +10990,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout-index.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git checkout-index' [-u] [-q] [-a] [-f] [-n] [--prefix=<string>]\n"
 "\t\t   [--stage=<number>|all]\n"
@@ -11265,7 +11265,7 @@ msgstr "Cambia ramas o restaura los archivos de tu árbol de trabajo"
 
 #. type: Plain text
 #: en/git-checkout.txt:18
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git checkout' [-q] [-f] [-m] [<branch>]\n"
 "'git checkout' [-q] [-f] [-m] --detach [<branch>]\n"
@@ -11376,7 +11376,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-checkout.txt:82
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git checkout' [<tree-ish>] [--] <pathspec>..."
 msgstr ""
 
@@ -11394,7 +11394,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-checkout.txt:98
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git checkout' (-p|--patch) [<tree-ish>] [--] [<pathspec>...]"
 msgstr ""
 
@@ -11736,7 +11736,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:326 en/git-switch.txt:58
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "As a special case, you may use `A...B` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -11766,7 +11766,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:337
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "As a special case, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -12337,7 +12337,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git cherry-pick' [--edit] [-n] [-m parent-number] [-s] [-x] [--ff]\n"
 "\t\t  [-S[<keyid>]] <commit>...\n"
@@ -12394,13 +12394,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-cherry-pick.txt:43 en/git-merge.txt:116 en/git-revert.txt:36 en/git-verify-commit.txt:27
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "<commit>..."
 msgstr ""
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:52
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Commits to cherry-pick.  For a more complete list of ways to spell commits, see linkgit:gitrevisions[7].  Sets of commits can be passed but no traversal is done by default, as if the `--no-walk` option was specified, see linkgit:git-rev-list[1]. Note that specifying a range will feed all <commit>... arguments to a single revision walk (see a later example that uses 'maint master..next')."
 msgstr ""
 
@@ -12430,7 +12430,7 @@ msgstr "-x"
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:78
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When recording the commit, append a line that says \"(cherry picked from commit ...)\" to the original commit message in order to indicate which commit this change was cherry-picked from.  This is done only for cherry picks without conflicts.  Do not use this option if you are cherry-picking from your private branch because the information is useless to the recipient.  If on the other hand you are cherry-picking between two publicly visible branches (e.g. backporting a fix to a maintenance branch for an older release from a development branch), adding this information can be useful."
 msgstr ""
 
@@ -12788,7 +12788,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:58
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git checkout -b topic origin/master\n"
 "# work and create some commits\n"
@@ -12824,7 +12824,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git log --graph --oneline --decorate --boundary origin/master...topic\n"
 "* 7654321 (origin/master) upstream tip commit\n"
@@ -12847,7 +12847,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:96
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git cherry origin/master topic\n"
 "- cccc000... commit C\n"
@@ -12875,7 +12875,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:126
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git log --graph --oneline --decorate --boundary origin/master...topic\n"
 "* 7654321 (origin/master) upstream tip commit\n"
@@ -12901,7 +12901,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:136
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git cherry origin/master topic base\n"
 "- cccc000... commit C\n"
@@ -12953,7 +12953,7 @@ msgstr "Remueve archivos del árbol de trabajo no rastreados"
 
 #. type: Plain text
 #: en/git-clean.txt:12
-#, fuzzy, no-wrap, priority:100
+#, fuzzy, ignore-ellipsis, no-wrap, priority:100
 msgid "'git clean' [-d] [-f] [-i] [-n] [-q] [-e <pattern>] [-x | -X] [--] <path>...\n"
 msgstr "git clean [-d] [-f] [-i] [-n] [-q] [-e <patrón>] [-x | -X] [--] <rutas>..."
 
@@ -12971,7 +12971,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-clean.txt:25
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If any optional `<path>...` arguments are given, only those paths are affected."
 msgstr ""
 
@@ -13582,7 +13582,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-clone.txt:306
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "$ git clone git://git.kernel.org/pub/scm/.../linux.git my-linux\n"
 "$ cd my-linux\n"
@@ -13612,7 +13612,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-clone.txt:325
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "$ git clone --reference /git/linux.git \\\n"
 "\tgit://git.kernel.org/pub/scm/.../linux.git \\\n"
@@ -13805,7 +13805,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-commit-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git commit-tree' <tree> [(-p <parent>)...]\n"
 "'git commit-tree' [(-p <parent>)...] [-S[<keyid>]] [(-m <message>)...]\n"
@@ -14006,7 +14006,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-commit.txt:17
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git commit' [-a | --interactive | --patch] [-s] [-v] [-u<mode>] [--amend]\n"
 "\t   [--dry-run] [(-c | -C | --fixup | --squash) <commit>]\n"
@@ -14426,7 +14426,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-commit.txt:248
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "\t$ git reset --soft HEAD^\n"
 "\t$ ... do something else to come up with the right tree ...\n"
@@ -14591,7 +14591,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-commit.txt:346 en/git-rm.txt:29
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "<file>..."
 msgstr ""
 
@@ -15568,7 +15568,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-config.txt:428
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "However, if you really only want to replace the line for the default proxy, i.e. the one without a \"for ...\" postfix, do something like this:"
 msgstr ""
 
@@ -16926,7 +16926,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-cvsserver.txt:26
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git-cvsserver' [<options>] [pserver|server] [<directory> ...]\n"
 msgstr ""
 
@@ -17624,7 +17624,7 @@ msgstr "Un servidor realmente simple para repositorios Git"
 
 #. type: Plain text
 #: en/git-daemon.txt:25
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git daemon' [--verbose] [--syslog] [--export-all]\n"
 "\t     [--timeout=<n>] [--init-timeout=<n>] [--max-connections=<n>]\n"
@@ -18190,7 +18190,7 @@ msgstr "Dar a un objeto un nombre legible por humanos basado en una referencia d
 
 #. type: Plain text
 #: en/git-describe.txt:14
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "'git describe' [--all] [--tags] [--contains] [--abbrev=<n>] [<commit-ish>...]\n"
 "'git describe' [--all] [--tags] [--contains] [--abbrev=<n>] --dirty[=<mark>]\n"
@@ -18217,7 +18217,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-describe.txt:37
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "<commit-ish>..."
 msgstr ""
 
@@ -18313,7 +18313,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-describe.txt:95
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Always output the long format (the tag, the number of commits and the abbreviated commit name) even when it matches a tag.  This is useful when you want to see parts of the commit object name in \"describe\" output, even when the commit in question happens to be a tagged version.  Instead of just emitting the tag name, it will describe such a commit as v1.2-0-gdeadbee (0th commit since tag v1.2 that points at object deadbee....)."
 msgstr ""
 
@@ -18491,7 +18491,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-files.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git diff-files' [-q] [-0|-1|-2|-3|-c|--cc] [<common diff options>] [<path>...]\n"
 msgstr ""
 
@@ -18563,7 +18563,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-index.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git diff-index' [-m] [--cached] [<common diff options>] <tree-ish> [<path>...]\n"
 msgstr ""
 
@@ -18702,7 +18702,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-index.txt:102
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "  torvalds@ppc970:~/v2.6/linux> git diff-index --abbrev HEAD\n"
 "  :100644 100664 7476bb... 000000...      kernel/sched.c\n"
@@ -18740,7 +18740,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-difftool.txt:12
-#, fuzzy, no-wrap, priority:100
+#, fuzzy, ignore-ellipsis, no-wrap, priority:100
 msgid "'git difftool' [<options>] [<commit> [<commit>]] [--] [<path>...]\n"
 msgstr "git difftool [<opciones>] [<commit> [<commit>]] [--] [<ruta>...]"
 
@@ -19052,7 +19052,7 @@ msgstr "Compara el contenido y el modo de blobs encontrados a través de dos obj
 
 #. type: Plain text
 #: en/git-diff-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git diff-tree' [--stdin] [-m] [-s] [-v] [--no-commit-id] [--pretty]\n"
 "\t      [-t] [-r] [-c | --cc] [--combined-all-paths] [--root]\n"
@@ -19085,7 +19085,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff-tree.txt:32 en/git-diff.txt:114 en/git-submodule.txt:422
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "<path>..."
 msgstr ""
 
@@ -19211,7 +19211,7 @@ msgstr "Muestra los cambios entre commits, commit y árbol de trabajo, etc"
 
 #. type: Plain text
 #: en/git-diff.txt:17
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git diff' [<options>] [<commit>] [--] [<path>...]\n"
 "'git diff' [<options>] --cached [<commit>] [--] [<path>...]\n"
@@ -19228,7 +19228,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:24
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] [--] [<path>...]"
 msgstr ""
 
@@ -19252,7 +19252,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:41
-#, fuzzy, no-wrap, priority:280
+#, fuzzy, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] --cached [<commit>] [--] [<path>...]"
 msgstr "git difftool [<opciones>] [<commit> [<commit>]] [--] [<ruta>...]"
 
@@ -19264,7 +19264,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:51
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit> [--] [<path>...]"
 msgstr ""
 
@@ -19276,7 +19276,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:59
-#, fuzzy, no-wrap, priority:280
+#, fuzzy, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit> <commit> [--] [<path>...]"
 msgstr "git difftool [<opciones>] [<commit> [<commit>]] [--] [<ruta>...]"
 
@@ -19288,7 +19288,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:64
-#, fuzzy, no-wrap, priority:280
+#, fuzzy, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit>..<commit> [--] [<path>...]"
 msgstr "git difftool [<opciones>] [<commit> [<commit>]] [--] [<ruta>...]"
 
@@ -19300,13 +19300,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:70
-#, fuzzy, no-wrap, priority:280
+#, fuzzy, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit>\\...<commit> [--] [<path>...]"
 msgstr "git difftool [<opciones>] [<commit> [<commit>]] [--] [<ruta>...]"
 
 #. type: Plain text
 #: en/git-diff.txt:77
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "This form is to view the changes on the branch containing and up to the second <commit>, starting at a common ancestor of both <commit>.  \"git diff A\\...B\" is equivalent to \"git diff $(git merge-base A B) B\".  You can omit any one of <commit>, which has the same effect as using HEAD instead."
 msgstr ""
 
@@ -19318,7 +19318,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:89
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "For a more complete list of ways to spell <commit>, see \"SPECIFYING REVISIONS\" section in linkgit:gitrevisions[7].  However, \"diff\" is about comparing two _endpoints_, not ranges, and the range notations (\"<commit>..<commit>\" and \"<commit>\\...<commit>\") do not mean a range as defined in the \"SPECIFYING RANGES\" section in linkgit:gitrevisions[7]."
 msgstr ""
 
@@ -19426,7 +19426,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-diff.txt:160
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git diff topic master    <1>\n"
 "$ git diff topic..master   <2>\n"
@@ -19746,7 +19746,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:143
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<git-rev-list-args>...]"
 msgstr ""
 
@@ -19827,7 +19827,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-fast-export.txt:215
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git init anon-repo\n"
 "$ cd anon-repo\n"
@@ -22137,7 +22137,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch-pack.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git fetch-pack' [--all] [--quiet|-q] [--keep|-k] [--thin] [--include-tag]\n"
 "\t[--upload-pack=<git-upload-pack>]\n"
@@ -22291,7 +22291,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fetch-pack.txt:117 en/git-ls-remote.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<refs>..."
 msgstr ""
 
@@ -22321,7 +22321,7 @@ msgstr "Descarga objetos y referencias de otro repositorio"
 
 #. type: Plain text
 #: en/git-fetch.txt:16
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git fetch' [<options>] [<repository> [<refspec>...]]\n"
 "'git fetch' [<options>] <group>\n"
@@ -22662,7 +22662,7 @@ msgstr "--summary"
 
 #. type: Plain text
 #: en/git-fetch.txt:226
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "For a successfully fetched ref, the summary shows the old and new values of the ref in a form suitable for using as an argument to `git log` (this is `<old>..<new>` in most cases, and `<old>...<new>` for forced non-fast-forward updates)."
 msgstr ""
 
@@ -22784,7 +22784,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:18
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git filter-branch' [--setup <command>] [--subdirectory-filter <directory>]\n"
 "\t[--env-filter <command>] [--tree-filter <command>]\n"
@@ -22923,7 +22923,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:117
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for rewriting the index.  It is similar to the tree filter but does not check out the tree, which makes it much faster.  Frequently used with `git rm --cached --ignore-unmatch ...`, see EXAMPLES below.  For hairy cases, see linkgit:git-update-index[1]."
 msgstr ""
 
@@ -22935,7 +22935,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:125
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for rewriting the commit's parent list.  It will receive the parent string on stdin and shall output the new parent string on stdout.  The parent string is in the format described in linkgit:git-commit-tree[1]: empty for the initial commit, \"-p parent\" for a normal commit and \"-p parent1 -p parent2 -p parent3 ...\" for a merge commit."
 msgstr ""
 
@@ -22959,7 +22959,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:138
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for performing the commit.  If this filter is specified, it will be called instead of the 'git commit-tree' command, with arguments of the form \"<TREE_ID> [(-p <PARENT_COMMIT_ID>)...]\" and the log message on stdin.  The commit id is expected on stdout."
 msgstr ""
 
@@ -23061,7 +23061,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-filter-branch.txt:207
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<rev-list options>..."
 msgstr ""
 
@@ -23322,7 +23322,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-filter-branch.txt:388
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git filter-branch ... C..H\n"
 msgstr ""
 
@@ -23334,7 +23334,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-filter-branch.txt:395
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "git filter-branch ... C..H --not D\n"
 "git filter-branch ... D..H --not C\n"
@@ -23573,7 +23573,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git for-each-ref' [--count=<count>] [--shell|--perl|--python|--tcl]\n"
 "\t\t   [(--sort=<key>)...] [--format=<format>] [<pattern>...]\n"
@@ -23590,7 +23590,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-for-each-ref.txt:29 en/git-show-ref.txt:88
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<pattern>..."
 msgstr ""
 
@@ -23878,7 +23878,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:197
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Left-, middle-, or right-align the content between %(align:...) and %(end). The \"align:\" is followed by `width=<width>` and `position=<position>` in any order separated by a comma, where the `<position>` is either left, right or middle, default being left and `<width>` is the total length of the content with alignment. For brevity, the \"width=\" and/or \"position=\" prefixes may be omitted, and bare <width> and <position> used instead.  For instance, `%(align:<width>,<position>)`. If the contents length is more than the width then no alignment is performed. If used with `--quote` everything in between %(align:...) and %(end) is quoted, but if nested then only the topmost level performs quoting."
 msgstr ""
 
@@ -23890,7 +23890,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:210
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Used as %(if)...%(then)...%(end) or %(if)...%(then)...%(else)...%(end).  If there is an atom with value or string literal after the %(if) then everything after the %(then) is printed, else if the %(else) atom is used, then everything after %(else) is printed. We ignore space when evaluating the string before %(then), this is useful when we use the %(HEAD) atom which prints either \"*\" or \" \" and we want to apply the 'if' condition only on the 'HEAD' ref.  Append \":equals=<string>\" or \":notequals=<string>\" to compare the value between the %(if:...) and %(then) atoms with the given string."
 msgstr ""
 
@@ -24111,7 +24111,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:361
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "An example to show the usage of %(if)...%(then)...%(else)...%(end).  This prefixes the current branch with a star."
 msgstr ""
 
@@ -24123,7 +24123,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:369
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "An example to show the usage of %(if)...%(then)...%(end).  This prints the authorname, if present."
 msgstr ""
 
@@ -24769,7 +24769,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:372
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "Do the same for ia64 so we can have sleek & trim looking\n"
 "...\n"
@@ -24777,7 +24777,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:380
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Typically it will be placed in a MUA's drafts folder, edited to add timely commentary that should not go in the changelog after the three dashes, and then sent as a message whose body, in our example, starts with \"arch/arm config files were...\".  On the receiving end, readers can save interesting patches in a UNIX mailbox and apply them with linkgit:git-am[1]."
 msgstr ""
 
@@ -24789,7 +24789,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:390
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "...\n"
 "> So we should do such-and-such.\n"
@@ -24811,7 +24811,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:398
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "arch/arm config files were slimmed down using a python script\n"
 "...\n"
@@ -24985,7 +24985,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:499
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Configure your mail server composition as plain text: Edit...Account Settings...Composition & Addressing, uncheck \"Compose Messages in HTML\"."
 msgstr ""
 
@@ -25122,7 +25122,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:573
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Use Message -> Insert file... and insert the patch."
 msgstr ""
 
@@ -25297,7 +25297,7 @@ msgstr "Verifica la conectividad y disponibilidad de los objetos en la base de d
 
 #. type: Plain text
 #: en/git-fsck-objects.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git fsck-objects' ...\n"
 msgstr ""
 
@@ -25685,7 +25685,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-gc.txt:55
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Once housekeeping is triggered by exceeding the limits of configuration options such as `gc.auto` and `gc.autoPackLimit`, all other housekeeping tasks (e.g. rerere, working trees, reflog...) will be performed as well."
 msgstr ""
 
@@ -25859,7 +25859,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-grep.txt:32
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git grep' [-a | --text] [-I] [--textconv] [-i | --ignore-case] [-w | --word-regexp]\n"
 "\t   [-v | --invert-match] [-h|-H] [--full-name]\n"
@@ -26467,7 +26467,7 @@ msgstr "--not"
 
 #. type: Labeled list
 #: en/git-grep.txt:284
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "( ... )"
 msgstr ""
 
@@ -26497,7 +26497,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-grep.txt:300
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<tree>..."
 msgstr ""
 
@@ -26815,7 +26815,7 @@ msgstr "Computa ID de objeto y, opcionalmente, crea un blob de un archivo"
 
 #. type: Plain text
 #: en/git-hash-object.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git hash-object' [-t <type>] [-w] [--path=<file>|--no-filters] [--stdin [--literally]] [--] <file>...\n"
 "'git hash-object' [-t <type>] [-w] --stdin-paths [--no-filters]\n"
@@ -26945,7 +26945,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-help.txt:38
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Note that `git --help ...` is identical to `git help ...` because the former is internally converted into the latter."
 msgstr ""
 
@@ -27395,7 +27395,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:102
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tAuthType Basic\n"
 "\tAuthName \"Git Access\"\n"
@@ -27413,7 +27413,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:115
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "<LocationMatch \"^/git/.*/git-receive-pack$\">\n"
 "\tAuthType Basic\n"
@@ -27437,7 +27437,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:136
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "<Location /git/private>\n"
 "\tAuthType Basic\n"
@@ -27587,7 +27587,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:231
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "auth.require = (\n"
 "\t\"/\" => (\n"
@@ -27790,7 +27790,7 @@ msgstr "Empuja objetos por HTTP/DAV a otro repositorio"
 
 #. type: Plain text
 #: en/git-http-push.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git http-push' [--all] [--dry-run] [--force] [--verbose] <url> <ref> [<ref>...]\n"
 msgstr ""
 
@@ -27859,7 +27859,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-http-push.txt:54 en/git-send-pack.txt:98
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<ref>..."
 msgstr ""
 
@@ -28724,7 +28724,7 @@ msgstr "Agregar o analizar información estructurada en mensajes de commit"
 
 #. type: Plain text
 #: en/git-interpret-trailers.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git interpret-trailers' [<options>] [(--trailer <token>[(=|:)<value>])...] [<file>...]\n"
 "'git interpret-trailers' [<options>] [--parse] [<file>...]\n"
@@ -29394,7 +29394,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-log.txt:13
-#, fuzzy, no-wrap, priority:260
+#, fuzzy, ignore-ellipsis, no-wrap, priority:260
 msgid "'git log' [<options>] [<revision range>] [[--] <path>...]\n"
 msgstr "git log [<opciones>] [<rango-de-revisión>] [[--] <ruta>...]"
 
@@ -29490,7 +29490,7 @@ msgstr "--full-diff"
 
 #. type: Plain text
 #: en/git-log.txt:63
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Without this flag, `git log -p <path>...` shows commits that touch the specified paths, and diffs about the same specified paths.  With this, the full diff is shown for commits that touch the specified paths; this means that \"<path>...\" limits only commits, and doesn't limit diff for those commits."
 msgstr ""
 
@@ -29544,7 +29544,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-log.txt:93 en/git-shortlog.txt:72
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "[--] <path>..."
 msgstr ""
 
@@ -29820,7 +29820,7 @@ msgstr "Muestra información sobre archivos in el índice y el árbol de trabajo
 
 #. type: Plain text
 #: en/git-ls-files.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-files' [-z] [-t] [-v] [-f]\n"
 "\t\t(--[cached|deleted|others|ignored|stage|unmerged|killed|modified])*\n"
@@ -30301,7 +30301,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-remote.txt:15
-#, fuzzy, no-wrap, priority:100
+#, fuzzy, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-remote' [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
 "\t      [-q | --quiet] [--exit-code] [--get-url] [--sort=<key>]\n"
@@ -30409,7 +30409,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-remote.txt:91
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When unspecified, all references, after filtering done with --heads and --tags, are shown.  When <refs>... are specified, only references matching the given patterns are displayed."
 msgstr ""
 
@@ -30454,7 +30454,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-tree' [-d] [-r] [-t] [-l] [-z]\n"
 "\t    [--name-only] [--name-status] [--full-name] [--full-tree] [--abbrev[=<n>]]\n"
@@ -30535,7 +30535,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-ls-tree.txt:76
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<path>...]"
 msgstr ""
 
@@ -30745,7 +30745,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mailsplit.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git mailsplit' [-b] [-f<nn>] [-d<prec>] [--keep-cr] [--mboxrd]\n"
 "\t\t-o<directory> [--] [(<mbox>|<Maildir>)...]\n"
@@ -30867,7 +30867,7 @@ msgstr "Encuentra un ancestro común bueno para una posible fusión"
 
 #. type: Plain text
 #: en/git-merge-base.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git merge-base' [-a|--all] <commit> <commit>...\n"
 "'git merge-base' [-a|--all] --octopus <commit>...\n"
@@ -31064,7 +31064,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:139
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tA=$(git rev-parse --verify A)\n"
 "\tif test \"$A\" = \"$(git merge-base A B)\"\n"
@@ -31081,7 +31081,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:146
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tif git merge-base --is-ancestor A B\n"
 "\tthen\n"
@@ -31568,7 +31568,7 @@ msgstr "Ejecuta las herramientas de fusión de resolución de conflictos para re
 
 #. type: Plain text
 #: en/git-mergetool.txt:12
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git mergetool' [--tool=<tool>] [-y | --[no-]prompt] [<file>...]\n"
 msgstr ""
 
@@ -31730,7 +31730,7 @@ msgstr "Junta dos o mas historiales de desarrollo juntos"
 
 #. type: Plain text
 #: en/git-merge.txt:17
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git merge' [-n] [--stat] [--no-commit] [--squash] [--[no-]edit]\n"
 "\t[-s <strategy>] [-X <strategy-option>] [-S[<keyid>]]\n"
@@ -32323,7 +32323,7 @@ msgstr "Mueve o cambia el nombre a archivos, directorios o enlaces simbólicos"
 
 #. type: Plain text
 #: en/git-mv.txt:13
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git mv' <options>... <args>...\n"
 msgstr ""
 
@@ -32335,7 +32335,7 @@ msgstr "Mueve o cambia el nombre a archivos, directorios o enlaces simbólicos"
 
 #. type: Plain text
 #: en/git-mv.txt:20
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 " git mv [-v] [-f] [-n] [-k] <source> <destination>\n"
 " git mv [-v] [-f] [-n] [-k] <source> ... <destination directory>\n"
@@ -32403,7 +32403,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-name-rev.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git name-rev' [--tags] [--refs=<pattern>]\n"
 "\t       ( --all | --stdin | <commit-ish>... )\n"
@@ -32521,7 +32521,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-notes.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git notes' [list [<object>]]\n"
 "'git notes' add [-f] [--allow-empty] [-F <file> | -m <msg> | (-c | -C) <object>] [<object>]\n"
@@ -32857,7 +32857,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-notes.txt:229
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Commit notes are blobs containing extra information about an object (usually information to supplement a commit's message).  These blobs are taken from notes refs.  A notes ref is usually a branch which contains \"files\" whose paths are the object names for the objects they describe, with some directory separators included for performance reasons footnote:[Permitted pathnames have the form 'ab'`/`'cd'`/`'ef'`/`'...'`/`'abcdef...': a sequence of directory names of two hexadecimal digits each followed by a filename with the rest of the object ID.]."
 msgstr ""
 
@@ -32923,7 +32923,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-notes.txt:288
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git notes add -m 'Tested-by: Johannes Sixt <j6t@kdbg.org>' 72a144e2\n"
 "$ git show -s 72a144e\n"
@@ -33142,7 +33142,7 @@ msgstr "Importar desde y enviar a repositorios Perforce"
 
 #. type: Plain text
 #: en/git-p4.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git p4 clone' [<sync options>] [<clone options>] <p4 depot path>...\n"
 "'git p4 sync' [<sync options>] [<p4 depot path>...]\n"
@@ -33975,7 +33975,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-p4.txt:445
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The full syntax for a p4 view is documented in 'p4 help views'.  'git p4' knows only a subset of the view syntax.  It understands multi-line mappings, overlays with '+', exclusions with '-' and double-quotes around whitespace.  Of the possible wildcards, 'git p4' only handles '...', and only when it is at the end of the path.  'git p4' will complain if it encounters an unhandled wildcard."
 msgstr ""
 
@@ -34017,7 +34017,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-p4.txt:475
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "//depot/main/...\n"
 "//depot/branch1/...\n"
@@ -34031,7 +34031,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-p4.txt:480
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "//depot/main/... //depot/branch1/...\n"
 msgstr ""
 
@@ -35148,7 +35148,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-pack-redundant.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git pack-redundant' [ --verbose ] [ --alt-odb ] < --all | .pack filename ... >\n"
 msgstr ""
 
@@ -35448,7 +35448,7 @@ msgstr "Limpia todos los objetos no alcanzables de la base de datos de objetos"
 
 #. type: Plain text
 #: en/git-prune.txt:13
-#, fuzzy, no-wrap, priority:100
+#, fuzzy, ignore-ellipsis, no-wrap, priority:100
 msgid "'git prune' [-n] [-v] [--progress] [--expire <time>] [--] [<head>...]\n"
 msgstr "git prune [-n] [-v] [--progress] [--expire <tiempo>] [--] [<head>...]"
 
@@ -35502,7 +35502,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-prune.txt:54
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<head>..."
 msgstr ""
 
@@ -35556,7 +35556,7 @@ msgstr "Realiza un fetch e integra con otro repositorio o rama local"
 
 #. type: Plain text
 #: en/git-pull.txt:13
-#, fuzzy, no-wrap, priority:220
+#, fuzzy, ignore-ellipsis, no-wrap, priority:220
 msgid "'git pull' [<options>] [<repository> [<refspec>...]]\n"
 msgstr "git pull [<opciones>] [<repositorio> [<especificación-de-referencia>...]]"
 
@@ -35904,7 +35904,7 @@ msgstr "Actualiza referencias remotas junto con sus objetos asociados"
 
 #. type: Plain text
 #: en/git-push.txt:18
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git push' [--all | --mirror | --tags] [--follow-tags] [--atomic] [-n | --dry-run] [--receive-pack=<git-receive-pack>]\n"
 "\t   [--repo=<repository>] [-f | --force] [-d | --delete] [--prune] [-v | --verbose]\n"
@@ -35934,7 +35934,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:39
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "When the command line does not specify what to push with `<refspec>...` arguments or `--all`, `--mirror`, `--tags` options, the command finds the default `<refspec>` by consulting `remote.*.push` configuration, and if it is not found, honors `push.default` configuration to decide what to push (See linkgit:git-config[1] for the meaning of `push.default`)."
 msgstr ""
 
@@ -35958,7 +35958,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:56
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "<refspec>..."
 msgstr ""
 
@@ -36318,7 +36318,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:343
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "Note that `--force` applies to all the refs that are pushed, hence using it with `push.default` set to `matching` or with multiple push destinations configured with `remote.*.push` may overwrite refs other than the current branch (including local refs that are strictly behind their remote counterpart).  To force a push to only one branch, use a `+` in front of the refspec to push (e.g `git push origin +master` to force a push to the `master` branch). See the `<refspec>...` section above for details."
 msgstr ""
 
@@ -36450,7 +36450,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:445
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "For a successfully pushed ref, the summary shows the old and new values of the ref in a form suitable for using as an argument to `git log` (this is `<old>..<new>` in most cases, and `<old>...<new>` for forced non-fast-forward updates)."
 msgstr ""
 
@@ -36711,7 +36711,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:616
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "See the section describing `<refspec>...` above for a discussion of the matching semantics."
 msgstr ""
 
@@ -37412,7 +37412,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-read-tree.txt:357
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git fetch git://.... linus\n"
 "$ LT=`git rev-parse FETCH_HEAD`\n"
@@ -37466,7 +37466,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-read-tree.txt:405
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "'git read-tree' and other merge-based commands ('git merge', 'git checkout'...) can help maintaining the skip-worktree bitmap and working directory update. `$GIT_DIR/info/sparse-checkout` is used to define the skip-worktree reference bitmap. When 'git read-tree' needs to update the working directory, it resets the skip-worktree bit in the index based on this file, which uses the same syntax as .gitignore files.  If an entry matches a pattern in this file, skip-worktree will not be set on that entry. Otherwise, skip-worktree will be set."
 msgstr ""
 
@@ -37846,7 +37846,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:219
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "As a special case, you may use \"A\\...B\" as a shortcut for the merge base of A and B if there is exactly one merge base. You can leave out at most one of A and B, in which case it defaults to HEAD."
 msgstr ""
 
@@ -38110,7 +38110,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:430
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "It is currently only possible to recreate the merge commits using the `recursive` merge strategy; Different merge strategies can be used only via explicit `exec git merge -s <strategy> [...]` commands."
 msgstr ""
 
@@ -38164,7 +38164,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:457
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "\tgit rebase -i --exec \"cmd1 && cmd2 && ...\"\n"
 msgstr ""
 
@@ -38176,7 +38176,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:461
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "\tgit rebase -i --exec \"cmd1\" --exec \"cmd2\" --exec ...\n"
 msgstr ""
 
@@ -38212,7 +38212,7 @@ msgstr "--no-autosquash"
 
 #. type: Plain text
 #: en/git-rebase.txt:495
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When the commit log message begins with \"squash! ...\" (or \"fixup! ...\"), and there is already a commit in the todo list that matches the same `...`, automatically modify the todo list of rebase -i so that the commit marked for squashing comes right after the commit to be modified, and change the action of the moved commit from `pick` to `squash` (or `fixup`).  A commit matches the `...` if the commit subject matches, or if the `...` refers to the commit's hash. As a fall-back, partial matches of the commit subject work, too.  The recommended way to create fixup/squash commits is by using the `--fixup`/`--squash` options of linkgit:git-commit[1]."
 msgstr ""
 
@@ -38539,7 +38539,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:636
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "pick deadbee The oneline of this commit\n"
 "pick fa1afe1 The oneline of the next commit\n"
@@ -38643,7 +38643,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:710
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "pick deadbee Implement feature XXX\n"
 "fixup f1a5c00 Fix to feature XXX\n"
@@ -38662,7 +38662,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:720
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The \"exec\" command launches the command in a shell (the one specified in `$SHELL`, or the default shell if `$SHELL` is not set), so you can use shell features (like \"cd\", \">\", \";\" ...). The command is run from the root of the working tree."
 msgstr ""
 
@@ -38806,7 +38806,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:815
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "    o---o---o---o---o---o---o---o  master\n"
 "\t \\\t\t\t \\\n"
@@ -39604,7 +39604,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reflog.txt:27
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git reflog' ['show'] [log-options] [<ref>]\n"
 "'git reflog expire' [--expire=<time>] [--expire-unreachable=<time>]\n"
@@ -39791,7 +39791,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-remote-ext.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git remote add <nick> \"ext::<command>[ <arguments>...]\"\n"
 msgstr ""
 
@@ -39929,7 +39929,7 @@ msgstr "GIT_EXT_SERVICE"
 
 #. type: Plain text
 #: en/git-remote-ext.txt:70
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Set to long name (git-upload-pack, etc...) of service helper needs to invoke."
 msgstr ""
 
@@ -39941,7 +39941,7 @@ msgstr "GIT_EXT_SERVICE_NOPREFIX"
 
 #. type: Plain text
 #: en/git-remote-ext.txt:74
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Set to long name (upload-pack, etc...) of service helper needs to invoke."
 msgstr ""
 
@@ -40121,7 +40121,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-remote.txt:25
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git remote' [-v | --verbose]\n"
 "'git remote add' [-t <branch>] [-m <master>] [-f] [--[no-]tags] [--mirror=<fetch|push>] <name> <url>\n"
@@ -40440,7 +40440,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-remote.txt:235
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "$ git remote\n"
 "origin\n"
@@ -40684,7 +40684,7 @@ msgstr "Crea, lista, borra referencias para reemplazar objetos"
 
 #. type: Plain text
 #: en/git-replace.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git replace' [-f] <object> <replacement>\n"
 "'git replace' [-f] --edit <object>\n"
@@ -40804,13 +40804,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-replace.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--graft <commit> [<parent>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/git-replace.txt:93
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Create a graft commit. A new commit is created with the same content as <commit> except that its parents will be [<parent>...] instead of <commit>'s parents. A replacement ref is then created to replace <commit> with the newly created commit. Use `--convert-graft-file` to convert a `$GIT_DIR/info/grafts` file and use replace refs instead."
 msgstr ""
 
@@ -41232,7 +41232,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rerere.txt:121
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git switch topic\n"
 "\t$ git merge master\n"
@@ -41264,7 +41264,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rerere.txt:145
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git switch topic\n"
 "\t$ git merge master\n"
@@ -41369,7 +41369,7 @@ msgstr "Reinicia el HEAD actual a un estado especifico"
 
 #. type: Plain text
 #: en/git-reset.txt:14
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git reset' [-q] [<tree-ish>] [--] <paths>...\n"
 "'git reset' (--patch | -p) [<tree-ish>] [--] [<paths>...]\n"
@@ -41384,7 +41384,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-reset.txt:22
-#, fuzzy, no-wrap, priority:280
+#, fuzzy, ignore-ellipsis, no-wrap, priority:280
 msgid "'git reset' [-q] [<tree-ish>] [--] <paths>..."
 msgstr "git reset [-q] [<árbol-ismo>] [--] <rutas>..."
 
@@ -41396,7 +41396,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reset.txt:30
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "This means that `git reset <paths>` is the opposite of `git add <paths>`. This command is equivalent to `git restore [--source=<tree-ish>] --staged <paths>...`."
 msgstr ""
 
@@ -41408,7 +41408,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-reset.txt:38
-#, fuzzy, no-wrap, priority:280
+#, fuzzy, ignore-ellipsis, no-wrap, priority:280
 msgid "'git reset' (--patch | -p) [<tree-ish>] [--] [<paths>...]"
 msgstr "git reset --patch [<árbol-ismo>] [--] [<rutas>...]"
 
@@ -41563,7 +41563,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:138
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git commit ...\n"
 "$ git reset --soft HEAD^      <1>\n"
@@ -41636,7 +41636,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:170
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git commit ...\n"
 "$ git reset --hard HEAD~3   <1>\n"
@@ -41656,7 +41656,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:190
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git pull                         <1>\n"
 "Auto-merging nitfol\n"
@@ -41701,7 +41701,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:215
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git pull                         <1>\n"
 "Auto-merging nitfol\n"
@@ -41827,7 +41827,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:289
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git tag start\n"
 "$ git switch -c branch1\n"
@@ -41870,7 +41870,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:317
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git reset -N HEAD^                        <1>\n"
 "$ git add -p                                <2>\n"
@@ -42096,7 +42096,7 @@ msgstr "Cambia ramas o restaura los archivos de tu árbol de trabajo"
 
 #. type: Plain text
 #: en/git-restore.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git restore' [<options>] [--source=<tree>] [--staged] [--worktree] <pathspec>...\n"
 "'git restore' (-p|--patch) [<options>] [--source=<tree>] [--staged] [--worktree] [<pathspec>...]\n"
@@ -42349,7 +42349,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-revert.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git revert' [--[no-]edit] [-n] [-m parent-number] [-s] [-S[<keyid>]] <commit>...\n"
 "'git revert' (--continue | --skip | --abort | --quit)\n"
@@ -42453,7 +42453,7 @@ msgstr "Lista objetos commit en orden cronológico inverso"
 
 #. type: Plain text
 #: en/git-rev-list.txt:65
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git rev-list' [ --max-count=<number> ]\n"
 "\t     [ --skip=<number> ]\n"
@@ -42556,13 +42556,13 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-list.txt:102
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Another special notation is \"'<commit1>'...'<commit2>'\" which is useful for merges.  The resulting set of commits is the symmetric difference between the two operands.  The following two commands are equivalent:"
 msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-list.txt:106
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git rev-list A B --not $(git merge-base --all A B)\n"
 "\t$ git rev-list A...B\n"
@@ -42588,7 +42588,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-parse.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git rev-parse' [<options>] <args>...\n"
 msgstr ""
 
@@ -43072,7 +43072,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-parse.txt:253
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Resolve \"$GIT_DIR/<path>\" and takes other path relocation variables such as $GIT_OBJECT_DIRECTORY, $GIT_INDEX_FILE... into account. For example, if $GIT_OBJECT_DIRECTORY is set to /foo/bar then \"git rev-parse --git-path objects/abc\" returns /foo/bar/abc."
 msgstr ""
 
@@ -43180,7 +43180,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:290
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<args>..."
 msgstr ""
 
@@ -43312,7 +43312,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:364
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "OPTS_SPEC=\"\\\n"
 "some-command [<options>] <args>...\n"
@@ -43370,7 +43370,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:389
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "usage: some-command [<options>] <args>...\n"
 msgstr ""
 
@@ -43382,7 +43382,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:397
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "    -h, --help            show the help\n"
 "    --foo                 some nifty option --foo\n"
@@ -43393,7 +43393,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:400
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "An option group Header\n"
 "    -C[...]               option C with an optional argument\n"
@@ -43498,7 +43498,7 @@ msgstr "Borra archivos del árbol de trabajo y del índice"
 
 #. type: Plain text
 #: en/git-rm.txt:12
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git rm' [-f | --force] [-n] [-r] [--cached] [--ignore-unmatch] [--quiet] [--] <file>...\n"
 msgstr ""
 
@@ -43726,7 +43726,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-email.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git send-email' [<options>] <file|directory|rev-list options>...\n"
 "'git send-email' --dump-aliases\n"
@@ -43794,7 +43794,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:53
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--bcc=<address>,..."
 msgstr ""
 
@@ -43812,7 +43812,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:59
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--cc=<address>,..."
 msgstr ""
 
@@ -43896,7 +43896,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-email.txt:110
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "  [PATCH 0/2] Here is what I did...\n"
 "    [PATCH 1/2] Clean up and tests\n"
@@ -43927,7 +43927,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:119
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--to=<address>,..."
 msgstr ""
 
@@ -44059,7 +44059,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-send-email.txt:188
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "$ git send-email --smtp-auth=\"PLAIN LOGIN GSSAPI\" ...\n"
 msgstr ""
 
@@ -44755,7 +44755,7 @@ msgstr "Empujar objetos por protocolo Git a otro repositorio"
 
 #. type: Plain text
 #: en/git-send-pack.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git send-pack' [--all] [--dry-run] [--force] [--receive-pack=<git-receive-pack>]\n"
 "\t\t[--verbose] [--thin] [--atomic]\n"
@@ -45128,7 +45128,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-shortlog.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "'git shortlog' [<options>] [<revision range>] [[--] <path>...]\n"
 "git log --pretty=short | 'git shortlog' [<options>]\n"
@@ -45256,7 +45256,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show-branch.txt:17
-#, fuzzy, no-wrap, priority:100
+#, fuzzy, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git show-branch' [-a|--all] [-r|--remotes] [--topo-order | --date-order]\n"
 "\t\t[--current] [--color[=<when>] | --no-color] [--sparse]\n"
@@ -45621,7 +45621,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show-ref.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git show-ref' [-q|--quiet] [--verify] [--head] [-d|--dereference]\n"
 "\t     [-s|--hash[=<n>]] [--abbrev[=<n>]] [--tags]\n"
@@ -45769,7 +45769,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-show-ref.txt:111
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git show-ref --head --dereference\n"
 "832e76a9899f560a90ffd62ae2ce83bbeff58f54 HEAD\n"
@@ -45790,7 +45790,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-show-ref.txt:121
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git show-ref --heads --hash\n"
 "2e3ba0114a1f52b47df29743d6915d056be13278\n"
@@ -45911,7 +45911,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show.txt:13
-#, fuzzy, no-wrap, priority:260
+#, fuzzy, ignore-ellipsis, no-wrap, priority:260
 msgid "'git show' [<options>] [<object>...]\n"
 msgstr "git show [<opciones>] <objeto>..."
 
@@ -45959,7 +45959,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-show.txt:37
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "<object>..."
 msgstr ""
 
@@ -46217,7 +46217,7 @@ msgstr "Agrega contenidos de un archivo al área de staging"
 
 #. type: Plain text
 #: en/git-stage.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git stage' args...\n"
 msgstr ""
 
@@ -46241,7 +46241,7 @@ msgstr "Poner en un stash los cambios en un directorio de trabajo sucio de todas
 
 #. type: Plain text
 #: en/git-stash.txt:22
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git stash' list [<options>]\n"
 "'git stash' show [<options>] [<stash>]\n"
@@ -46264,7 +46264,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stash.txt:38
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "The modifications stashed away by this command can be listed with `git stash list`, inspected with `git stash show`, and restored (potentially on top of a different commit) with `git stash apply`.  Calling `git stash` without any arguments is equivalent to `git stash push`.  A stash is by default listed as \"WIP on 'branchname' ...\", but you can give a more descriptive message on the command line when you create one."
 msgstr ""
 
@@ -46276,7 +46276,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-stash.txt:49
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "push [-p|--patch] [-k|--[no-]keep-index] [-u|--include-untracked] [-a|--all] [-q|--quiet] [-m|--message <message>] [--] [<pathspec>...]"
 msgstr ""
 
@@ -46348,7 +46348,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:104
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "stash@{0}: WIP on submit: 6ebd0e2... Update git-stash documentation\n"
 "stash@{1}: On master: 9cc0589... Add git-stash\n"
@@ -46521,7 +46521,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:227
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git pull\n"
 " ...\n"
@@ -46539,7 +46539,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:246
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git switch -c my_wip\n"
@@ -46560,7 +46560,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:257
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git stash\n"
@@ -46584,7 +46584,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:275
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git add --patch foo            # add just first part to the index\n"
@@ -46638,7 +46638,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-status.txt:13
-#, fuzzy, no-wrap, priority:280
+#, fuzzy, ignore-ellipsis, no-wrap, priority:280
 msgid "'git status' [<options>...] [--] [<pathspec>...]\n"
 msgstr "git status [<opciones>] [--] <especificación-de-ruta>..."
 
@@ -47115,7 +47115,7 @@ msgstr ""
 
 #. type: delimited block .
 #: en/git-status.txt:345
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "Field       Meaning\n"
 "--------------------------------------------------------\n"
@@ -47437,7 +47437,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-submodule.txt:23
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git submodule' [--quiet] [--cached]\n"
 "'git submodule' [--quiet] add [<options>] [--] <repository> [<path>]\n"
@@ -47508,7 +47508,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:74
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "status [--cached] [--recursive] [--] [<path>...]"
 msgstr ""
 
@@ -47532,7 +47532,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:91
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "init [--] [<path>...]"
 msgstr ""
 
@@ -47562,7 +47562,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:114
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "deinit [-f|--force] (--all|[--] <path>...)"
 msgstr ""
 
@@ -47592,7 +47592,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:132
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "update [--init] [--remote] [-N|--no-fetch] [--[no-]recommend-shallow] [-f|--force] [--checkout|--rebase|--merge] [--reference <repository>] [--depth <depth>] [--recursive] [--jobs <n>] [--] [<path>...]"
 msgstr ""
 
@@ -47716,7 +47716,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:182
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "summary [--cached|--files] [(-n|--summary-limit) <n>] [commit] [--] [<path>...]"
 msgstr ""
 
@@ -47758,7 +47758,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:224
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "sync [--recursive] [--] [<path>...]"
 msgstr ""
 
@@ -48284,7 +48284,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:127
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Fetch unfetched revisions from the Subversion remote we are tracking.  The name of the [svn-remote \"...\"] section in the $GIT_DIR/config file may be specified as an optional command-line argument."
 msgstr ""
 
@@ -48730,7 +48730,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:366
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "is supported, non-numeric args are not: HEAD, NEXT, BASE, PREV, etc ..."
 msgstr ""
 
@@ -49631,7 +49631,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-svn.txt:876
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "# Clone a repo (like git clone):\n"
 "\tgit svn clone http://svn.example.com/project/trunk\n"
@@ -49684,7 +49684,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-svn.txt:924
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "# Do the initial import on a server\n"
 "\tssh server \"cd /pub && git svn clone http://svn.example.com/project [options...]\"\n"
@@ -50395,7 +50395,7 @@ msgstr "Crea, lista, borra o verifica un tag de objeto firmado con GPG"
 
 #. type: Plain text
 #: en/git-tag.txt:20
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git tag' [-a | -s | -u <keyid>] [-f] [-m <msg> | -F <file>] [-e]\n"
 "\t<tagname> [<commit> | <object>]\n"
@@ -50541,7 +50541,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-tag.txt:103
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "List tags. With optional `<pattern>...`, e.g. `git tag --list 'v-*'`, list only the tags that match the pattern(s)."
 msgstr ""
 
@@ -50831,13 +50831,13 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:319
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "\tgit://git..../proj.git master\n"
 msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:321
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "to get the following updates...\n"
 msgstr ""
 
@@ -50849,7 +50849,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:327
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "$ git pull git://git..../proj.git master\n"
 msgstr ""
 
@@ -50974,7 +50974,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git.txt:55
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Other options are available to control how the manual page is displayed. See linkgit:git-help[1] for more information, because `git --help ...` is converted internally into `git help ...`."
 msgstr ""
 
@@ -51018,7 +51018,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git.txt:82
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Note that omitting the `=` in `git -c foo.bar ...` is allowed and sets `foo.bar` to the boolean true value (just like `[foo]bar` would in a config file). Including the equals but with an empty value (like `git -c foo.bar= ...`) sets `foo.bar` to the empty string which `git config --type=bool` will convert to `false`."
 msgstr ""
 
@@ -51222,7 +51222,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:169
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--list-cmds=group[,group...]"
 msgstr ""
 
@@ -51725,7 +51725,7 @@ msgstr "`GIT_COMMON_DIR`"
 
 #. type: Plain text
 #: en/git.txt:481
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If this variable is set to a path, non-worktree files that are normally in $GIT_DIR will be taken from this path instead. Worktree-specific files such as HEAD or index are taken from $GIT_DIR. See linkgit:gitrepository-layout[5] and linkgit:git-worktree[1] for details. This variable has lower precedence than other path variables such as GIT_INDEX_FILE, GIT_OBJECT_DIRECTORY..."
 msgstr ""
 
@@ -52196,10 +52196,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:685
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2`"
-msgstr "`GIT_TRACE`"
+msgstr "`GIT_TRACE2`"
 
 #. type: Plain text
 #: en/git.txt:689
@@ -52227,10 +52226,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:720
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE_SETUP`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2_EVENT`"
-msgstr "`GIT_TRACE_SETUP`"
+msgstr "`GIT_TRACE2_EVENT`"
 
 #. type: Plain text
 #: en/git.txt:725
@@ -52240,10 +52238,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:726
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE_PERFORMANCE`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2_PERF`"
-msgstr "`GIT_TRACE_PERFORMANCE`"
+msgstr "`GIT_TRACE2_PERF`"
 
 #. type: Plain text
 #: en/git.txt:732
@@ -52682,7 +52679,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-update-index.txt:29
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git update-index'\n"
 "\t     [--add] [--remove | --force-remove] [--replace]\n"
@@ -53242,7 +53239,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-update-index.txt:348
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The command looks at `core.ignorestat` configuration variable.  When this is true, paths updated with `git update-index paths...` and paths updated with other Git commands that update both index and working tree (e.g. 'git apply --index', 'git checkout-index -u', and 'git read-tree -u') are automatically marked as \"assume unchanged\".  Note that \"assume unchanged\" bit is *not* set if `git update-index --refresh` finds the working tree file matches the index (use `git update-index --really-refresh` if you want to mark them as \"assume unchanged\")."
 msgstr ""
 
@@ -54111,7 +54108,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-commit.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-commit' <commit>...\n"
 msgstr ""
 
@@ -54153,7 +54150,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-pack.txt:13
-#, fuzzy, no-wrap, priority:100
+#, fuzzy, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-pack' [-v|--verbose] [-s|--stat-only] [--] <pack>.idx ...\n"
 msgstr "git verify-pack [-v | --verbose] [-s | --stat-only] <paquete>..."
 
@@ -54165,7 +54162,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-verify-pack.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<pack>.idx ..."
 msgstr ""
 
@@ -54243,7 +54240,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-tag.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-tag' [--format=<format>] <tag>...\n"
 msgstr ""
 
@@ -54261,7 +54258,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-verify-tag.txt:27
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<tag>..."
 msgstr ""
 
@@ -54285,7 +54282,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-web--browse.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git web{litdd}browse' [<options>] <url|file>...\n"
 msgstr ""
 
@@ -54559,7 +54556,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-whatchanged.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git whatchanged' <option>...\n"
 msgstr ""
 
@@ -55089,7 +55086,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-worktree.txt:372
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git worktree add -b emergency-fix ../temp master\n"
 "$ pushd ../temp\n"
@@ -56290,7 +56287,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/pretty-formats.txt:115
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'%C(...)'"
 msgstr ""
 
@@ -56302,7 +56299,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/pretty-formats.txt:129
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "\"CONFIGURATION FILE\" section of linkgit:git-config[1].  By default, colors are shown only when enabled for log output (by `color.diff`, `color.ui`, or `--color`, and respecting the `auto` settings of the former if we are going to a terminal). `%C(auto,...)` is accepted as a historical synonym for the default (e.g., `%C(auto,red)`). Specifying `%C(always,...)` will show the colors even when color is not otherwise enabled (though consider just using `--color=always` to enable color for the whole output, including this format and anything else git might color).  `auto` alone (i.e. `%C(auto)`) will turn on auto coloring on the next placeholders until the color is switched again."
 msgstr ""
 
@@ -57393,7 +57390,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/pull-fetch-param.txt:45
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "Whether that update is allowed without `--force` depends on the ref namespace it's being fetched to, the type of object being fetched, and whether the update is considered to be a fast-forward. Generally, the same rules apply for fetching as when pushing, see the `<refspec>...` section of linkgit:git-push[1] for what those are. Exceptions to those rules particular to 'git fetch' are noted below."
 msgstr ""
 
@@ -57864,13 +57861,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/revisions.txt:280
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "The '...' (three-dot) Symmetric Difference Notation"
 msgstr ""
 
 #. type: Plain text
 #: en/revisions.txt:286
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "A similar notation 'r1\\...r2' is called symmetric difference of 'r1' and 'r2' and is defined as 'r1 r2 --not $(git merge-base --all r1 r2)'.  It is the set of commits that are reachable from either one of 'r1' (left side) or 'r2' (right side) but not from both."
 msgstr ""
 
@@ -57960,7 +57957,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/revisions.txt:331
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'<rev1>\\...<rev2>'"
 msgstr ""
 
@@ -58014,7 +58011,7 @@ msgstr ""
 
 #. type: delimited block .
 #: en/revisions.txt:377
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "   Args   Expanded arguments    Selected commits\n"
 "   D                            G H D\n"
@@ -58504,7 +58501,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:256
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "For example, `--cherry-pick --right-only A...B` omits those commits from `B` which are in `A` or are patch-equivalent to a commit in `A`. In other words, this lists the `+` commits from `git cherry A B`.  More precisely, `--cherry-pick --right-only --no-merges` gives the exact list."
 msgstr ""
 
@@ -58516,7 +58513,7 @@ msgstr "--cherry"
 
 #. type: Plain text
 #: en/rev-list-options.txt:263
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "A synonym for `--right-only --cherry-mark --no-merges`; useful to limit the output to the commits on our side and mark those that have been applied to the other side of a forked history with `git log --cherry upstream...mybranch`, similar to `git cherry upstream mybranch`."
 msgstr ""
 
@@ -58528,7 +58525,7 @@ msgstr "--walk-reflogs"
 
 #. type: Plain text
 #: en/rev-list-options.txt:271
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Instead of walking the commit ancestry chain, walk reflog entries from the most recent one to older ones.  When this option is used you cannot specify commits to exclude (that is, '{caret}commit', 'commit1..commit2', and 'commit1\\...commit2' notations cannot be used)."
 msgstr ""
 
@@ -59521,7 +59518,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:875
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "`--date=format:...` feeds the format `...` to your system `strftime`, except for %z and %Z, which are handled internally.  Use `--date=format:%c` to show the date in your system locale's preferred format.  See the `strftime` manual for a complete list of format placeholders. When using `-local`, the correct syntax is `--date=format-local:...`."
 msgstr ""
 
@@ -59557,7 +59554,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:892
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Print also the parents of the commit (in the form \"commit parent...\").  Also enables parent rewriting, see 'History Simplification' above."
 msgstr ""
 
@@ -59569,7 +59566,7 @@ msgstr "--children"
 
 #. type: Plain text
 #: en/rev-list-options.txt:896
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Print also the children of the commit (in the form \"commit child...\").  Also enables parent rewriting, see 'History Simplification' above."
 msgstr ""
 
@@ -59622,13 +59619,13 @@ msgstr ""
 
 #. type: delimited block -
 #: en/rev-list-options.txt:922
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "\t$ git rev-list --left-right --boundary --pretty=oneline A...B\n"
 msgstr ""
 
 #. type: delimited block -
 #: en/rev-list-options.txt:929
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "\t>bbbbbbb... 3rd on b\n"
 "\t>bbbbbbb... 2nd on b\n"

--- a/po/documentation.fr.po
+++ b/po/documentation.fr.po
@@ -2437,7 +2437,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/config.txt:256
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The value for many variables that specify various sizes can be suffixed with `k`, `M`,... to mean \"scale the number by 1024\", \"by 1024x1024\", etc."
 msgstr ""
 
@@ -2828,7 +2828,7 @@ msgstr "compare l'<arbre-esque> et l'index."
 
 #. type: Labeled list
 #: en/diff-format.txt:16
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "git-diff-tree [-r] <tree-ish-1> <tree-ish-2> [<pattern>...]"
 msgstr "git-diff-tree [-r] <arbre-esque-1> <arbre-esque-2> [<motif>...]"
 
@@ -2840,7 +2840,7 @@ msgstr "Compare les arbres nommés par les deux arguments."
 
 #. type: Labeled list
 #: en/diff-format.txt:19
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "git-diff-files [<pattern>...]"
 msgstr "git-diff-files [<motif>...]"
 
@@ -3594,7 +3594,7 @@ msgstr "Il y a (nombre de parents + 1) caractères `@` dans l'entête de section
 
 #. type: Plain text
 #: en/diff-generate-patch.txt:179
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Unlike the traditional 'unified' diff format, which shows two files A and B with a single column that has `-` (minus -- appears in A but removed in B), `+` (plus -- missing in A but added to B), or `\" \"` (space -- unchanged) prefix, this format compares two or more files file1, file2,... with one file X, and shows how X differs from each of fileN.  One column for each of fileN is prepended to the output line to note how X's line is different from it."
 msgstr "À la différence du format diff 'unifié' traditionnel qui montre deux fichiers A et B avec une seule colonne qui a un préfixe `-` (moins -- apparaît dans A mais supprimé dans B), `+` (plus -- manquant dans A mais ajouté dans B), ou `\" \"` (espace -- non modifié), ce format compare un fichier ou plus fichier1, fichier2,… avec un fichier X, et affiche comment X diffère de chaque fichierN. Une colonne pour chaque fichierN est insérée dans la sortie pour montrer comment la ligne de X est différente de la ligne correspondante de celui-ci."
 
@@ -3927,7 +3927,7 @@ msgstr "--stat[=<largeur>[,<largeur-de-nom>[,<nombre>]]]"
 
 #. type: Plain text
 #: en/diff-options.txt:137
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Generate a diffstat. By default, as much space as necessary will be used for the filename part, and the rest for the graph part. Maximum width defaults to terminal width, or 80 columns if not connected to a terminal, and can be overridden by `<width>`. The width of the filename part can be limited by giving another width `<name-width>` after a comma. The width of the graph part can be limited by using `--stat-graph-width=<width>` (affects all commands generating a stat graph) or by setting `diff.statGraphWidth=<width>` (does not affect `git format-patch`).  By giving a third parameter `<count>`, you can limit the output to the first `<count>` lines, followed by `...` if there are more."
 msgstr "Génerer un diffstat. Par défaut, autant d'espace que nécessaire sera utilisé pour la partie du nom de fichier et le reste pour la partie de graphe. La largeur maximum est par défaut la largeur du terminal, ou 80 colonnes si non connecté à un terminal, et peut être outrepassé avec `<largeur>`. La largeur du nom de fichier peut être limitée en fournissant une autre largeur `<largeur-de-nom>` après une virgule. La largeur de la partie du graphe peut être limitée en utilisant `--stat-graph-width=<largeur>` (affecte toutes les commandes générant un graphe de stat) ou en réglant `diff.statGraphWidth=<largeur>` (n'affecte pas `git format-patch`). En ajoutant un troisième paramètre `<nombre>`, vous pouvez limiter la sortie aux premières `<nombre>` lignes, suivies de `...` s'il y en a plus."
 
@@ -3975,13 +3975,13 @@ msgstr "N'affiche que la dernière ligne du format `--stat` contenant le nombre 
 
 #. type: Labeled list
 #: en/diff-options.txt:161
-#, 280, no-wrap, priority
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "-X[<param1,param2,...>]"
 msgstr "-X[<param1,param2,...>]"
 
 #. type: Labeled list
 #: en/diff-options.txt:162
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--dirstat[=<param1,param2,...>]"
 msgstr "--dirstat[=<param1,param2,...>]"
 
@@ -4071,13 +4071,13 @@ msgstr "Synonyme de --dirstat=cumulative"
 
 #. type: Labeled list
 #: en/diff-options.txt:209
-#, 280, no-wrap, priority
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--dirstat-by-file[=<param1,param2>...]"
 msgstr "--dirstat-by-file[=<param1,param2>...]"
 
 #. type: Plain text
 #: en/diff-options.txt:211
-#, 280, priority
+#, ignore-ellipsis, priority:280
 msgid "Synonym for --dirstat=files,param1,param2..."
 msgstr "Synonyme de --dirstat=files,param1,param2...."
 
@@ -4759,13 +4759,13 @@ msgstr "Les options `-M` et `-C` nécessitent un temps de traitement en O(n²) o
 
 #. type: Labeled list
 #: en/diff-options.txt:527
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--diff-filter=[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr "--diff-filter=[(A|C|D|M|R|T|U|X|B)...[*]]"
 
 #. type: Plain text
 #: en/diff-options.txt:538
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Select only files that are Added (`A`), Copied (`C`), Deleted (`D`), Modified (`M`), Renamed (`R`), have their type (i.e. regular file, symlink, submodule, ...) changed (`T`), are Unmerged (`U`), are Unknown (`X`), or have had their pairing Broken (`B`).  Any combination of the filter characters (including none) can be used.  When `*` (All-or-none) is added to the combination, all paths are selected if there is any file that matches other criteria in the comparison; if there is no file that matches other criteria, nothing is selected."
 msgstr "Sélectionner seulement les fichiers qui sont Ajoutés (`A`), Copiés (`C`), supprimés (Deleted `D`), Modifiés (`M`), Renommés (`R`), ont eu un changement de Type (`T`) (c-à-d fichier normal, lien symbolique, sous-module …), sont non fusionnés (Unmerged `U`), sont inconnus (Unknown `X`) ou ont eu leur appairage cassé (Broken `B`). Toute combinaison de caractères de filtre (incluant aucun) peut être utilisée). Quand `*` (Tout-ou-rien) est ajouté à la combinaison, tous les chemins sont sélectionnés s'il y a des fichiers qui correspondent aux autres critères dans la comparaison ; s'il n'y a aucun fichier qui correspond aux autres critères, rien n'est sélectionné."
 
@@ -4825,7 +4825,7 @@ msgstr "Pour illustrer la différence entre `-S<regex> --pickaxe-regex` et `-G<r
 
 #. type: delimited block -
 #: en/diff-options.txt:573
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "+    return !regexec(regexp, two->ptr, 1, &regmatch, 0);\n"
 "...\n"
@@ -5757,7 +5757,7 @@ msgstr "SYNOPSIS"
 
 #. type: Plain text
 #: en/git-add.txt:15
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "'git add' [--verbose | -v] [--dry-run | -n] [--force | -f] [--interactive | -i] [--patch | -p]\n"
 "\t  [--edit | -e] [--[no-]all | --[no-]ignore-removal | [--update | -u]]\n"
@@ -5819,7 +5819,7 @@ msgstr "OPTIONS"
 
 #. type: Labeled list
 #: en/git-add.txt:52 en/git-grep.txt:308 en/git-status.txt:148
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid "<pathspec>..."
 msgstr "<spécificateur de chemin>..."
 
@@ -5963,7 +5963,7 @@ msgstr "Mettre à jour l'index en y ajoutant les nouveaux fichiers qui sont inco
 
 #. type: Plain text
 #: en/git-add.txt:145
-#, priority:300
+#, ignore-ellipsis, priority:300
 msgid "This option is primarily to help users who are used to older versions of Git, whose \"git add <pathspec>...\" was a synonym for \"git add --no-all <pathspec>...\", i.e. ignored removed files."
 msgstr "Cette option sert principalement à aider les utilisateurs de versions anciennes de Git pour lesquels « git add <chemin>... » était synonyme de « git add --no-all <chemin>... », c'est-à-dire qui ignorait les fichiers effacés."
 
@@ -6485,7 +6485,7 @@ msgstr "git-am - Appliquer une série de rustines depuis des fichiers mailbox"
 
 #. type: Plain text
 #: en/git-am.txt:20
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git am' [--signoff] [--keep] [--[no-]keep-cr] [--[no-]utf8]\n"
 "\t [--[no-]3way] [--interactive] [--committer-date-is-author-date]\n"
@@ -6513,7 +6513,7 @@ msgstr "Découpe des messages courriel dans un boîte aux lettre en message, aut
 
 #. type: Labeled list
 #: en/git-am.txt:29
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "(<mbox>|<Maildir>)..."
 msgstr "(<mbox>|<Maildir>)..."
 
@@ -7051,7 +7051,7 @@ msgstr "git-apply - Applique une rustine à des fichiers et/ou à l'index"
 
 #. type: Plain text
 #: en/git-apply.txt:20
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git apply' [--stat] [--numstat] [--summary] [--check] [--index | --intent-to-add] [--3way]\n"
 "\t  [--apply] [--no-add] [--build-fake-ancestor=<file>] [-R | --reverse]\n"
@@ -7077,7 +7077,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-apply.txt:37
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<patch>..."
 msgstr "<rustine>..."
 
@@ -7491,7 +7491,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-archimport.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git archimport' [-h] [-v] [-o] [-a] [-f] [-T] [-D depth] [-t tempdir]\n"
 "               <archive/branch>[:<git-branch>] ...\n"
@@ -7655,7 +7655,7 @@ msgstr "git-archive - Crée une archive de fichiers depuis un arbre nommé"
 
 #. type: Plain text
 #: en/git-archive.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git archive' [--format=<fmt>] [--list] [--prefix=<prefix>/] [<extra>]\n"
 "\t      [-o <file> | --output=<file>] [--worktree-attributes]\n"
@@ -8043,7 +8043,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bisect.txt:31
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 " git bisect start [--term-{old,good}=<term> --term-{new,bad}=<term>]\n"
 "\t\t  [--no-checkout] [<bad> [<good>...]] [--] [<paths>...]\n"
@@ -8238,7 +8238,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-bisect.txt:158
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git bisect new [<rev>...]\n"
 msgstr "git bisect new [<rév>...]\n"
 
@@ -8268,7 +8268,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bisect.txt:175
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If you would like to use your own terms instead of \"bad\"/\"good\" or \"new\"/\"old\", you can choose any names you like (except existing bisect subcommands like `reset`, `start`, ...) by starting the bisection using"
 msgstr ""
 
@@ -8708,7 +8708,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-bisect.txt:463
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git bisect start HEAD <known-good-commit> [ <boundary-commit> ... ] --no-checkout\n"
 "$ git bisect run sh -c '\n"
@@ -9176,7 +9176,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:26
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git branch' [--color[=<when>] | --no-color] [--show-current]\n"
 "\t[-v [--abbrev=<length> | --no-abbrev]]\n"
@@ -9221,7 +9221,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:61
-#, fuzzy, priority:240
+#, fuzzy, ignore-ellipsis, priority:240
 #| msgid "As a special case, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgid "The command's second form creates a new branch head named <branchname> which points to the current `HEAD`, or <start-point> if given. As a special case, for <start-point>, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr "Autre cas spécial supplémentaire, vous pouvez utiliser « A...B » comme raccourci pour la base de fusion de `A` et `B` s'il y a exactement une seule base de fusion. Vous pouvez ne pas spécifier `A` ou `B`, auquel cas ce sera `HEAD` par défaut."
@@ -9420,7 +9420,7 @@ msgstr "afficher à la fois les branches de suivi et les branches locales"
 
 #. type: Plain text
 #: en/git-branch.txt:176
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "List branches.  With optional `<pattern>...`, e.g. `git branch --list 'maint-*'`, list only the branches that match the pattern(s)."
 msgstr ""
 
@@ -9666,7 +9666,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:291
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "Sort based on the key given. Prefix `-` to sort in descending order of the value. You may use the --sort=<key> option multiple times, in which case the last key becomes the primary key. The keys supported are the same as those in `git for-each-ref`. Sort order defaults to the value configured for the `branch.sort` variable if exists, or to sorting based on the full refname (including `refs/...` prefix). This lists detached HEAD (if present) first, then local branches and finally remote-tracking branches. See linkgit:git-config[1]."
 msgstr ""
 
@@ -9708,7 +9708,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-branch.txt:317
-#, fuzzy, no-wrap, priority:240
+#, fuzzy, ignore-ellipsis, no-wrap, priority:240
 #| msgid ""
 #| "$ git clone git://git.kernel.org/pub/scm/.../linux.git my-linux\n"
 #| "$ cd my-linux\n"
@@ -9737,7 +9737,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-branch.txt:329
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git clone git://git.kernel.org/.../git.git my.git\n"
 "$ cd my.git\n"
@@ -9851,7 +9851,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bundle.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git bundle' create <file> <git-rev-list-args>\n"
 "'git bundle' verify <file>\n"
@@ -9927,7 +9927,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-bundle.txt:71
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<refname>...]"
 msgstr "[<nom-de-réf>...]"
 
@@ -10703,7 +10703,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-attr.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git check-attr' [-a | --all | <attr>...] [--] <pathname>...\n"
 "'git check-attr' --stdin [-z] [-a | --all | <attr>...]\n"
@@ -10944,7 +10944,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-ignore.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git check-ignore' [<options>] <pathname>...\n"
 "'git check-ignore' [<options>] --stdin\n"
@@ -11120,7 +11120,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-mailmap.txt:13
-#, fuzzy, no-wrap, priority:100
+#, fuzzy, ignore-ellipsis, no-wrap, priority:100
 msgid "'git check-mailmap' [<options>] <contact>...\n"
 msgstr "git check-mailmap [<options>] <contact>..."
 
@@ -11156,7 +11156,7 @@ msgstr "git-checkout-index - Copie les fichiers depuis l'index dans l'arbre de t
 
 #. type: Plain text
 #: en/git-checkout-index.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git checkout-index' [-u] [-q] [-a] [-f] [-n] [--prefix=<string>]\n"
 "\t\t   [--stage=<number>|all]\n"
@@ -11431,7 +11431,7 @@ msgstr "git-checkout - Bascule sur une autre branche ou restaure des fichiers de
 
 #. type: Plain text
 #: en/git-checkout.txt:18
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git checkout' [-q] [-f] [-m] [<branch>]\n"
 "'git checkout' [-q] [-f] [-m] --detach [<branch>]\n"
@@ -11559,7 +11559,7 @@ msgstr "Omettre <branche> détache HEAD au sommet de la branche actuelle."
 
 #. type: Labeled list
 #: en/git-checkout.txt:82
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git checkout' [<tree-ish>] [--] <pathspec>..."
 msgstr "'git checkout' [<arbre-esque>] [--] <spéc. de chemin>..."
 
@@ -11578,7 +11578,7 @@ msgstr "L'index peut contenir des entrées non fusionnées à cause d'un échec 
 
 #. type: Labeled list
 #: en/git-checkout.txt:98
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git checkout' (-p|--patch) [<tree-ish>] [--] [<pathspec>...]"
 msgstr "'git checkout' (-p|--patch) [<arbre-esque>] [--] [<spéc. de chemin>...]"
 
@@ -11936,7 +11936,7 @@ msgstr "Vous pouvez utiliser la syntaxe `\"@{-N}\"` pour faire référence à la
 
 #. type: Plain text
 #: en/git-checkout.txt:326 en/git-switch.txt:58
-#, fuzzy, priority:240
+#, fuzzy, ignore-ellipsis, priority:240
 #| msgid "As a special case, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgid "As a special case, you may use `A...B` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr "Autre cas spécial supplémentaire, vous pouvez utiliser « A...B » comme raccourci pour la base de fusion de `A` et `B` s'il y a exactement une seule base de fusion. Vous pouvez ne pas spécifier `A` ou `B`, auquel cas ce sera `HEAD` par défaut."
@@ -11968,7 +11968,7 @@ msgstr "Le nom du commit auquel démarrer la nouvelle branche ; voir linkgit:gi
 
 #. type: Plain text
 #: en/git-checkout.txt:337
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "As a special case, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr "Autre cas spécial supplémentaire, vous pouvez utiliser « A...B » comme raccourci pour la base de fusion de `A` et `B` s'il y a exactement une seule base de fusion. Vous pouvez ne pas spécifier `A` ou `B`, auquel cas ce sera `HEAD` par défaut."
 
@@ -12621,7 +12621,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git cherry-pick' [--edit] [-n] [-m parent-number] [-s] [-x] [--ff]\n"
 "\t\t  [-S[<keyid>]] <commit>...\n"
@@ -12678,13 +12678,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-cherry-pick.txt:43 en/git-merge.txt:116 en/git-revert.txt:36 en/git-verify-commit.txt:27
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "<commit>..."
 msgstr "<commit>..."
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:52
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Commits to cherry-pick.  For a more complete list of ways to spell commits, see linkgit:gitrevisions[7].  Sets of commits can be passed but no traversal is done by default, as if the `--no-walk` option was specified, see linkgit:git-rev-list[1]. Note that specifying a range will feed all <commit>... arguments to a single revision walk (see a later example that uses 'maint master..next')."
 msgstr ""
 
@@ -12714,7 +12714,7 @@ msgstr "-x"
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:78
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When recording the commit, append a line that says \"(cherry picked from commit ...)\" to the original commit message in order to indicate which commit this change was cherry-picked from.  This is done only for cherry picks without conflicts.  Do not use this option if you are cherry-picking from your private branch because the information is useless to the recipient.  If on the other hand you are cherry-picking between two publicly visible branches (e.g. backporting a fix to a maintenance branch for an older release from a development branch), adding this information can be useful."
 msgstr ""
 
@@ -13072,7 +13072,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:58
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git checkout -b topic origin/master\n"
 "# work and create some commits\n"
@@ -13108,7 +13108,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git log --graph --oneline --decorate --boundary origin/master...topic\n"
 "* 7654321 (origin/master) upstream tip commit\n"
@@ -13131,7 +13131,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:96
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git cherry origin/master topic\n"
 "- cccc000... commit C\n"
@@ -13159,7 +13159,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:126
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git log --graph --oneline --decorate --boundary origin/master...topic\n"
 "* 7654321 (origin/master) upstream tip commit\n"
@@ -13185,7 +13185,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:136
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git cherry origin/master topic base\n"
 "- cccc000... commit C\n"
@@ -13237,7 +13237,7 @@ msgstr "git-clean - Supprime les fichiers non suivis de l'arbre de travail"
 
 #. type: Plain text
 #: en/git-clean.txt:12
-#, fuzzy, no-wrap, priority:100
+#, fuzzy, ignore-ellipsis, no-wrap, priority:100
 msgid "'git clean' [-d] [-f] [-i] [-n] [-q] [-e <pattern>] [-x | -X] [--] <path>...\n"
 msgstr "git clean [-d] [-f] [-i] [-n] [-q] [-e <motif>] [-x | -X] [--] <chemins>..."
 
@@ -13255,7 +13255,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-clean.txt:25
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If any optional `<path>...` arguments are given, only those paths are affected."
 msgstr ""
 
@@ -13918,7 +13918,7 @@ msgstr "Cloner depuis l'amont :"
 
 #. type: delimited block -
 #: en/git-clone.txt:306
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "$ git clone git://git.kernel.org/pub/scm/.../linux.git my-linux\n"
 "$ cd my-linux\n"
@@ -13954,7 +13954,7 @@ msgstr "Cloner depuis l'amont tout en empruntant depuis une répertoire local ex
 
 #. type: delimited block -
 #: en/git-clone.txt:325
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "$ git clone --reference /git/linux.git \\\n"
 "\tgit://git.kernel.org/pub/scm/.../linux.git \\\n"
@@ -14151,7 +14151,7 @@ msgstr "git-commit - Crée un nouvel objet commit"
 
 #. type: Plain text
 #: en/git-commit-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git commit-tree' <tree> [(-p <parent>)...]\n"
 "'git commit-tree' [(-p <parent>)...] [-S[<keyid>]] [(-m <message>)...]\n"
@@ -14353,7 +14353,7 @@ msgstr "git-commit - Enregistrer les modifications dans le dépôt"
 
 #. type: Plain text
 #: en/git-commit.txt:17
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git commit' [-a | --interactive | --patch] [-s] [-v] [-u<mode>] [--amend]\n"
 "\t   [--dry-run] [(-c | -C | --fixup | --squash) <commit>]\n"
@@ -14779,7 +14779,7 @@ msgstr "C'est un équivalent grossier de :"
 
 #. type: delimited block -
 #: en/git-commit.txt:248
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "\t$ git reset --soft HEAD^\n"
 "\t$ ... do something else to come up with the right tree ...\n"
@@ -14947,7 +14947,7 @@ msgstr "Annuler la variable de configuration `commit.gpgSign` qui force tous les
 
 #. type: Labeled list
 #: en/git-commit.txt:346 en/git-rm.txt:29
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "<file>..."
 msgstr "<fichier>..."
 
@@ -15950,7 +15950,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-config.txt:428
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "However, if you really only want to replace the line for the default proxy, i.e. the one without a \"for ...\" postfix, do something like this:"
 msgstr ""
 
@@ -17308,7 +17308,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-cvsserver.txt:26
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git-cvsserver' [<options>] [pserver|server] [<directory> ...]\n"
 msgstr ""
 
@@ -18006,7 +18006,7 @@ msgstr "git-daemon - un serveur vraiment très simple pour les dépôts Git"
 
 #. type: Plain text
 #: en/git-daemon.txt:25
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git daemon' [--verbose] [--syslog] [--export-all]\n"
 "\t     [--timeout=<n>] [--init-timeout=<n>] [--max-connections=<n>]\n"
@@ -18574,7 +18574,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-describe.txt:14
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "'git describe' [--all] [--tags] [--contains] [--abbrev=<n>] [<commit-ish>...]\n"
 "'git describe' [--all] [--tags] [--contains] [--abbrev=<n>] --dirty[=<mark>]\n"
@@ -18620,7 +18620,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-describe.txt:37
-#, 260, no-wrap, priority
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "<commit-ish>..."
 msgstr "<commit-esque>..."
 
@@ -18747,7 +18747,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-describe.txt:95
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Always output the long format (the tag, the number of commits and the abbreviated commit name) even when it matches a tag.  This is useful when you want to see parts of the commit object name in \"describe\" output, even when the commit in question happens to be a tagged version.  Instead of just emitting the tag name, it will describe such a commit as v1.2-0-gdeadbee (0th commit since tag v1.2 that points at object deadbee....)."
 msgstr ""
 "Afficher toujours le format long (l'étiquette, le nombre de commits et le "
@@ -18999,7 +18999,7 @@ msgstr "git-diff-files - Compare les fichiers dans l'arbre de travail et dans l'
 
 #. type: Plain text
 #: en/git-diff-files.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git diff-files' [-q] [-0|-1|-2|-3|-c|--cc] [<common diff options>] [<path>...]\n"
 msgstr "'git diff-files' [-q] [-0|-1|-2|-3|-c|--cc] [<options diff communes>] [<chemin>...]\n"
 
@@ -19071,7 +19071,7 @@ msgstr "git-diff-index - Compare un arbre avec l'arbre de travail ou l'index"
 
 #. type: Plain text
 #: en/git-diff-index.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git diff-index' [-m] [--cached] [<common diff options>] <tree-ish> [<path>...]\n"
 msgstr ""
 
@@ -19210,7 +19210,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-index.txt:102
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "  torvalds@ppc970:~/v2.6/linux> git diff-index --abbrev HEAD\n"
 "  :100644 100664 7476bb... 000000...      kernel/sched.c\n"
@@ -19248,7 +19248,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-difftool.txt:12
-#, fuzzy, no-wrap, priority:100
+#, fuzzy, ignore-ellipsis, no-wrap, priority:100
 msgid "'git difftool' [<options>] [<commit> [<commit>]] [--] [<path>...]\n"
 msgstr "'git diff' [<options>] <commit> <commit> [--] [<chemin>...]"
 
@@ -19560,7 +19560,7 @@ msgstr "Compare le contenu et la mode des blobs trouvés via deux objets arbre"
 
 #. type: Plain text
 #: en/git-diff-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git diff-tree' [--stdin] [-m] [-s] [-v] [--no-commit-id] [--pretty]\n"
 "\t      [-t] [-r] [-c | --cc] [--combined-all-paths] [--root]\n"
@@ -19593,7 +19593,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff-tree.txt:32 en/git-diff.txt:114 en/git-submodule.txt:422
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "<path>..."
 msgstr "<chemin>..."
 
@@ -19719,7 +19719,7 @@ msgstr "git-diff - Affiche les modifications entre les commits, un commit et l'a
 
 #. type: Plain text
 #: en/git-diff.txt:17
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git diff' [<options>] [<commit>] [--] [<path>...]\n"
 "'git diff' [<options>] --cached [<commit>] [--] [<path>...]\n"
@@ -19741,7 +19741,7 @@ msgstr "Affiche les modifications entre l'arbre de travail et l'index ou un arbr
 
 #. type: Labeled list
 #: en/git-diff.txt:24
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] [--] [<path>...]"
 msgstr "'git diff' [<options>] [--] [<chemin>...]"
 
@@ -19765,7 +19765,7 @@ msgstr "Cette forme sert à comparer les deux chemins indiqués sur le système 
 
 #. type: Labeled list
 #: en/git-diff.txt:41
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] --cached [<commit>] [--] [<path>...]"
 msgstr "'git diff' [<options>] --cached [<commit>] [--] [<chemin>...]"
 
@@ -19777,7 +19777,7 @@ msgstr "Cette forme sert à visualiser les modifications que vous avez indexées
 
 #. type: Labeled list
 #: en/git-diff.txt:51
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit> [--] [<path>...]"
 msgstr "'git diff' [<options>] <commit> [--] [<chemin>...]"
 
@@ -19789,7 +19789,7 @@ msgstr "Cette forme sert à visualiser les modifications présentes dans l'arbre
 
 #. type: Labeled list
 #: en/git-diff.txt:59
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit> <commit> [--] [<path>...]"
 msgstr "'git diff' [<options>] <commit> <commit> [--] [<chemin>...]"
 
@@ -19801,7 +19801,7 @@ msgstr "Ceci sert à visualiser les modifications entre deux <commit> arbitraire
 
 #. type: Labeled list
 #: en/git-diff.txt:64
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit>..<commit> [--] [<path>...]"
 msgstr "'git diff' [<options>] <commit>..<commit> [--] [<chemin>...]"
 
@@ -19813,13 +19813,13 @@ msgstr "Cette forme est synonyme de la précédente. Si <commit> est omis d'un c
 
 #. type: Labeled list
 #: en/git-diff.txt:70
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit>\\...<commit> [--] [<path>...]"
 msgstr "'git diff' [<options>] <commit>\\...<commit> [--] [<chemin>...]"
 
 #. type: Plain text
 #: en/git-diff.txt:77
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "This form is to view the changes on the branch containing and up to the second <commit>, starting at a common ancestor of both <commit>.  \"git diff A\\...B\" is equivalent to \"git diff $(git merge-base A B) B\".  You can omit any one of <commit>, which has the same effect as using HEAD instead."
 msgstr "Cette forme sert à visualiser les modifications sur la branche contenant et jusqu'au second <commit>, en débutant à l'ancêtre commun au deux <commit>. \"git diff A\\...B\" est équivalent à \"git diff $(git merge-base A B) B\". Vous pouvez omettre l'un ou l'autre <commit>, ce qui a le même effet que de spécifier HEAD à la place."
 
@@ -19831,7 +19831,7 @@ msgstr "Juste au cas où vous feriez quelque chose d'exotique, il doit être not
 
 #. type: Plain text
 #: en/git-diff.txt:89
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "For a more complete list of ways to spell <commit>, see \"SPECIFYING REVISIONS\" section in linkgit:gitrevisions[7].  However, \"diff\" is about comparing two _endpoints_, not ranges, and the range notations (\"<commit>..<commit>\" and \"<commit>\\...<commit>\") do not mean a range as defined in the \"SPECIFYING RANGES\" section in linkgit:gitrevisions[7]."
 msgstr "Pour une liste plus complète des moyens de spécifier <commit>, voir la section « SPÉCIFIER LES RÉVISIONS » dans linkgit:gitrevisions[7]. Cependant, \"diff\" concerne la comparaison de deux _point finaux_, et non d'intervalles, et les notations d'intervalle (\"<commit>..<commit>\" et \"<commit>\\...<commit>\") ne réfèrent pas un intervalle tel que défini dans la section « SPÉCIFIER LES RÉVISIONS » de linkgit:gitrevisions[7]."
 
@@ -19945,7 +19945,7 @@ msgstr "Comparaison de branches"
 
 #. type: delimited block -
 #: en/git-diff.txt:160
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git diff topic master    <1>\n"
 "$ git diff topic..master   <2>\n"
@@ -20273,7 +20273,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:143
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<git-rev-list-args>...]"
 msgstr "[<git-rev-list-args>...]"
 
@@ -20354,7 +20354,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-fast-export.txt:215
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git init anon-repo\n"
 "$ cd anon-repo\n"
@@ -22664,7 +22664,7 @@ msgstr "git-fetch-pack - Recevoir les objets manquants depuis un autre dépôt"
 
 #. type: Plain text
 #: en/git-fetch-pack.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git fetch-pack' [--all] [--quiet|-q] [--keep|-k] [--thin] [--include-tag]\n"
 "\t[--upload-pack=<git-upload-pack>]\n"
@@ -22818,7 +22818,7 @@ msgstr "L'URL du dépôt distant."
 
 #. type: Labeled list
 #: en/git-fetch-pack.txt:117 en/git-ls-remote.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<refs>..."
 msgstr ""
 
@@ -22848,7 +22848,7 @@ msgstr "git-fetch - Télécharger les objets et références depuis un autre dé
 
 #. type: Plain text
 #: en/git-fetch.txt:16
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git fetch' [<options>] [<repository> [<refspec>...]]\n"
 "'git fetch' [<options>] <group>\n"
@@ -23189,7 +23189,7 @@ msgstr "résumé"
 
 #. type: Plain text
 #: en/git-fetch.txt:226
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "For a successfully fetched ref, the summary shows the old and new values of the ref in a form suitable for using as an argument to `git log` (this is `<old>..<new>` in most cases, and `<old>...<new>` for forced non-fast-forward updates)."
 msgstr ""
 
@@ -23311,7 +23311,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:18
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git filter-branch' [--setup <command>] [--subdirectory-filter <directory>]\n"
 "\t[--env-filter <command>] [--tree-filter <command>]\n"
@@ -23450,7 +23450,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:117
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for rewriting the index.  It is similar to the tree filter but does not check out the tree, which makes it much faster.  Frequently used with `git rm --cached --ignore-unmatch ...`, see EXAMPLES below.  For hairy cases, see linkgit:git-update-index[1]."
 msgstr ""
 
@@ -23462,7 +23462,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:125
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for rewriting the commit's parent list.  It will receive the parent string on stdin and shall output the new parent string on stdout.  The parent string is in the format described in linkgit:git-commit-tree[1]: empty for the initial commit, \"-p parent\" for a normal commit and \"-p parent1 -p parent2 -p parent3 ...\" for a merge commit."
 msgstr ""
 
@@ -23486,7 +23486,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:138
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for performing the commit.  If this filter is specified, it will be called instead of the 'git commit-tree' command, with arguments of the form \"<TREE_ID> [(-p <PARENT_COMMIT_ID>)...]\" and the log message on stdin.  The commit id is expected on stdout."
 msgstr ""
 
@@ -23588,7 +23588,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-filter-branch.txt:207
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<rev-list options>..."
 msgstr ""
 
@@ -23849,7 +23849,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-filter-branch.txt:388
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git filter-branch ... C..H\n"
 msgstr ""
 
@@ -23861,7 +23861,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-filter-branch.txt:395
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "git filter-branch ... C..H --not D\n"
 "git filter-branch ... D..H --not C\n"
@@ -24100,7 +24100,7 @@ msgstr "git-for-each-ref - Affiche des informations sur chaque référence"
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git for-each-ref' [--count=<count>] [--shell|--perl|--python|--tcl]\n"
 "\t\t   [(--sort=<key>)...] [--format=<format>] [<pattern>...]\n"
@@ -24117,7 +24117,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-for-each-ref.txt:29 en/git-show-ref.txt:88
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<pattern>..."
 msgstr ""
 
@@ -24405,7 +24405,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:197
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Left-, middle-, or right-align the content between %(align:...) and %(end). The \"align:\" is followed by `width=<width>` and `position=<position>` in any order separated by a comma, where the `<position>` is either left, right or middle, default being left and `<width>` is the total length of the content with alignment. For brevity, the \"width=\" and/or \"position=\" prefixes may be omitted, and bare <width> and <position> used instead.  For instance, `%(align:<width>,<position>)`. If the contents length is more than the width then no alignment is performed. If used with `--quote` everything in between %(align:...) and %(end) is quoted, but if nested then only the topmost level performs quoting."
 msgstr ""
 
@@ -24417,7 +24417,7 @@ msgstr "if"
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:210
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Used as %(if)...%(then)...%(end) or %(if)...%(then)...%(else)...%(end).  If there is an atom with value or string literal after the %(if) then everything after the %(then) is printed, else if the %(else) atom is used, then everything after %(else) is printed. We ignore space when evaluating the string before %(then), this is useful when we use the %(HEAD) atom which prints either \"*\" or \" \" and we want to apply the 'if' condition only on the 'HEAD' ref.  Append \":equals=<string>\" or \":notequals=<string>\" to compare the value between the %(if:...) and %(then) atoms with the given string."
 msgstr ""
 
@@ -24638,7 +24638,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:361
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "An example to show the usage of %(if)...%(then)...%(else)...%(end).  This prefixes the current branch with a star."
 msgstr ""
 
@@ -24650,7 +24650,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:369
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "An example to show the usage of %(if)...%(then)...%(end).  This prints the authorname, if present."
 msgstr ""
 
@@ -25296,7 +25296,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:372
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "Do the same for ia64 so we can have sleek & trim looking\n"
 "...\n"
@@ -25304,7 +25304,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:380
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Typically it will be placed in a MUA's drafts folder, edited to add timely commentary that should not go in the changelog after the three dashes, and then sent as a message whose body, in our example, starts with \"arch/arm config files were...\".  On the receiving end, readers can save interesting patches in a UNIX mailbox and apply them with linkgit:git-am[1]."
 msgstr ""
 
@@ -25316,7 +25316,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:390
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "...\n"
 "> So we should do such-and-such.\n"
@@ -25338,7 +25338,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:398
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "arch/arm config files were slimmed down using a python script\n"
 "...\n"
@@ -25512,7 +25512,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:499
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Configure your mail server composition as plain text: Edit...Account Settings...Composition & Addressing, uncheck \"Compose Messages in HTML\"."
 msgstr ""
 
@@ -25649,7 +25649,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:573
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Use Message -> Insert file... and insert the patch."
 msgstr ""
 
@@ -25824,7 +25824,7 @@ msgstr "git-fsck-objects - Vérifier la connectivité et la validité des objets
 
 #. type: Plain text
 #: en/git-fsck-objects.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git fsck-objects' ...\n"
 msgstr "'git fsck-objects' ...\n"
 
@@ -26216,7 +26216,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-gc.txt:55
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Once housekeeping is triggered by exceeding the limits of configuration options such as `gc.auto` and `gc.autoPackLimit`, all other housekeeping tasks (e.g. rerere, working trees, reflog...) will be performed as well."
 msgstr ""
 
@@ -26390,7 +26390,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-grep.txt:32
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git grep' [-a | --text] [-I] [--textconv] [-i | --ignore-case] [-w | --word-regexp]\n"
 "\t   [-v | --invert-match] [-h|-H] [--full-name]\n"
@@ -26998,7 +26998,7 @@ msgstr "--not"
 
 #. type: Labeled list
 #: en/git-grep.txt:284
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "( ... )"
 msgstr ""
 
@@ -27028,7 +27028,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-grep.txt:300
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<tree>..."
 msgstr ""
 
@@ -27346,7 +27346,7 @@ msgstr "Calculer l'ID d'objet et créer optionnellement un blob depuis un fichie
 
 #. type: Plain text
 #: en/git-hash-object.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git hash-object' [-t <type>] [-w] [--path=<file>|--no-filters] [--stdin [--literally]] [--] <file>...\n"
 "'git hash-object' [-t <type>] [-w] --stdin-paths [--no-filters]\n"
@@ -27476,7 +27476,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-help.txt:38
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Note that `git --help ...` is identical to `git help ...` because the former is internally converted into the latter."
 msgstr ""
 
@@ -27926,7 +27926,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:102
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tAuthType Basic\n"
 "\tAuthName \"Git Access\"\n"
@@ -27944,7 +27944,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:115
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "<LocationMatch \"^/git/.*/git-receive-pack$\">\n"
 "\tAuthType Basic\n"
@@ -27968,7 +27968,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:136
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "<Location /git/private>\n"
 "\tAuthType Basic\n"
@@ -28118,7 +28118,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:231
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "auth.require = (\n"
 "\t\"/\" => (\n"
@@ -28321,7 +28321,7 @@ msgstr "git-http-push - Pousse des objets via HTTP/DAV sur un autre dépôt"
 
 #. type: Plain text
 #: en/git-http-push.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git http-push' [--all] [--dry-run] [--force] [--verbose] <url> <ref> [<ref>...]\n"
 msgstr ""
 
@@ -28390,7 +28390,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-http-push.txt:54 en/git-send-pack.txt:98
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<ref>..."
 msgstr ""
 
@@ -29263,7 +29263,7 @@ msgstr "git-interpret-trailers -  ajoute ou analyse de l'information structurée
 
 #. type: Plain text
 #: en/git-interpret-trailers.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git interpret-trailers' [<options>] [(--trailer <token>[(=|:)<value>])...] [<file>...]\n"
 "'git interpret-trailers' [<options>] [--parse] [<file>...]\n"
@@ -29933,7 +29933,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-log.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'git log' [<options>] [<revision range>] [[--] <path>...]\n"
 msgstr "'git log' [<options>] [<plage de révision>] [[--] <chemin>...]\n"
 
@@ -30029,7 +30029,7 @@ msgstr "--full-diff"
 
 #. type: Plain text
 #: en/git-log.txt:63
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Without this flag, `git log -p <path>...` shows commits that touch the specified paths, and diffs about the same specified paths.  With this, the full diff is shown for commits that touch the specified paths; this means that \"<path>...\" limits only commits, and doesn't limit diff for those commits."
 msgstr ""
 
@@ -30083,7 +30083,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-log.txt:93 en/git-shortlog.txt:72
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "[--] <path>..."
 msgstr "[--] <chemin>..."
 
@@ -30359,7 +30359,7 @@ msgstr "git-ls-files - Affiche des informations sur les fichiers de l'index et d
 
 #. type: Plain text
 #: en/git-ls-files.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-files' [-z] [-t] [-v] [-f]\n"
 "\t\t(--[cached|deleted|others|ignored|stage|unmerged|killed|modified])*\n"
@@ -30840,7 +30840,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-remote.txt:15
-#, fuzzy, no-wrap, priority:100
+#, fuzzy, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-remote' [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
 "\t      [-q | --quiet] [--exit-code] [--get-url] [--sort=<key>]\n"
@@ -30948,7 +30948,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-remote.txt:91
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When unspecified, all references, after filtering done with --heads and --tags, are shown.  When <refs>... are specified, only references matching the given patterns are displayed."
 msgstr ""
 
@@ -30993,7 +30993,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-tree' [-d] [-r] [-t] [-l] [-z]\n"
 "\t    [--name-only] [--name-status] [--full-name] [--full-tree] [--abbrev[=<n>]]\n"
@@ -31074,7 +31074,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-ls-tree.txt:76
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<path>...]"
 msgstr "[<chemin>...]"
 
@@ -31284,7 +31284,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mailsplit.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git mailsplit' [-b] [-f<nn>] [-d<prec>] [--keep-cr] [--mboxrd]\n"
 "\t\t-o<directory> [--] [(<mbox>|<Maildir>)...]\n"
@@ -31406,7 +31406,7 @@ msgstr "Trouver un ancêtre aussi bon que possible pour une fusion"
 
 #. type: Plain text
 #: en/git-merge-base.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git merge-base' [-a|--all] <commit> <commit>...\n"
 "'git merge-base' [-a|--all] --octopus <commit>...\n"
@@ -31603,7 +31603,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:139
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tA=$(git rev-parse --verify A)\n"
 "\tif test \"$A\" = \"$(git merge-base A B)\"\n"
@@ -31620,7 +31620,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:146
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tif git merge-base --is-ancestor A B\n"
 "\tthen\n"
@@ -32107,7 +32107,7 @@ msgstr "Lancer les outils de résolution de conflit de fusion pour résoudre les
 
 #. type: Plain text
 #: en/git-mergetool.txt:12
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git mergetool' [--tool=<tool>] [-y | --[no-]prompt] [<file>...]\n"
 msgstr ""
 
@@ -32269,7 +32269,7 @@ msgstr "Fusionner deux ou plusieurs historiques de développement ensemble"
 
 #. type: Plain text
 #: en/git-merge.txt:17
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git merge' [-n] [--stat] [--no-commit] [--squash] [--[no-]edit]\n"
 "\t[-s <strategy>] [-X <strategy-option>] [-S[<keyid>]]\n"
@@ -32863,7 +32863,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mv.txt:13
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git mv' <options>... <args>...\n"
 msgstr "'git mv' <options>... <args>...\n"
 
@@ -32875,7 +32875,7 @@ msgstr "Déplace ou renomme un fichier, un répertoire ou un symlink."
 
 #. type: Plain text
 #: en/git-mv.txt:20
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 " git mv [-v] [-f] [-n] [-k] <source> <destination>\n"
 " git mv [-v] [-f] [-n] [-k] <source> ... <destination directory>\n"
@@ -32972,7 +32972,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-name-rev.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git name-rev' [--tags] [--refs=<pattern>]\n"
 "\t       ( --all | --stdin | <commit-ish>... )\n"
@@ -33090,7 +33090,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-notes.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git notes' [list [<object>]]\n"
 "'git notes' add [-f] [--allow-empty] [-F <file> | -m <msg> | (-c | -C) <object>] [<object>]\n"
@@ -33426,7 +33426,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-notes.txt:229
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Commit notes are blobs containing extra information about an object (usually information to supplement a commit's message).  These blobs are taken from notes refs.  A notes ref is usually a branch which contains \"files\" whose paths are the object names for the objects they describe, with some directory separators included for performance reasons footnote:[Permitted pathnames have the form 'ab'`/`'cd'`/`'ef'`/`'...'`/`'abcdef...': a sequence of directory names of two hexadecimal digits each followed by a filename with the rest of the object ID.]."
 msgstr ""
 
@@ -33492,7 +33492,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-notes.txt:288
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git notes add -m 'Tested-by: Johannes Sixt <j6t@kdbg.org>' 72a144e2\n"
 "$ git show -s 72a144e\n"
@@ -33711,7 +33711,7 @@ msgstr "git-p4 - Importe depuis et soumet à des dépôts Perforce"
 
 #. type: Plain text
 #: en/git-p4.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git p4 clone' [<sync options>] [<clone options>] <p4 depot path>...\n"
 "'git p4 sync' [<sync options>] [<p4 depot path>...]\n"
@@ -34544,7 +34544,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-p4.txt:445
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The full syntax for a p4 view is documented in 'p4 help views'.  'git p4' knows only a subset of the view syntax.  It understands multi-line mappings, overlays with '+', exclusions with '-' and double-quotes around whitespace.  Of the possible wildcards, 'git p4' only handles '...', and only when it is at the end of the path.  'git p4' will complain if it encounters an unhandled wildcard."
 msgstr ""
 
@@ -34586,7 +34586,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-p4.txt:475
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "//depot/main/...\n"
 "//depot/branch1/...\n"
@@ -34600,7 +34600,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-p4.txt:480
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "//depot/main/... //depot/branch1/...\n"
 msgstr ""
 
@@ -35717,7 +35717,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-pack-redundant.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git pack-redundant' [ --verbose ] [ --alt-odb ] < --all | .pack filename ... >\n"
 msgstr ""
 
@@ -36017,7 +36017,7 @@ msgstr "git-prune - Élague tous les objets non joignables de la base de donnée
 
 #. type: Plain text
 #: en/git-prune.txt:13
-#, fuzzy, no-wrap, priority:100
+#, fuzzy, ignore-ellipsis, no-wrap, priority:100
 msgid "'git prune' [-n] [-v] [--progress] [--expire <time>] [--] [<head>...]\n"
 msgstr "git prune [-n] [-v] [--progress] [--expire <heure>] [--] [<head>…]"
 
@@ -36071,7 +36071,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-prune.txt:54
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<head>..."
 msgstr ""
 
@@ -36125,7 +36125,7 @@ msgstr "Rapatrier et intégrer un autre dépôt ou une branche locale"
 
 #. type: Plain text
 #: en/git-pull.txt:13
-#, fuzzy, no-wrap, priority:220
+#, fuzzy, ignore-ellipsis, no-wrap, priority:220
 msgid "'git pull' [<options>] [<repository> [<refspec>...]]\n"
 msgstr "git pull [<options>] [<dépôt> [<spécification-de-référence>...]]"
 
@@ -36475,7 +36475,7 @@ msgstr "Mettre à jour les références distantes ainsi que les objets associés
 
 #. type: Plain text
 #: en/git-push.txt:18
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git push' [--all | --mirror | --tags] [--follow-tags] [--atomic] [-n | --dry-run] [--receive-pack=<git-receive-pack>]\n"
 "\t   [--repo=<repository>] [-f | --force] [-d | --delete] [--prune] [-v | --verbose]\n"
@@ -36505,7 +36505,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:39
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "When the command line does not specify what to push with `<refspec>...` arguments or `--all`, `--mirror`, `--tags` options, the command finds the default `<refspec>` by consulting `remote.*.push` configuration, and if it is not found, honors `push.default` configuration to decide what to push (See linkgit:git-config[1] for the meaning of `push.default`)."
 msgstr ""
 
@@ -36529,7 +36529,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:56
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "<refspec>..."
 msgstr ""
 
@@ -36889,7 +36889,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:343
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "Note that `--force` applies to all the refs that are pushed, hence using it with `push.default` set to `matching` or with multiple push destinations configured with `remote.*.push` may overwrite refs other than the current branch (including local refs that are strictly behind their remote counterpart).  To force a push to only one branch, use a `+` in front of the refspec to push (e.g `git push origin +master` to force a push to the `master` branch). See the `<refspec>...` section above for details."
 msgstr ""
 
@@ -37021,7 +37021,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:445
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "For a successfully pushed ref, the summary shows the old and new values of the ref in a form suitable for using as an argument to `git log` (this is `<old>..<new>` in most cases, and `<old>...<new>` for forced non-fast-forward updates)."
 msgstr ""
 
@@ -37282,7 +37282,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:616
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "See the section describing `<refspec>...` above for a discussion of the matching semantics."
 msgstr ""
 
@@ -37983,7 +37983,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-read-tree.txt:357
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git fetch git://.... linus\n"
 "$ LT=`git rev-parse FETCH_HEAD`\n"
@@ -38037,7 +38037,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-read-tree.txt:405
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "'git read-tree' and other merge-based commands ('git merge', 'git checkout'...) can help maintaining the skip-worktree bitmap and working directory update. `$GIT_DIR/info/sparse-checkout` is used to define the skip-worktree reference bitmap. When 'git read-tree' needs to update the working directory, it resets the skip-worktree bit in the index based on this file, which uses the same syntax as .gitignore files.  If an entry matches a pattern in this file, skip-worktree will not be set on that entry. Otherwise, skip-worktree will be set."
 msgstr ""
 
@@ -38417,7 +38417,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:219
-#, fuzzy, priority:100
+#, fuzzy, ignore-ellipsis, priority:100
 msgid "As a special case, you may use \"A\\...B\" as a shortcut for the merge base of A and B if there is exactly one merge base. You can leave out at most one of A and B, in which case it defaults to HEAD."
 msgstr "Autre cas spécial supplémentaire, vous pouvez utiliser « A...B » comme raccourci pour la base de fusion de `A` et `B` s'il y a exactement une seule base de fusion. Vous pouvez ne pas spécifier `A` ou `B`, auquel cas ce sera `HEAD` par défaut."
 
@@ -38681,7 +38681,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:430
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "It is currently only possible to recreate the merge commits using the `recursive` merge strategy; Different merge strategies can be used only via explicit `exec git merge -s <strategy> [...]` commands."
 msgstr ""
 
@@ -38735,7 +38735,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:457
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "\tgit rebase -i --exec \"cmd1 && cmd2 && ...\"\n"
 msgstr ""
 
@@ -38747,7 +38747,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:461
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "\tgit rebase -i --exec \"cmd1\" --exec \"cmd2\" --exec ...\n"
 msgstr ""
 
@@ -38783,7 +38783,7 @@ msgstr "--no-autosquash"
 
 #. type: Plain text
 #: en/git-rebase.txt:495
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When the commit log message begins with \"squash! ...\" (or \"fixup! ...\"), and there is already a commit in the todo list that matches the same `...`, automatically modify the todo list of rebase -i so that the commit marked for squashing comes right after the commit to be modified, and change the action of the moved commit from `pick` to `squash` (or `fixup`).  A commit matches the `...` if the commit subject matches, or if the `...` refers to the commit's hash. As a fall-back, partial matches of the commit subject work, too.  The recommended way to create fixup/squash commits is by using the `--fixup`/`--squash` options of linkgit:git-commit[1]."
 msgstr ""
 
@@ -39110,7 +39110,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:636
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "pick deadbee The oneline of this commit\n"
 "pick fa1afe1 The oneline of the next commit\n"
@@ -39214,7 +39214,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:710
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "pick deadbee Implement feature XXX\n"
 "fixup f1a5c00 Fix to feature XXX\n"
@@ -39233,7 +39233,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:720
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The \"exec\" command launches the command in a shell (the one specified in `$SHELL`, or the default shell if `$SHELL` is not set), so you can use shell features (like \"cd\", \">\", \";\" ...). The command is run from the root of the working tree."
 msgstr ""
 
@@ -39377,7 +39377,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:815
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "    o---o---o---o---o---o---o---o  master\n"
 "\t \\\t\t\t \\\n"
@@ -40175,7 +40175,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reflog.txt:27
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git reflog' ['show'] [log-options] [<ref>]\n"
 "'git reflog expire' [--expire=<time>] [--expire-unreachable=<time>]\n"
@@ -40362,7 +40362,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-remote-ext.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git remote add <nick> \"ext::<command>[ <arguments>...]\"\n"
 msgstr ""
 
@@ -40500,7 +40500,7 @@ msgstr "GIT_EXT_SERVICE"
 
 #. type: Plain text
 #: en/git-remote-ext.txt:70
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Set to long name (git-upload-pack, etc...) of service helper needs to invoke."
 msgstr ""
 
@@ -40512,7 +40512,7 @@ msgstr "GIT_EXT_SERVICE_NOPREFIX"
 
 #. type: Plain text
 #: en/git-remote-ext.txt:74
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Set to long name (upload-pack, etc...) of service helper needs to invoke."
 msgstr ""
 
@@ -40692,7 +40692,7 @@ msgstr "git-remote - Gère un ensemble de dépôts suivis"
 
 #. type: Plain text
 #: en/git-remote.txt:25
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git remote' [-v | --verbose]\n"
 "'git remote add' [-t <branch>] [-m <master>] [-f] [--[no-]tags] [--mirror=<fetch|push>] <name> <url>\n"
@@ -41011,7 +41011,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-remote.txt:235
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "$ git remote\n"
 "origin\n"
@@ -41255,7 +41255,7 @@ msgstr "Créer, lister, supprimer des référence pour remplacer des objets"
 
 #. type: Plain text
 #: en/git-replace.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git replace' [-f] <object> <replacement>\n"
 "'git replace' [-f] --edit <object>\n"
@@ -41375,13 +41375,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-replace.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--graft <commit> [<parent>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/git-replace.txt:93
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Create a graft commit. A new commit is created with the same content as <commit> except that its parents will be [<parent>...] instead of <commit>'s parents. A replacement ref is then created to replace <commit> with the newly created commit. Use `--convert-graft-file` to convert a `$GIT_DIR/info/grafts` file and use replace refs instead."
 msgstr ""
 
@@ -41803,7 +41803,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rerere.txt:121
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git switch topic\n"
 "\t$ git merge master\n"
@@ -41835,7 +41835,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rerere.txt:145
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git switch topic\n"
 "\t$ git merge master\n"
@@ -41940,7 +41940,7 @@ msgstr "git-reset - Réinitialise la HEAD actuelle à l'état spécifié"
 
 #. type: Plain text
 #: en/git-reset.txt:14
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git reset' [-q] [<tree-ish>] [--] <paths>...\n"
 "'git reset' (--patch | -p) [<tree-ish>] [--] [<paths>...]\n"
@@ -41958,7 +41958,7 @@ msgstr "Dans la première et la deuxième forme, cette commande copie les entré
 
 #. type: Labeled list
 #: en/git-reset.txt:22
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git reset' [-q] [<tree-ish>] [--] <paths>..."
 msgstr "'git reset' [-q] [<arbre-esque>] [--] <chemins>..."
 
@@ -41970,7 +41970,7 @@ msgstr "Cette forme réinitialise les entrées d'index pour tous les `<chemins>`
 
 #. type: Plain text
 #: en/git-reset.txt:30
-#, 280, priority
+#, ignore-ellipsis, priority:280
 msgid "This means that `git reset <paths>` is the opposite of `git add <paths>`. This command is equivalent to `git restore [--source=<tree-ish>] --staged <paths>...`."
 msgstr ""
 "Cela signifie que `git reset <chemins>` est l'opposé de `git add <chemins>`. "
@@ -41990,7 +41990,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-reset.txt:38
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git reset' (--patch | -p) [<tree-ish>] [--] [<paths>...]"
 msgstr "'git reset' (--patch | -p) [<arbre-esque>] [--] [<chemins>...]"
 
@@ -42152,7 +42152,7 @@ msgstr "Défaire un commit et le refaire"
 
 #. type: delimited block -
 #: en/git-reset.txt:138
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git commit ...\n"
 "$ git reset --soft HEAD^      <1>\n"
@@ -42232,7 +42232,7 @@ msgstr "Défaire des commit de manière permanente"
 
 #. type: delimited block -
 #: en/git-reset.txt:170
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git commit ...\n"
 "$ git reset --hard HEAD~3   <1>\n"
@@ -42254,7 +42254,7 @@ msgstr "Défaire une fusion ou un tirage"
 
 #. type: delimited block -
 #: en/git-reset.txt:190
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git pull                         <1>\n"
 "Auto-merging nitfol\n"
@@ -42308,7 +42308,7 @@ msgstr "Défaire une fusion ou un tirage dans un arbre de travail sale"
 
 #. type: delimited block -
 #: en/git-reset.txt:215
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git pull                         <1>\n"
 "Auto-merging nitfol\n"
@@ -42452,7 +42452,7 @@ msgstr "Supposons que vous êtes en train de travailler sur quelque chose et que
 
 #. type: delimited block -
 #: en/git-reset.txt:289
-#, 280, no-wrap, priority
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git tag start\n"
 "$ git switch -c branch1\n"
@@ -42506,7 +42506,7 @@ msgstr "Supposons que vous avez créé de nombreuses modifications logiquement a
 
 #. type: delimited block -
 #: en/git-reset.txt:317
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git reset -N HEAD^                        <1>\n"
 "$ git add -p                                <2>\n"
@@ -42805,7 +42805,7 @@ msgstr "Basculer de branche ou restaurer la copie de travail"
 
 #. type: Plain text
 #: en/git-restore.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git restore' [<options>] [--source=<tree>] [--staged] [--worktree] <pathspec>...\n"
 "'git restore' (-p|--patch) [<options>] [--source=<tree>] [--staged] [--worktree] [<pathspec>...]\n"
@@ -43082,7 +43082,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-revert.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git revert' [--[no-]edit] [-n] [-m parent-number] [-s] [-S[<keyid>]] <commit>...\n"
 "'git revert' (--continue | --skip | --abort | --quit)\n"
@@ -43186,7 +43186,7 @@ msgstr "Afficher les objets commit dans l'ordre chronologique inverse"
 
 #. type: Plain text
 #: en/git-rev-list.txt:65
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git rev-list' [ --max-count=<number> ]\n"
 "\t     [ --skip=<number> ]\n"
@@ -43289,13 +43289,13 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-list.txt:102
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Another special notation is \"'<commit1>'...'<commit2>'\" which is useful for merges.  The resulting set of commits is the symmetric difference between the two operands.  The following two commands are equivalent:"
 msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-list.txt:106
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git rev-list A B --not $(git merge-base --all A B)\n"
 "\t$ git rev-list A...B\n"
@@ -43321,7 +43321,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-parse.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git rev-parse' [<options>] <args>...\n"
 msgstr ""
 
@@ -43805,7 +43805,7 @@ msgstr "--git-path <chemin>"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:253
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Resolve \"$GIT_DIR/<path>\" and takes other path relocation variables such as $GIT_OBJECT_DIRECTORY, $GIT_INDEX_FILE... into account. For example, if $GIT_OBJECT_DIRECTORY is set to /foo/bar then \"git rev-parse --git-path objects/abc\" returns /foo/bar/abc."
 msgstr ""
 
@@ -43913,7 +43913,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:290
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<args>..."
 msgstr ""
 
@@ -44045,7 +44045,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:364
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "OPTS_SPEC=\"\\\n"
 "some-command [<options>] <args>...\n"
@@ -44103,7 +44103,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:389
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "usage: some-command [<options>] <args>...\n"
 msgstr ""
 
@@ -44115,7 +44115,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:397
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "    -h, --help            show the help\n"
 "    --foo                 some nifty option --foo\n"
@@ -44126,7 +44126,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:400
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "An option group Header\n"
 "    -C[...]               option C with an optional argument\n"
@@ -44231,7 +44231,7 @@ msgstr "git-rm - Supprime des fichiers de l'arbre de travail et de l'index"
 
 #. type: Plain text
 #: en/git-rm.txt:12
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git rm' [-f | --force] [-n] [-r] [--cached] [--ignore-unmatch] [--quiet] [--] <file>...\n"
 msgstr "'git rm' [-f | --force] [-n] [-r] [--cached] [--ignore-unmatch] [--quiet] [--] <fichier>...\n"
 
@@ -44459,7 +44459,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-email.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git send-email' [<options>] <file|directory|rev-list options>...\n"
 "'git send-email' --dump-aliases\n"
@@ -44527,7 +44527,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:53
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--bcc=<address>,..."
 msgstr ""
 
@@ -44545,7 +44545,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:59
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--cc=<address>,..."
 msgstr ""
 
@@ -44629,7 +44629,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-email.txt:110
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "  [PATCH 0/2] Here is what I did...\n"
 "    [PATCH 1/2] Clean up and tests\n"
@@ -44660,7 +44660,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:119
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--to=<address>,..."
 msgstr ""
 
@@ -44792,7 +44792,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-send-email.txt:188
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "$ git send-email --smtp-auth=\"PLAIN LOGIN GSSAPI\" ...\n"
 msgstr ""
 
@@ -45488,7 +45488,7 @@ msgstr "git-send-pack - Pousse des objets par le protocole Git vers un autre dé
 
 #. type: Plain text
 #: en/git-send-pack.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git send-pack' [--all] [--dry-run] [--force] [--receive-pack=<git-receive-pack>]\n"
 "\t\t[--verbose] [--thin] [--atomic]\n"
@@ -45861,7 +45861,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-shortlog.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "'git shortlog' [<options>] [<revision range>] [[--] <path>...]\n"
 "git log --pretty=short | 'git shortlog' [<options>]\n"
@@ -45989,7 +45989,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show-branch.txt:17
-#, fuzzy, no-wrap, priority:100
+#, fuzzy, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git show-branch' [-a|--all] [-r|--remotes] [--topo-order | --date-order]\n"
 "\t\t[--current] [--color[=<when>] | --no-color] [--sparse]\n"
@@ -46354,7 +46354,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show-ref.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git show-ref' [-q|--quiet] [--verify] [--head] [-d|--dereference]\n"
 "\t     [-s|--hash[=<n>]] [--abbrev[=<n>]] [--tags]\n"
@@ -46502,7 +46502,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-show-ref.txt:111
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git show-ref --head --dereference\n"
 "832e76a9899f560a90ffd62ae2ce83bbeff58f54 HEAD\n"
@@ -46523,7 +46523,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-show-ref.txt:121
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git show-ref --heads --hash\n"
 "2e3ba0114a1f52b47df29743d6915d056be13278\n"
@@ -46644,7 +46644,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show.txt:13
-#, fuzzy, no-wrap, priority:260
+#, fuzzy, ignore-ellipsis, no-wrap, priority:260
 msgid "'git show' [<options>] [<object>...]\n"
 msgstr "git show [<options>] <objet>..."
 
@@ -46692,7 +46692,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-show.txt:37
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "<object>..."
 msgstr ""
 
@@ -46950,7 +46950,7 @@ msgstr "git-stage - Ajoute le contenu de fichiers à l'index"
 
 #. type: Plain text
 #: en/git-stage.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git stage' args...\n"
 msgstr "'git stage' args...\n"
 
@@ -46974,7 +46974,7 @@ msgstr "Remiser les modifications d'un répertoire de travail sale"
 
 #. type: Plain text
 #: en/git-stash.txt:22
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git stash' list [<options>]\n"
 "'git stash' show [<options>] [<stash>]\n"
@@ -46997,7 +46997,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stash.txt:38
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "The modifications stashed away by this command can be listed with `git stash list`, inspected with `git stash show`, and restored (potentially on top of a different commit) with `git stash apply`.  Calling `git stash` without any arguments is equivalent to `git stash push`.  A stash is by default listed as \"WIP on 'branchname' ...\", but you can give a more descriptive message on the command line when you create one."
 msgstr ""
 
@@ -47009,7 +47009,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-stash.txt:49
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "push [-p|--patch] [-k|--[no-]keep-index] [-u|--include-untracked] [-a|--all] [-q|--quiet] [-m|--message <message>] [--] [<pathspec>...]"
 msgstr ""
 
@@ -47081,7 +47081,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:104
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "stash@{0}: WIP on submit: 6ebd0e2... Update git-stash documentation\n"
 "stash@{1}: On master: 9cc0589... Add git-stash\n"
@@ -47254,7 +47254,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:227
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git pull\n"
 " ...\n"
@@ -47272,7 +47272,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:246
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git switch -c my_wip\n"
@@ -47293,7 +47293,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:257
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git stash\n"
@@ -47317,7 +47317,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:275
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git add --patch foo            # add just first part to the index\n"
@@ -47371,7 +47371,7 @@ msgstr "git-status - Montrer le statut de l'arbre de travail"
 
 #. type: Plain text
 #: en/git-status.txt:13
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git status' [<options>...] [--] [<pathspec>...]\n"
 msgstr "'git status' [<options>...] [--] [<spécificateur de chemin>...]\n"
 
@@ -47893,7 +47893,7 @@ msgstr "    2 <XY> <sous> <mH> <mI> <mW> <hH> <hI> <X><score> <chemin><sep><chem
 
 #. type: delimited block .
 #: en/git-status.txt:345
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "Field       Meaning\n"
 "--------------------------------------------------------\n"
@@ -48258,7 +48258,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-submodule.txt:23
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git submodule' [--quiet] [--cached]\n"
 "'git submodule' [--quiet] add [<options>] [--] <repository> [<path>]\n"
@@ -48329,7 +48329,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:74
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "status [--cached] [--recursive] [--] [<path>...]"
 msgstr ""
 
@@ -48353,7 +48353,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:91
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "init [--] [<path>...]"
 msgstr ""
 
@@ -48383,7 +48383,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:114
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "deinit [-f|--force] (--all|[--] <path>...)"
 msgstr ""
 
@@ -48413,7 +48413,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:132
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "update [--init] [--remote] [-N|--no-fetch] [--[no-]recommend-shallow] [-f|--force] [--checkout|--rebase|--merge] [--reference <repository>] [--depth <depth>] [--recursive] [--jobs <n>] [--] [<path>...]"
 msgstr ""
 
@@ -48537,7 +48537,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:182
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "summary [--cached|--files] [(-n|--summary-limit) <n>] [commit] [--] [<path>...]"
 msgstr ""
 
@@ -48579,7 +48579,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:224
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "sync [--recursive] [--] [<path>...]"
 msgstr ""
 
@@ -49105,7 +49105,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:127
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Fetch unfetched revisions from the Subversion remote we are tracking.  The name of the [svn-remote \"...\"] section in the $GIT_DIR/config file may be specified as an optional command-line argument."
 msgstr ""
 
@@ -49551,7 +49551,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:366
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "is supported, non-numeric args are not: HEAD, NEXT, BASE, PREV, etc ..."
 msgstr ""
 
@@ -50452,7 +50452,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-svn.txt:876
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "# Clone a repo (like git clone):\n"
 "\tgit svn clone http://svn.example.com/project/trunk\n"
@@ -50505,7 +50505,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-svn.txt:924
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "# Do the initial import on a server\n"
 "\tssh server \"cd /pub && git svn clone http://svn.example.com/project [options...]\"\n"
@@ -51254,7 +51254,7 @@ msgstr "Créer, lister, supprimer ou vérifier un objet d'étiquette signé avec
 
 #. type: Plain text
 #: en/git-tag.txt:20
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git tag' [-a | -s | -u <keyid>] [-f] [-m <msg> | -F <file>] [-e]\n"
 "\t<tagname> [<commit> | <object>]\n"
@@ -51401,7 +51401,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-tag.txt:103
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "List tags. With optional `<pattern>...`, e.g. `git tag --list 'v-*'`, list only the tags that match the pattern(s)."
 msgstr ""
 
@@ -51693,13 +51693,13 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:319
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "\tgit://git..../proj.git master\n"
 msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:321
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "to get the following updates...\n"
 msgstr "pour récupérer les mises à jour suivantes…\n"
 
@@ -51711,7 +51711,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:327
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "$ git pull git://git..../proj.git master\n"
 msgstr ""
 
@@ -51836,7 +51836,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git.txt:55
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Other options are available to control how the manual page is displayed. See linkgit:git-help[1] for more information, because `git --help ...` is converted internally into `git help ...`."
 msgstr ""
 
@@ -51880,7 +51880,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git.txt:82
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Note that omitting the `=` in `git -c foo.bar ...` is allowed and sets `foo.bar` to the boolean true value (just like `[foo]bar` would in a config file). Including the equals but with an empty value (like `git -c foo.bar= ...`) sets `foo.bar` to the empty string which `git config --type=bool` will convert to `false`."
 msgstr ""
 
@@ -52084,7 +52084,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:169
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--list-cmds=group[,group...]"
 msgstr ""
 
@@ -52587,7 +52587,7 @@ msgstr "`GIT_COMMON_DIR`"
 
 #. type: Plain text
 #: en/git.txt:481
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If this variable is set to a path, non-worktree files that are normally in $GIT_DIR will be taken from this path instead. Worktree-specific files such as HEAD or index are taken from $GIT_DIR. See linkgit:gitrepository-layout[5] and linkgit:git-worktree[1] for details. This variable has lower precedence than other path variables such as GIT_INDEX_FILE, GIT_OBJECT_DIRECTORY..."
 msgstr ""
 
@@ -53058,10 +53058,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:685
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2`"
-msgstr "`GIT_TRACE`"
+msgstr "`GIT_TRACE2`"
 
 #. type: Plain text
 #: en/git.txt:689
@@ -53089,10 +53088,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:720
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE_SETUP`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2_EVENT`"
-msgstr "`GIT_TRACE_SETUP`"
+msgstr "`GIT_TRACE2_EVENT`"
 
 #. type: Plain text
 #: en/git.txt:725
@@ -53102,10 +53100,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:726
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE_PERFORMANCE`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2_PERF`"
-msgstr "`GIT_TRACE_PERFORMANCE`"
+msgstr "`GIT_TRACE2_PERF`"
 
 #. type: Plain text
 #: en/git.txt:732
@@ -53544,7 +53541,7 @@ msgstr "git-update-index - Enregistre le contenu de fichiers de l'arbre de trava
 
 #. type: Plain text
 #: en/git-update-index.txt:29
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git update-index'\n"
 "\t     [--add] [--remove | --force-remove] [--replace]\n"
@@ -54104,7 +54101,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-update-index.txt:348
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The command looks at `core.ignorestat` configuration variable.  When this is true, paths updated with `git update-index paths...` and paths updated with other Git commands that update both index and working tree (e.g. 'git apply --index', 'git checkout-index -u', and 'git read-tree -u') are automatically marked as \"assume unchanged\".  Note that \"assume unchanged\" bit is *not* set if `git update-index --refresh` finds the working tree file matches the index (use `git update-index --really-refresh` if you want to mark them as \"assume unchanged\")."
 msgstr ""
 
@@ -54973,7 +54970,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-commit.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-commit' <commit>...\n"
 msgstr ""
 
@@ -55015,7 +55012,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-pack.txt:13
-#, fuzzy, no-wrap, priority:100
+#, fuzzy, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-pack' [-v|--verbose] [-s|--stat-only] [--] <pack>.idx ...\n"
 msgstr "git verify-pack [-v | --verbose] [-s | --stat-only] <pack>..."
 
@@ -55027,7 +55024,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-verify-pack.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<pack>.idx ..."
 msgstr ""
 
@@ -55105,7 +55102,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-tag.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-tag' [--format=<format>] <tag>...\n"
 msgstr ""
 
@@ -55123,7 +55120,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-verify-tag.txt:27
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<tag>..."
 msgstr ""
 
@@ -55147,7 +55144,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-web--browse.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git web{litdd}browse' [<options>] <url|file>...\n"
 msgstr ""
 
@@ -55421,7 +55418,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-whatchanged.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git whatchanged' <option>...\n"
 msgstr ""
 
@@ -55951,7 +55948,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-worktree.txt:372
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git worktree add -b emergency-fix ../temp master\n"
 "$ pushd ../temp\n"
@@ -57157,7 +57154,7 @@ msgstr "color"
 
 #. type: Labeled list
 #: en/pretty-formats.txt:115
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'%C(...)'"
 msgstr ""
 
@@ -57169,7 +57166,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/pretty-formats.txt:129
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "\"CONFIGURATION FILE\" section of linkgit:git-config[1].  By default, colors are shown only when enabled for log output (by `color.diff`, `color.ui`, or `--color`, and respecting the `auto` settings of the former if we are going to a terminal). `%C(auto,...)` is accepted as a historical synonym for the default (e.g., `%C(auto,red)`). Specifying `%C(always,...)` will show the colors even when color is not otherwise enabled (though consider just using `--color=always` to enable color for the whole output, including this format and anything else git might color).  `auto` alone (i.e. `%C(auto)`) will turn on auto coloring on the next placeholders until the color is switched again."
 msgstr ""
 
@@ -58266,7 +58263,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/pull-fetch-param.txt:45
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "Whether that update is allowed without `--force` depends on the ref namespace it's being fetched to, the type of object being fetched, and whether the update is considered to be a fast-forward. Generally, the same rules apply for fetching as when pushing, see the `<refspec>...` section of linkgit:git-push[1] for what those are. Exceptions to those rules particular to 'git fetch' are noted below."
 msgstr ""
 
@@ -58737,13 +58734,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/revisions.txt:280
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "The '...' (three-dot) Symmetric Difference Notation"
 msgstr ""
 
 #. type: Plain text
 #: en/revisions.txt:286
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "A similar notation 'r1\\...r2' is called symmetric difference of 'r1' and 'r2' and is defined as 'r1 r2 --not $(git merge-base --all r1 r2)'.  It is the set of commits that are reachable from either one of 'r1' (left side) or 'r2' (right side) but not from both."
 msgstr ""
 
@@ -58833,7 +58830,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/revisions.txt:331
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'<rev1>\\...<rev2>'"
 msgstr ""
 
@@ -58887,7 +58884,7 @@ msgstr ""
 
 #. type: delimited block .
 #: en/revisions.txt:377
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "   Args   Expanded arguments    Selected commits\n"
 "   D                            G H D\n"
@@ -59377,7 +59374,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:256
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "For example, `--cherry-pick --right-only A...B` omits those commits from `B` which are in `A` or are patch-equivalent to a commit in `A`. In other words, this lists the `+` commits from `git cherry A B`.  More precisely, `--cherry-pick --right-only --no-merges` gives the exact list."
 msgstr ""
 
@@ -59389,7 +59386,7 @@ msgstr "--cherry"
 
 #. type: Plain text
 #: en/rev-list-options.txt:263
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "A synonym for `--right-only --cherry-mark --no-merges`; useful to limit the output to the commits on our side and mark those that have been applied to the other side of a forked history with `git log --cherry upstream...mybranch`, similar to `git cherry upstream mybranch`."
 msgstr ""
 
@@ -59401,7 +59398,7 @@ msgstr "--walk-reflogs"
 
 #. type: Plain text
 #: en/rev-list-options.txt:271
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Instead of walking the commit ancestry chain, walk reflog entries from the most recent one to older ones.  When this option is used you cannot specify commits to exclude (that is, '{caret}commit', 'commit1..commit2', and 'commit1\\...commit2' notations cannot be used)."
 msgstr ""
 
@@ -60394,7 +60391,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:875
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "`--date=format:...` feeds the format `...` to your system `strftime`, except for %z and %Z, which are handled internally.  Use `--date=format:%c` to show the date in your system locale's preferred format.  See the `strftime` manual for a complete list of format placeholders. When using `-local`, the correct syntax is `--date=format-local:...`."
 msgstr ""
 
@@ -60430,7 +60427,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:892
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Print also the parents of the commit (in the form \"commit parent...\").  Also enables parent rewriting, see 'History Simplification' above."
 msgstr ""
 
@@ -60442,7 +60439,7 @@ msgstr "--children"
 
 #. type: Plain text
 #: en/rev-list-options.txt:896
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Print also the children of the commit (in the form \"commit child...\").  Also enables parent rewriting, see 'History Simplification' above."
 msgstr ""
 
@@ -60495,13 +60492,13 @@ msgstr ""
 
 #. type: delimited block -
 #: en/rev-list-options.txt:922
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "\t$ git rev-list --left-right --boundary --pretty=oneline A...B\n"
 msgstr ""
 
 #. type: delimited block -
 #: en/rev-list-options.txt:929
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "\t>bbbbbbb... 3rd on b\n"
 "\t>bbbbbbb... 2nd on b\n"

--- a/po/documentation.hu.po
+++ b/po/documentation.hu.po
@@ -2437,7 +2437,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/config.txt:256
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The value for many variables that specify various sizes can be suffixed with `k`, `M`,... to mean \"scale the number by 1024\", \"by 1024x1024\", etc."
 msgstr ""
 
@@ -2827,7 +2827,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-format.txt:16
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "git-diff-tree [-r] <tree-ish-1> <tree-ish-2> [<pattern>...]"
 msgstr ""
 
@@ -2839,7 +2839,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-format.txt:19
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "git-diff-files [<pattern>...]"
 msgstr ""
 
@@ -3519,7 +3519,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/diff-generate-patch.txt:179
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Unlike the traditional 'unified' diff format, which shows two files A and B with a single column that has `-` (minus -- appears in A but removed in B), `+` (plus -- missing in A but added to B), or `\" \"` (space -- unchanged) prefix, this format compares two or more files file1, file2,... with one file X, and shows how X differs from each of fileN.  One column for each of fileN is prepended to the output line to note how X's line is different from it."
 msgstr ""
 
@@ -3842,7 +3842,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:137
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Generate a diffstat. By default, as much space as necessary will be used for the filename part, and the rest for the graph part. Maximum width defaults to terminal width, or 80 columns if not connected to a terminal, and can be overridden by `<width>`. The width of the filename part can be limited by giving another width `<name-width>` after a comma. The width of the graph part can be limited by using `--stat-graph-width=<width>` (affects all commands generating a stat graph) or by setting `diff.statGraphWidth=<width>` (does not affect `git format-patch`).  By giving a third parameter `<count>`, you can limit the output to the first `<count>` lines, followed by `...` if there are more."
 msgstr ""
 
@@ -3890,13 +3890,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:161
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "-X[<param1,param2,...>]"
 msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:162
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--dirstat[=<param1,param2,...>]"
 msgstr ""
 
@@ -3986,13 +3986,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:209
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--dirstat-by-file[=<param1,param2>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:211
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Synonym for --dirstat=files,param1,param2..."
 msgstr ""
 
@@ -4653,13 +4653,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:527
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--diff-filter=[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:538
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Select only files that are Added (`A`), Copied (`C`), Deleted (`D`), Modified (`M`), Renamed (`R`), have their type (i.e. regular file, symlink, submodule, ...) changed (`T`), are Unmerged (`U`), are Unknown (`X`), or have had their pairing Broken (`B`).  Any combination of the filter characters (including none) can be used.  When `*` (All-or-none) is added to the combination, all paths are selected if there is any file that matches other criteria in the comparison; if there is no file that matches other criteria, nothing is selected."
 msgstr ""
 
@@ -4719,7 +4719,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/diff-options.txt:573
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "+    return !regexec(regexp, two->ptr, 1, &regmatch, 0);\n"
 "...\n"
@@ -5642,7 +5642,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-add.txt:15
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "'git add' [--verbose | -v] [--dry-run | -n] [--force | -f] [--interactive | -i] [--patch | -p]\n"
 "\t  [--edit | -e] [--[no-]all | --[no-]ignore-removal | [--update | -u]]\n"
@@ -5700,7 +5700,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-add.txt:52 en/git-grep.txt:308 en/git-status.txt:148
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid "<pathspec>..."
 msgstr ""
 
@@ -5844,7 +5844,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-add.txt:145
-#, priority:300
+#, ignore-ellipsis, priority:300
 msgid "This option is primarily to help users who are used to older versions of Git, whose \"git add <pathspec>...\" was a synonym for \"git add --no-all <pathspec>...\", i.e. ignored removed files."
 msgstr ""
 
@@ -6342,7 +6342,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-am.txt:20
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git am' [--signoff] [--keep] [--[no-]keep-cr] [--[no-]utf8]\n"
 "\t [--[no-]3way] [--interactive] [--committer-date-is-author-date]\n"
@@ -6362,7 +6362,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-am.txt:29
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "(<mbox>|<Maildir>)..."
 msgstr ""
 
@@ -6898,7 +6898,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-apply.txt:20
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git apply' [--stat] [--numstat] [--summary] [--check] [--index | --intent-to-add] [--3way]\n"
 "\t  [--apply] [--no-add] [--build-fake-ancestor=<file>] [-R | --reverse]\n"
@@ -6924,7 +6924,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-apply.txt:37
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<patch>..."
 msgstr ""
 
@@ -7338,7 +7338,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-archimport.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git archimport' [-h] [-v] [-o] [-a] [-f] [-T] [-D depth] [-t tempdir]\n"
 "               <archive/branch>[:<git-branch>] ...\n"
@@ -7502,7 +7502,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-archive.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git archive' [--format=<fmt>] [--list] [--prefix=<prefix>/] [<extra>]\n"
 "\t      [-o <file> | --output=<file>] [--worktree-attributes]\n"
@@ -7890,7 +7890,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bisect.txt:31
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 " git bisect start [--term-{old,good}=<term> --term-{new,bad}=<term>]\n"
 "\t\t  [--no-checkout] [<bad> [<good>...]] [--] [<paths>...]\n"
@@ -8085,7 +8085,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-bisect.txt:158
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git bisect new [<rev>...]\n"
 msgstr ""
 
@@ -8115,7 +8115,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bisect.txt:175
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If you would like to use your own terms instead of \"bad\"/\"good\" or \"new\"/\"old\", you can choose any names you like (except existing bisect subcommands like `reset`, `start`, ...) by starting the bisection using"
 msgstr ""
 
@@ -8555,7 +8555,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-bisect.txt:463
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git bisect start HEAD <known-good-commit> [ <boundary-commit> ... ] --no-checkout\n"
 "$ git bisect run sh -c '\n"
@@ -9023,7 +9023,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:26
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git branch' [--color[=<when>] | --no-color] [--show-current]\n"
 "\t[-v [--abbrev=<length> | --no-abbrev]]\n"
@@ -9068,7 +9068,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:61
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "The command's second form creates a new branch head named <branchname> which points to the current `HEAD`, or <start-point> if given. As a special case, for <start-point>, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -9266,7 +9266,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:176
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "List branches.  With optional `<pattern>...`, e.g. `git branch --list 'maint-*'`, list only the branches that match the pattern(s)."
 msgstr ""
 
@@ -9512,7 +9512,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:291
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "Sort based on the key given. Prefix `-` to sort in descending order of the value. You may use the --sort=<key> option multiple times, in which case the last key becomes the primary key. The keys supported are the same as those in `git for-each-ref`. Sort order defaults to the value configured for the `branch.sort` variable if exists, or to sorting based on the full refname (including `refs/...` prefix). This lists detached HEAD (if present) first, then local branches and finally remote-tracking branches. See linkgit:git-config[1]."
 msgstr ""
 
@@ -9554,7 +9554,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-branch.txt:317
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git clone git://git.kernel.org/pub/scm/.../linux-2.6 my2.6\n"
 "$ cd my2.6\n"
@@ -9576,7 +9576,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-branch.txt:329
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git clone git://git.kernel.org/.../git.git my.git\n"
 "$ cd my.git\n"
@@ -9690,7 +9690,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bundle.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git bundle' create <file> <git-rev-list-args>\n"
 "'git bundle' verify <file>\n"
@@ -9766,7 +9766,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-bundle.txt:71
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<refname>...]"
 msgstr ""
 
@@ -10542,7 +10542,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-attr.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git check-attr' [-a | --all | <attr>...] [--] <pathname>...\n"
 "'git check-attr' --stdin [-z] [-a | --all | <attr>...]\n"
@@ -10783,7 +10783,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-ignore.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git check-ignore' [<options>] <pathname>...\n"
 "'git check-ignore' [<options>] --stdin\n"
@@ -10959,7 +10959,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-mailmap.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git check-mailmap' [<options>] <contact>...\n"
 msgstr ""
 
@@ -10995,7 +10995,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout-index.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git checkout-index' [-u] [-q] [-a] [-f] [-n] [--prefix=<string>]\n"
 "\t\t   [--stage=<number>|all]\n"
@@ -11270,7 +11270,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:18
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git checkout' [-q] [-f] [-m] [<branch>]\n"
 "'git checkout' [-q] [-f] [-m] --detach [<branch>]\n"
@@ -11381,7 +11381,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-checkout.txt:82
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git checkout' [<tree-ish>] [--] <pathspec>..."
 msgstr ""
 
@@ -11399,7 +11399,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-checkout.txt:98
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git checkout' (-p|--patch) [<tree-ish>] [--] [<pathspec>...]"
 msgstr ""
 
@@ -11741,7 +11741,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:326 en/git-switch.txt:58
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "As a special case, you may use `A...B` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -11771,7 +11771,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:337
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "As a special case, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -12342,7 +12342,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git cherry-pick' [--edit] [-n] [-m parent-number] [-s] [-x] [--ff]\n"
 "\t\t  [-S[<keyid>]] <commit>...\n"
@@ -12399,13 +12399,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-cherry-pick.txt:43 en/git-merge.txt:116 en/git-revert.txt:36 en/git-verify-commit.txt:27
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "<commit>..."
 msgstr ""
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:52
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Commits to cherry-pick.  For a more complete list of ways to spell commits, see linkgit:gitrevisions[7].  Sets of commits can be passed but no traversal is done by default, as if the `--no-walk` option was specified, see linkgit:git-rev-list[1]. Note that specifying a range will feed all <commit>... arguments to a single revision walk (see a later example that uses 'maint master..next')."
 msgstr ""
 
@@ -12435,7 +12435,7 @@ msgstr "-x"
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:78
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When recording the commit, append a line that says \"(cherry picked from commit ...)\" to the original commit message in order to indicate which commit this change was cherry-picked from.  This is done only for cherry picks without conflicts.  Do not use this option if you are cherry-picking from your private branch because the information is useless to the recipient.  If on the other hand you are cherry-picking between two publicly visible branches (e.g. backporting a fix to a maintenance branch for an older release from a development branch), adding this information can be useful."
 msgstr ""
 
@@ -12793,7 +12793,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:58
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git checkout -b topic origin/master\n"
 "# work and create some commits\n"
@@ -12829,7 +12829,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git log --graph --oneline --decorate --boundary origin/master...topic\n"
 "* 7654321 (origin/master) upstream tip commit\n"
@@ -12852,7 +12852,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:96
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git cherry origin/master topic\n"
 "- cccc000... commit C\n"
@@ -12880,7 +12880,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:126
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git log --graph --oneline --decorate --boundary origin/master...topic\n"
 "* 7654321 (origin/master) upstream tip commit\n"
@@ -12906,7 +12906,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:136
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git cherry origin/master topic base\n"
 "- cccc000... commit C\n"
@@ -12958,7 +12958,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-clean.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git clean' [-d] [-f] [-i] [-n] [-q] [-e <pattern>] [-x | -X] [--] <path>...\n"
 msgstr ""
 
@@ -12976,7 +12976,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-clean.txt:25
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If any optional `<path>...` arguments are given, only those paths are affected."
 msgstr ""
 
@@ -13587,7 +13587,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-clone.txt:306
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "$ git clone git://git.kernel.org/pub/scm/.../linux.git my-linux\n"
 "$ cd my-linux\n"
@@ -13617,7 +13617,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-clone.txt:325
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "$ git clone --reference /git/linux.git \\\n"
 "\tgit://git.kernel.org/pub/scm/.../linux.git \\\n"
@@ -13810,7 +13810,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-commit-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git commit-tree' <tree> [(-p <parent>)...]\n"
 "'git commit-tree' [(-p <parent>)...] [-S[<keyid>]] [(-m <message>)...]\n"
@@ -14011,7 +14011,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-commit.txt:17
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git commit' [-a | --interactive | --patch] [-s] [-v] [-u<mode>] [--amend]\n"
 "\t   [--dry-run] [(-c | -C | --fixup | --squash) <commit>]\n"
@@ -14431,7 +14431,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-commit.txt:248
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "\t$ git reset --soft HEAD^\n"
 "\t$ ... do something else to come up with the right tree ...\n"
@@ -14596,7 +14596,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-commit.txt:346 en/git-rm.txt:29
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "<file>..."
 msgstr ""
 
@@ -15573,7 +15573,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-config.txt:428
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "However, if you really only want to replace the line for the default proxy, i.e. the one without a \"for ...\" postfix, do something like this:"
 msgstr ""
 
@@ -16931,7 +16931,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-cvsserver.txt:26
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git-cvsserver' [<options>] [pserver|server] [<directory> ...]\n"
 msgstr ""
 
@@ -17629,7 +17629,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-daemon.txt:25
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git daemon' [--verbose] [--syslog] [--export-all]\n"
 "\t     [--timeout=<n>] [--init-timeout=<n>] [--max-connections=<n>]\n"
@@ -18195,7 +18195,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-describe.txt:14
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "'git describe' [--all] [--tags] [--contains] [--abbrev=<n>] [<commit-ish>...]\n"
 "'git describe' [--all] [--tags] [--contains] [--abbrev=<n>] --dirty[=<mark>]\n"
@@ -18222,7 +18222,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-describe.txt:37
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "<commit-ish>..."
 msgstr ""
 
@@ -18318,7 +18318,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-describe.txt:95
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Always output the long format (the tag, the number of commits and the abbreviated commit name) even when it matches a tag.  This is useful when you want to see parts of the commit object name in \"describe\" output, even when the commit in question happens to be a tagged version.  Instead of just emitting the tag name, it will describe such a commit as v1.2-0-gdeadbee (0th commit since tag v1.2 that points at object deadbee....)."
 msgstr ""
 
@@ -18496,7 +18496,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-files.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git diff-files' [-q] [-0|-1|-2|-3|-c|--cc] [<common diff options>] [<path>...]\n"
 msgstr ""
 
@@ -18568,7 +18568,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-index.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git diff-index' [-m] [--cached] [<common diff options>] <tree-ish> [<path>...]\n"
 msgstr ""
 
@@ -18707,7 +18707,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-index.txt:102
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "  torvalds@ppc970:~/v2.6/linux> git diff-index --abbrev HEAD\n"
 "  :100644 100664 7476bb... 000000...      kernel/sched.c\n"
@@ -18745,7 +18745,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-difftool.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git difftool' [<options>] [<commit> [<commit>]] [--] [<path>...]\n"
 msgstr ""
 
@@ -19057,7 +19057,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git diff-tree' [--stdin] [-m] [-s] [-v] [--no-commit-id] [--pretty]\n"
 "\t      [-t] [-r] [-c | --cc] [--combined-all-paths] [--root]\n"
@@ -19090,7 +19090,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff-tree.txt:32 en/git-diff.txt:114 en/git-submodule.txt:422
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "<path>..."
 msgstr ""
 
@@ -19216,7 +19216,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:17
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git diff' [<options>] [<commit>] [--] [<path>...]\n"
 "'git diff' [<options>] --cached [<commit>] [--] [<path>...]\n"
@@ -19233,7 +19233,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:24
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] [--] [<path>...]"
 msgstr ""
 
@@ -19257,7 +19257,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:41
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] --cached [<commit>] [--] [<path>...]"
 msgstr ""
 
@@ -19269,7 +19269,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:51
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit> [--] [<path>...]"
 msgstr ""
 
@@ -19281,7 +19281,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:59
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit> <commit> [--] [<path>...]"
 msgstr ""
 
@@ -19293,7 +19293,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:64
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit>..<commit> [--] [<path>...]"
 msgstr ""
 
@@ -19305,13 +19305,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:70
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit>\\...<commit> [--] [<path>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:77
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "This form is to view the changes on the branch containing and up to the second <commit>, starting at a common ancestor of both <commit>.  \"git diff A\\...B\" is equivalent to \"git diff $(git merge-base A B) B\".  You can omit any one of <commit>, which has the same effect as using HEAD instead."
 msgstr ""
 
@@ -19323,7 +19323,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:89
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "For a more complete list of ways to spell <commit>, see \"SPECIFYING REVISIONS\" section in linkgit:gitrevisions[7].  However, \"diff\" is about comparing two _endpoints_, not ranges, and the range notations (\"<commit>..<commit>\" and \"<commit>\\...<commit>\") do not mean a range as defined in the \"SPECIFYING RANGES\" section in linkgit:gitrevisions[7]."
 msgstr ""
 
@@ -19431,7 +19431,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-diff.txt:160
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git diff topic master    <1>\n"
 "$ git diff topic..master   <2>\n"
@@ -19751,7 +19751,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:143
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<git-rev-list-args>...]"
 msgstr ""
 
@@ -19832,7 +19832,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-fast-export.txt:215
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git init anon-repo\n"
 "$ cd anon-repo\n"
@@ -22142,7 +22142,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch-pack.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git fetch-pack' [--all] [--quiet|-q] [--keep|-k] [--thin] [--include-tag]\n"
 "\t[--upload-pack=<git-upload-pack>]\n"
@@ -22296,7 +22296,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fetch-pack.txt:117 en/git-ls-remote.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<refs>..."
 msgstr ""
 
@@ -22326,7 +22326,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch.txt:16
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git fetch' [<options>] [<repository> [<refspec>...]]\n"
 "'git fetch' [<options>] <group>\n"
@@ -22667,7 +22667,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch.txt:226
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "For a successfully fetched ref, the summary shows the old and new values of the ref in a form suitable for using as an argument to `git log` (this is `<old>..<new>` in most cases, and `<old>...<new>` for forced non-fast-forward updates)."
 msgstr ""
 
@@ -22789,7 +22789,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:18
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git filter-branch' [--setup <command>] [--subdirectory-filter <directory>]\n"
 "\t[--env-filter <command>] [--tree-filter <command>]\n"
@@ -22928,7 +22928,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:117
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for rewriting the index.  It is similar to the tree filter but does not check out the tree, which makes it much faster.  Frequently used with `git rm --cached --ignore-unmatch ...`, see EXAMPLES below.  For hairy cases, see linkgit:git-update-index[1]."
 msgstr ""
 
@@ -22940,7 +22940,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:125
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for rewriting the commit's parent list.  It will receive the parent string on stdin and shall output the new parent string on stdout.  The parent string is in the format described in linkgit:git-commit-tree[1]: empty for the initial commit, \"-p parent\" for a normal commit and \"-p parent1 -p parent2 -p parent3 ...\" for a merge commit."
 msgstr ""
 
@@ -22964,7 +22964,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:138
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for performing the commit.  If this filter is specified, it will be called instead of the 'git commit-tree' command, with arguments of the form \"<TREE_ID> [(-p <PARENT_COMMIT_ID>)...]\" and the log message on stdin.  The commit id is expected on stdout."
 msgstr ""
 
@@ -23066,7 +23066,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-filter-branch.txt:207
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<rev-list options>..."
 msgstr ""
 
@@ -23327,7 +23327,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-filter-branch.txt:388
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git filter-branch ... C..H\n"
 msgstr ""
 
@@ -23339,7 +23339,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-filter-branch.txt:395
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "git filter-branch ... C..H --not D\n"
 "git filter-branch ... D..H --not C\n"
@@ -23578,7 +23578,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git for-each-ref' [--count=<count>] [--shell|--perl|--python|--tcl]\n"
 "\t\t   [(--sort=<key>)...] [--format=<format>] [<pattern>...]\n"
@@ -23595,7 +23595,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-for-each-ref.txt:29 en/git-show-ref.txt:88
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<pattern>..."
 msgstr ""
 
@@ -23883,7 +23883,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:197
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Left-, middle-, or right-align the content between %(align:...) and %(end). The \"align:\" is followed by `width=<width>` and `position=<position>` in any order separated by a comma, where the `<position>` is either left, right or middle, default being left and `<width>` is the total length of the content with alignment. For brevity, the \"width=\" and/or \"position=\" prefixes may be omitted, and bare <width> and <position> used instead.  For instance, `%(align:<width>,<position>)`. If the contents length is more than the width then no alignment is performed. If used with `--quote` everything in between %(align:...) and %(end) is quoted, but if nested then only the topmost level performs quoting."
 msgstr ""
 
@@ -23895,7 +23895,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:210
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Used as %(if)...%(then)...%(end) or %(if)...%(then)...%(else)...%(end).  If there is an atom with value or string literal after the %(if) then everything after the %(then) is printed, else if the %(else) atom is used, then everything after %(else) is printed. We ignore space when evaluating the string before %(then), this is useful when we use the %(HEAD) atom which prints either \"*\" or \" \" and we want to apply the 'if' condition only on the 'HEAD' ref.  Append \":equals=<string>\" or \":notequals=<string>\" to compare the value between the %(if:...) and %(then) atoms with the given string."
 msgstr ""
 
@@ -24116,7 +24116,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:361
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "An example to show the usage of %(if)...%(then)...%(else)...%(end).  This prefixes the current branch with a star."
 msgstr ""
 
@@ -24128,7 +24128,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:369
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "An example to show the usage of %(if)...%(then)...%(end).  This prints the authorname, if present."
 msgstr ""
 
@@ -24774,7 +24774,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:372
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "Do the same for ia64 so we can have sleek & trim looking\n"
 "...\n"
@@ -24782,7 +24782,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:380
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Typically it will be placed in a MUA's drafts folder, edited to add timely commentary that should not go in the changelog after the three dashes, and then sent as a message whose body, in our example, starts with \"arch/arm config files were...\".  On the receiving end, readers can save interesting patches in a UNIX mailbox and apply them with linkgit:git-am[1]."
 msgstr ""
 
@@ -24794,7 +24794,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:390
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "...\n"
 "> So we should do such-and-such.\n"
@@ -24816,7 +24816,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:398
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "arch/arm config files were slimmed down using a python script\n"
 "...\n"
@@ -24990,7 +24990,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:499
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Configure your mail server composition as plain text: Edit...Account Settings...Composition & Addressing, uncheck \"Compose Messages in HTML\"."
 msgstr ""
 
@@ -25127,7 +25127,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:573
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Use Message -> Insert file... and insert the patch."
 msgstr ""
 
@@ -25302,7 +25302,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fsck-objects.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git fsck-objects' ...\n"
 msgstr ""
 
@@ -25690,7 +25690,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-gc.txt:55
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Once housekeeping is triggered by exceeding the limits of configuration options such as `gc.auto` and `gc.autoPackLimit`, all other housekeeping tasks (e.g. rerere, working trees, reflog...) will be performed as well."
 msgstr ""
 
@@ -25864,7 +25864,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-grep.txt:32
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git grep' [-a | --text] [-I] [--textconv] [-i | --ignore-case] [-w | --word-regexp]\n"
 "\t   [-v | --invert-match] [-h|-H] [--full-name]\n"
@@ -26472,7 +26472,7 @@ msgstr "--not"
 
 #. type: Labeled list
 #: en/git-grep.txt:284
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "( ... )"
 msgstr ""
 
@@ -26502,7 +26502,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-grep.txt:300
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<tree>..."
 msgstr ""
 
@@ -26820,7 +26820,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-hash-object.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git hash-object' [-t <type>] [-w] [--path=<file>|--no-filters] [--stdin [--literally]] [--] <file>...\n"
 "'git hash-object' [-t <type>] [-w] --stdin-paths [--no-filters]\n"
@@ -26950,7 +26950,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-help.txt:38
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Note that `git --help ...` is identical to `git help ...` because the former is internally converted into the latter."
 msgstr ""
 
@@ -27400,7 +27400,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:102
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tAuthType Basic\n"
 "\tAuthName \"Git Access\"\n"
@@ -27418,7 +27418,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:115
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "<LocationMatch \"^/git/.*/git-receive-pack$\">\n"
 "\tAuthType Basic\n"
@@ -27442,7 +27442,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:136
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "<Location /git/private>\n"
 "\tAuthType Basic\n"
@@ -27592,7 +27592,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:231
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "auth.require = (\n"
 "\t\"/\" => (\n"
@@ -27795,7 +27795,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-http-push.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git http-push' [--all] [--dry-run] [--force] [--verbose] <url> <ref> [<ref>...]\n"
 msgstr ""
 
@@ -27864,7 +27864,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-http-push.txt:54 en/git-send-pack.txt:98
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<ref>..."
 msgstr ""
 
@@ -28729,7 +28729,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-interpret-trailers.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git interpret-trailers' [<options>] [(--trailer <token>[(=|:)<value>])...] [<file>...]\n"
 "'git interpret-trailers' [<options>] [--parse] [<file>...]\n"
@@ -29399,7 +29399,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-log.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'git log' [<options>] [<revision range>] [[--] <path>...]\n"
 msgstr ""
 
@@ -29495,7 +29495,7 @@ msgstr "--full-diff"
 
 #. type: Plain text
 #: en/git-log.txt:63
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Without this flag, `git log -p <path>...` shows commits that touch the specified paths, and diffs about the same specified paths.  With this, the full diff is shown for commits that touch the specified paths; this means that \"<path>...\" limits only commits, and doesn't limit diff for those commits."
 msgstr ""
 
@@ -29549,7 +29549,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-log.txt:93 en/git-shortlog.txt:72
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "[--] <path>..."
 msgstr ""
 
@@ -29825,7 +29825,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-files.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-files' [-z] [-t] [-v] [-f]\n"
 "\t\t(--[cached|deleted|others|ignored|stage|unmerged|killed|modified])*\n"
@@ -30306,7 +30306,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-remote.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-remote' [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
 "\t      [-q | --quiet] [--exit-code] [--get-url] [--sort=<key>]\n"
@@ -30411,7 +30411,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-remote.txt:91
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When unspecified, all references, after filtering done with --heads and --tags, are shown.  When <refs>... are specified, only references matching the given patterns are displayed."
 msgstr ""
 
@@ -30456,7 +30456,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-tree' [-d] [-r] [-t] [-l] [-z]\n"
 "\t    [--name-only] [--name-status] [--full-name] [--full-tree] [--abbrev[=<n>]]\n"
@@ -30537,7 +30537,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-ls-tree.txt:76
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<path>...]"
 msgstr ""
 
@@ -30747,7 +30747,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mailsplit.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git mailsplit' [-b] [-f<nn>] [-d<prec>] [--keep-cr] [--mboxrd]\n"
 "\t\t-o<directory> [--] [(<mbox>|<Maildir>)...]\n"
@@ -30869,7 +30869,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git merge-base' [-a|--all] <commit> <commit>...\n"
 "'git merge-base' [-a|--all] --octopus <commit>...\n"
@@ -31066,7 +31066,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:139
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tA=$(git rev-parse --verify A)\n"
 "\tif test \"$A\" = \"$(git merge-base A B)\"\n"
@@ -31083,7 +31083,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:146
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tif git merge-base --is-ancestor A B\n"
 "\tthen\n"
@@ -31570,7 +31570,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mergetool.txt:12
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git mergetool' [--tool=<tool>] [-y | --[no-]prompt] [<file>...]\n"
 msgstr ""
 
@@ -31732,7 +31732,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge.txt:17
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git merge' [-n] [--stat] [--no-commit] [--squash] [--[no-]edit]\n"
 "\t[-s <strategy>] [-X <strategy-option>] [-S[<keyid>]]\n"
@@ -32325,7 +32325,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mv.txt:13
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git mv' <options>... <args>...\n"
 msgstr ""
 
@@ -32337,7 +32337,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mv.txt:20
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 " git mv [-v] [-f] [-n] [-k] <source> <destination>\n"
 " git mv [-v] [-f] [-n] [-k] <source> ... <destination directory>\n"
@@ -32405,7 +32405,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-name-rev.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git name-rev' [--tags] [--refs=<pattern>]\n"
 "\t       ( --all | --stdin | <commit-ish>... )\n"
@@ -32523,7 +32523,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-notes.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git notes' [list [<object>]]\n"
 "'git notes' add [-f] [--allow-empty] [-F <file> | -m <msg> | (-c | -C) <object>] [<object>]\n"
@@ -32859,7 +32859,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-notes.txt:229
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Commit notes are blobs containing extra information about an object (usually information to supplement a commit's message).  These blobs are taken from notes refs.  A notes ref is usually a branch which contains \"files\" whose paths are the object names for the objects they describe, with some directory separators included for performance reasons footnote:[Permitted pathnames have the form 'ab'`/`'cd'`/`'ef'`/`'...'`/`'abcdef...': a sequence of directory names of two hexadecimal digits each followed by a filename with the rest of the object ID.]."
 msgstr ""
 
@@ -32925,7 +32925,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-notes.txt:288
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git notes add -m 'Tested-by: Johannes Sixt <j6t@kdbg.org>' 72a144e2\n"
 "$ git show -s 72a144e\n"
@@ -33144,7 +33144,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-p4.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git p4 clone' [<sync options>] [<clone options>] <p4 depot path>...\n"
 "'git p4 sync' [<sync options>] [<p4 depot path>...]\n"
@@ -33977,7 +33977,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-p4.txt:445
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The full syntax for a p4 view is documented in 'p4 help views'.  'git p4' knows only a subset of the view syntax.  It understands multi-line mappings, overlays with '+', exclusions with '-' and double-quotes around whitespace.  Of the possible wildcards, 'git p4' only handles '...', and only when it is at the end of the path.  'git p4' will complain if it encounters an unhandled wildcard."
 msgstr ""
 
@@ -34019,7 +34019,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-p4.txt:475
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "//depot/main/...\n"
 "//depot/branch1/...\n"
@@ -34033,7 +34033,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-p4.txt:480
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "//depot/main/... //depot/branch1/...\n"
 msgstr ""
 
@@ -35150,7 +35150,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-pack-redundant.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git pack-redundant' [ --verbose ] [ --alt-odb ] < --all | .pack filename ... >\n"
 msgstr ""
 
@@ -35450,7 +35450,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-prune.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git prune' [-n] [-v] [--progress] [--expire <time>] [--] [<head>...]\n"
 msgstr ""
 
@@ -35504,7 +35504,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-prune.txt:54
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<head>..."
 msgstr ""
 
@@ -35558,7 +35558,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-pull.txt:13
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "'git pull' [<options>] [<repository> [<refspec>...]]\n"
 msgstr ""
 
@@ -35906,7 +35906,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:18
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git push' [--all | --mirror | --tags] [--follow-tags] [--atomic] [-n | --dry-run] [--receive-pack=<git-receive-pack>]\n"
 "\t   [--repo=<repository>] [-f | --force] [-d | --delete] [--prune] [-v | --verbose]\n"
@@ -35936,7 +35936,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:39
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "When the command line does not specify what to push with `<refspec>...` arguments or `--all`, `--mirror`, `--tags` options, the command finds the default `<refspec>` by consulting `remote.*.push` configuration, and if it is not found, honors `push.default` configuration to decide what to push (See linkgit:git-config[1] for the meaning of `push.default`)."
 msgstr ""
 
@@ -35960,7 +35960,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:56
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "<refspec>..."
 msgstr ""
 
@@ -36320,7 +36320,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:343
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "Note that `--force` applies to all the refs that are pushed, hence using it with `push.default` set to `matching` or with multiple push destinations configured with `remote.*.push` may overwrite refs other than the current branch (including local refs that are strictly behind their remote counterpart).  To force a push to only one branch, use a `+` in front of the refspec to push (e.g `git push origin +master` to force a push to the `master` branch). See the `<refspec>...` section above for details."
 msgstr ""
 
@@ -36452,7 +36452,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:445
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "For a successfully pushed ref, the summary shows the old and new values of the ref in a form suitable for using as an argument to `git log` (this is `<old>..<new>` in most cases, and `<old>...<new>` for forced non-fast-forward updates)."
 msgstr ""
 
@@ -36713,7 +36713,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:616
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "See the section describing `<refspec>...` above for a discussion of the matching semantics."
 msgstr ""
 
@@ -37414,7 +37414,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-read-tree.txt:357
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git fetch git://.... linus\n"
 "$ LT=`git rev-parse FETCH_HEAD`\n"
@@ -37468,7 +37468,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-read-tree.txt:405
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "'git read-tree' and other merge-based commands ('git merge', 'git checkout'...) can help maintaining the skip-worktree bitmap and working directory update. `$GIT_DIR/info/sparse-checkout` is used to define the skip-worktree reference bitmap. When 'git read-tree' needs to update the working directory, it resets the skip-worktree bit in the index based on this file, which uses the same syntax as .gitignore files.  If an entry matches a pattern in this file, skip-worktree will not be set on that entry. Otherwise, skip-worktree will be set."
 msgstr ""
 
@@ -37848,7 +37848,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:219
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "As a special case, you may use \"A\\...B\" as a shortcut for the merge base of A and B if there is exactly one merge base. You can leave out at most one of A and B, in which case it defaults to HEAD."
 msgstr ""
 
@@ -38112,7 +38112,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:430
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "It is currently only possible to recreate the merge commits using the `recursive` merge strategy; Different merge strategies can be used only via explicit `exec git merge -s <strategy> [...]` commands."
 msgstr ""
 
@@ -38166,7 +38166,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:457
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "\tgit rebase -i --exec \"cmd1 && cmd2 && ...\"\n"
 msgstr ""
 
@@ -38178,7 +38178,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:461
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "\tgit rebase -i --exec \"cmd1\" --exec \"cmd2\" --exec ...\n"
 msgstr ""
 
@@ -38214,7 +38214,7 @@ msgstr "--no-autosquash"
 
 #. type: Plain text
 #: en/git-rebase.txt:495
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When the commit log message begins with \"squash! ...\" (or \"fixup! ...\"), and there is already a commit in the todo list that matches the same `...`, automatically modify the todo list of rebase -i so that the commit marked for squashing comes right after the commit to be modified, and change the action of the moved commit from `pick` to `squash` (or `fixup`).  A commit matches the `...` if the commit subject matches, or if the `...` refers to the commit's hash. As a fall-back, partial matches of the commit subject work, too.  The recommended way to create fixup/squash commits is by using the `--fixup`/`--squash` options of linkgit:git-commit[1]."
 msgstr ""
 
@@ -38541,7 +38541,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:636
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "pick deadbee The oneline of this commit\n"
 "pick fa1afe1 The oneline of the next commit\n"
@@ -38645,7 +38645,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:710
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "pick deadbee Implement feature XXX\n"
 "fixup f1a5c00 Fix to feature XXX\n"
@@ -38664,7 +38664,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:720
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The \"exec\" command launches the command in a shell (the one specified in `$SHELL`, or the default shell if `$SHELL` is not set), so you can use shell features (like \"cd\", \">\", \";\" ...). The command is run from the root of the working tree."
 msgstr ""
 
@@ -38808,7 +38808,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:815
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "    o---o---o---o---o---o---o---o  master\n"
 "\t \\\t\t\t \\\n"
@@ -39606,7 +39606,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reflog.txt:27
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git reflog' ['show'] [log-options] [<ref>]\n"
 "'git reflog expire' [--expire=<time>] [--expire-unreachable=<time>]\n"
@@ -39793,7 +39793,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-remote-ext.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git remote add <nick> \"ext::<command>[ <arguments>...]\"\n"
 msgstr ""
 
@@ -39931,7 +39931,7 @@ msgstr "GIT_EXT_SERVICE"
 
 #. type: Plain text
 #: en/git-remote-ext.txt:70
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Set to long name (git-upload-pack, etc...) of service helper needs to invoke."
 msgstr ""
 
@@ -39943,7 +39943,7 @@ msgstr "GIT_EXT_SERVICE_NOPREFIX"
 
 #. type: Plain text
 #: en/git-remote-ext.txt:74
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Set to long name (upload-pack, etc...) of service helper needs to invoke."
 msgstr ""
 
@@ -40123,7 +40123,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-remote.txt:25
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git remote' [-v | --verbose]\n"
 "'git remote add' [-t <branch>] [-m <master>] [-f] [--[no-]tags] [--mirror=<fetch|push>] <name> <url>\n"
@@ -40442,7 +40442,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-remote.txt:235
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "$ git remote\n"
 "origin\n"
@@ -40686,7 +40686,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-replace.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git replace' [-f] <object> <replacement>\n"
 "'git replace' [-f] --edit <object>\n"
@@ -40806,13 +40806,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-replace.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--graft <commit> [<parent>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/git-replace.txt:93
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Create a graft commit. A new commit is created with the same content as <commit> except that its parents will be [<parent>...] instead of <commit>'s parents. A replacement ref is then created to replace <commit> with the newly created commit. Use `--convert-graft-file` to convert a `$GIT_DIR/info/grafts` file and use replace refs instead."
 msgstr ""
 
@@ -41234,7 +41234,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rerere.txt:121
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git switch topic\n"
 "\t$ git merge master\n"
@@ -41266,7 +41266,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rerere.txt:145
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git switch topic\n"
 "\t$ git merge master\n"
@@ -41371,7 +41371,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reset.txt:14
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git reset' [-q] [<tree-ish>] [--] <paths>...\n"
 "'git reset' (--patch | -p) [<tree-ish>] [--] [<paths>...]\n"
@@ -41386,7 +41386,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-reset.txt:22
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git reset' [-q] [<tree-ish>] [--] <paths>..."
 msgstr ""
 
@@ -41398,7 +41398,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reset.txt:30
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "This means that `git reset <paths>` is the opposite of `git add <paths>`. This command is equivalent to `git restore [--source=<tree-ish>] --staged <paths>...`."
 msgstr ""
 
@@ -41410,7 +41410,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-reset.txt:38
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git reset' (--patch | -p) [<tree-ish>] [--] [<paths>...]"
 msgstr ""
 
@@ -41565,7 +41565,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:138
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git commit ...\n"
 "$ git reset --soft HEAD^      <1>\n"
@@ -41638,7 +41638,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:170
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git commit ...\n"
 "$ git reset --hard HEAD~3   <1>\n"
@@ -41658,7 +41658,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:190
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git pull                         <1>\n"
 "Auto-merging nitfol\n"
@@ -41703,7 +41703,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:215
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git pull                         <1>\n"
 "Auto-merging nitfol\n"
@@ -41829,7 +41829,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:289
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git tag start\n"
 "$ git switch -c branch1\n"
@@ -41872,7 +41872,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:317
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git reset -N HEAD^                        <1>\n"
 "$ git add -p                                <2>\n"
@@ -42098,7 +42098,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-restore.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git restore' [<options>] [--source=<tree>] [--staged] [--worktree] <pathspec>...\n"
 "'git restore' (-p|--patch) [<options>] [--source=<tree>] [--staged] [--worktree] [<pathspec>...]\n"
@@ -42351,7 +42351,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-revert.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git revert' [--[no-]edit] [-n] [-m parent-number] [-s] [-S[<keyid>]] <commit>...\n"
 "'git revert' (--continue | --skip | --abort | --quit)\n"
@@ -42455,7 +42455,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-list.txt:65
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git rev-list' [ --max-count=<number> ]\n"
 "\t     [ --skip=<number> ]\n"
@@ -42558,13 +42558,13 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-list.txt:102
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Another special notation is \"'<commit1>'...'<commit2>'\" which is useful for merges.  The resulting set of commits is the symmetric difference between the two operands.  The following two commands are equivalent:"
 msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-list.txt:106
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git rev-list A B --not $(git merge-base --all A B)\n"
 "\t$ git rev-list A...B\n"
@@ -42590,7 +42590,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-parse.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git rev-parse' [<options>] <args>...\n"
 msgstr ""
 
@@ -43074,7 +43074,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-parse.txt:253
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Resolve \"$GIT_DIR/<path>\" and takes other path relocation variables such as $GIT_OBJECT_DIRECTORY, $GIT_INDEX_FILE... into account. For example, if $GIT_OBJECT_DIRECTORY is set to /foo/bar then \"git rev-parse --git-path objects/abc\" returns /foo/bar/abc."
 msgstr ""
 
@@ -43182,7 +43182,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:290
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<args>..."
 msgstr ""
 
@@ -43314,7 +43314,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:364
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "OPTS_SPEC=\"\\\n"
 "some-command [<options>] <args>...\n"
@@ -43372,7 +43372,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:389
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "usage: some-command [<options>] <args>...\n"
 msgstr ""
 
@@ -43384,7 +43384,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:397
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "    -h, --help            show the help\n"
 "    --foo                 some nifty option --foo\n"
@@ -43395,7 +43395,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:400
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "An option group Header\n"
 "    -C[...]               option C with an optional argument\n"
@@ -43500,7 +43500,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rm.txt:12
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git rm' [-f | --force] [-n] [-r] [--cached] [--ignore-unmatch] [--quiet] [--] <file>...\n"
 msgstr ""
 
@@ -43728,7 +43728,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-email.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git send-email' [<options>] <file|directory|rev-list options>...\n"
 "'git send-email' --dump-aliases\n"
@@ -43796,7 +43796,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:53
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--bcc=<address>,..."
 msgstr ""
 
@@ -43814,7 +43814,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:59
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--cc=<address>,..."
 msgstr ""
 
@@ -43898,7 +43898,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-email.txt:110
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "  [PATCH 0/2] Here is what I did...\n"
 "    [PATCH 1/2] Clean up and tests\n"
@@ -43929,7 +43929,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:119
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--to=<address>,..."
 msgstr ""
 
@@ -44061,7 +44061,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-send-email.txt:188
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "$ git send-email --smtp-auth=\"PLAIN LOGIN GSSAPI\" ...\n"
 msgstr ""
 
@@ -44757,7 +44757,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-pack.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git send-pack' [--all] [--dry-run] [--force] [--receive-pack=<git-receive-pack>]\n"
 "\t\t[--verbose] [--thin] [--atomic]\n"
@@ -45130,7 +45130,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-shortlog.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "'git shortlog' [<options>] [<revision range>] [[--] <path>...]\n"
 "git log --pretty=short | 'git shortlog' [<options>]\n"
@@ -45258,7 +45258,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show-branch.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git show-branch' [-a|--all] [-r|--remotes] [--topo-order | --date-order]\n"
 "\t\t[--current] [--color[=<when>] | --no-color] [--sparse]\n"
@@ -45619,7 +45619,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show-ref.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git show-ref' [-q|--quiet] [--verify] [--head] [-d|--dereference]\n"
 "\t     [-s|--hash[=<n>]] [--abbrev[=<n>]] [--tags]\n"
@@ -45767,7 +45767,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-show-ref.txt:111
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git show-ref --head --dereference\n"
 "832e76a9899f560a90ffd62ae2ce83bbeff58f54 HEAD\n"
@@ -45788,7 +45788,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-show-ref.txt:121
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git show-ref --heads --hash\n"
 "2e3ba0114a1f52b47df29743d6915d056be13278\n"
@@ -45909,7 +45909,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'git show' [<options>] [<object>...]\n"
 msgstr ""
 
@@ -45957,7 +45957,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-show.txt:37
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "<object>..."
 msgstr ""
 
@@ -46215,7 +46215,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stage.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git stage' args...\n"
 msgstr ""
 
@@ -46239,7 +46239,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stash.txt:22
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git stash' list [<options>]\n"
 "'git stash' show [<options>] [<stash>]\n"
@@ -46262,7 +46262,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stash.txt:38
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "The modifications stashed away by this command can be listed with `git stash list`, inspected with `git stash show`, and restored (potentially on top of a different commit) with `git stash apply`.  Calling `git stash` without any arguments is equivalent to `git stash push`.  A stash is by default listed as \"WIP on 'branchname' ...\", but you can give a more descriptive message on the command line when you create one."
 msgstr ""
 
@@ -46274,7 +46274,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-stash.txt:49
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "push [-p|--patch] [-k|--[no-]keep-index] [-u|--include-untracked] [-a|--all] [-q|--quiet] [-m|--message <message>] [--] [<pathspec>...]"
 msgstr ""
 
@@ -46346,7 +46346,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:104
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "stash@{0}: WIP on submit: 6ebd0e2... Update git-stash documentation\n"
 "stash@{1}: On master: 9cc0589... Add git-stash\n"
@@ -46519,7 +46519,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:227
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git pull\n"
 " ...\n"
@@ -46537,7 +46537,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:246
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git switch -c my_wip\n"
@@ -46558,7 +46558,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:257
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git stash\n"
@@ -46582,7 +46582,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:275
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git add --patch foo            # add just first part to the index\n"
@@ -46636,7 +46636,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-status.txt:13
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git status' [<options>...] [--] [<pathspec>...]\n"
 msgstr ""
 
@@ -47113,7 +47113,7 @@ msgstr ""
 
 #. type: delimited block .
 #: en/git-status.txt:345
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "Field       Meaning\n"
 "--------------------------------------------------------\n"
@@ -47434,7 +47434,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-submodule.txt:23
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git submodule' [--quiet] [--cached]\n"
 "'git submodule' [--quiet] add [<options>] [--] <repository> [<path>]\n"
@@ -47505,7 +47505,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:74
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "status [--cached] [--recursive] [--] [<path>...]"
 msgstr ""
 
@@ -47529,7 +47529,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:91
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "init [--] [<path>...]"
 msgstr ""
 
@@ -47559,7 +47559,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:114
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "deinit [-f|--force] (--all|[--] <path>...)"
 msgstr ""
 
@@ -47589,7 +47589,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:132
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "update [--init] [--remote] [-N|--no-fetch] [--[no-]recommend-shallow] [-f|--force] [--checkout|--rebase|--merge] [--reference <repository>] [--depth <depth>] [--recursive] [--jobs <n>] [--] [<path>...]"
 msgstr ""
 
@@ -47713,7 +47713,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:182
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "summary [--cached|--files] [(-n|--summary-limit) <n>] [commit] [--] [<path>...]"
 msgstr ""
 
@@ -47755,7 +47755,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:224
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "sync [--recursive] [--] [<path>...]"
 msgstr ""
 
@@ -48281,7 +48281,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:127
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Fetch unfetched revisions from the Subversion remote we are tracking.  The name of the [svn-remote \"...\"] section in the $GIT_DIR/config file may be specified as an optional command-line argument."
 msgstr ""
 
@@ -48727,7 +48727,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:366
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "is supported, non-numeric args are not: HEAD, NEXT, BASE, PREV, etc ..."
 msgstr ""
 
@@ -49628,7 +49628,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-svn.txt:876
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "# Clone a repo (like git clone):\n"
 "\tgit svn clone http://svn.example.com/project/trunk\n"
@@ -49681,7 +49681,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-svn.txt:924
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "# Do the initial import on a server\n"
 "\tssh server \"cd /pub && git svn clone http://svn.example.com/project [options...]\"\n"
@@ -50396,7 +50396,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-tag.txt:20
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git tag' [-a | -s | -u <keyid>] [-f] [-m <msg> | -F <file>] [-e]\n"
 "\t<tagname> [<commit> | <object>]\n"
@@ -50542,7 +50542,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-tag.txt:103
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "List tags. With optional `<pattern>...`, e.g. `git tag --list 'v-*'`, list only the tags that match the pattern(s)."
 msgstr ""
 
@@ -50832,13 +50832,13 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:319
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "\tgit://git..../proj.git master\n"
 msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:321
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "to get the following updates...\n"
 msgstr ""
 
@@ -50850,7 +50850,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:327
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "$ git pull git://git..../proj.git master\n"
 msgstr ""
 
@@ -50970,7 +50970,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git.txt:55
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Other options are available to control how the manual page is displayed. See linkgit:git-help[1] for more information, because `git --help ...` is converted internally into `git help ...`."
 msgstr ""
 
@@ -51014,7 +51014,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git.txt:82
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Note that omitting the `=` in `git -c foo.bar ...` is allowed and sets `foo.bar` to the boolean true value (just like `[foo]bar` would in a config file). Including the equals but with an empty value (like `git -c foo.bar= ...`) sets `foo.bar` to the empty string which `git config --type=bool` will convert to `false`."
 msgstr ""
 
@@ -51218,7 +51218,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:169
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--list-cmds=group[,group...]"
 msgstr ""
 
@@ -51721,7 +51721,7 @@ msgstr "`GIT_COMMON_DIR`"
 
 #. type: Plain text
 #: en/git.txt:481
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If this variable is set to a path, non-worktree files that are normally in $GIT_DIR will be taken from this path instead. Worktree-specific files such as HEAD or index are taken from $GIT_DIR. See linkgit:gitrepository-layout[5] and linkgit:git-worktree[1] for details. This variable has lower precedence than other path variables such as GIT_INDEX_FILE, GIT_OBJECT_DIRECTORY..."
 msgstr ""
 
@@ -52192,10 +52192,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:685
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2`"
-msgstr "`GIT_TRACE`"
+msgstr "`GIT_TRACE2`"
 
 #. type: Plain text
 #: en/git.txt:689
@@ -52223,10 +52222,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:720
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE_SETUP`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2_EVENT`"
-msgstr "`GIT_TRACE_SETUP`"
+msgstr "`GIT_TRACE2_EVENT`"
 
 #. type: Plain text
 #: en/git.txt:725
@@ -52236,10 +52234,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:726
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE_PERFORMANCE`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2_PERF`"
-msgstr "`GIT_TRACE_PERFORMANCE`"
+msgstr "`GIT_TRACE2_PERF`"
 
 #. type: Plain text
 #: en/git.txt:732
@@ -52678,7 +52675,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-update-index.txt:29
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git update-index'\n"
 "\t     [--add] [--remove | --force-remove] [--replace]\n"
@@ -53238,7 +53235,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-update-index.txt:348
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The command looks at `core.ignorestat` configuration variable.  When this is true, paths updated with `git update-index paths...` and paths updated with other Git commands that update both index and working tree (e.g. 'git apply --index', 'git checkout-index -u', and 'git read-tree -u') are automatically marked as \"assume unchanged\".  Note that \"assume unchanged\" bit is *not* set if `git update-index --refresh` finds the working tree file matches the index (use `git update-index --really-refresh` if you want to mark them as \"assume unchanged\")."
 msgstr ""
 
@@ -54107,7 +54104,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-commit.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-commit' <commit>...\n"
 msgstr ""
 
@@ -54149,7 +54146,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-pack.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-pack' [-v|--verbose] [-s|--stat-only] [--] <pack>.idx ...\n"
 msgstr ""
 
@@ -54161,7 +54158,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-verify-pack.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<pack>.idx ..."
 msgstr ""
 
@@ -54239,7 +54236,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-tag.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-tag' [--format=<format>] <tag>...\n"
 msgstr ""
 
@@ -54257,7 +54254,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-verify-tag.txt:27
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<tag>..."
 msgstr ""
 
@@ -54281,7 +54278,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-web--browse.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git web{litdd}browse' [<options>] <url|file>...\n"
 msgstr ""
 
@@ -54555,7 +54552,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-whatchanged.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git whatchanged' <option>...\n"
 msgstr ""
 
@@ -55085,7 +55082,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-worktree.txt:372
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git worktree add -b emergency-fix ../temp master\n"
 "$ pushd ../temp\n"
@@ -56287,7 +56284,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/pretty-formats.txt:115
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'%C(...)'"
 msgstr ""
 
@@ -56299,7 +56296,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/pretty-formats.txt:129
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "\"CONFIGURATION FILE\" section of linkgit:git-config[1].  By default, colors are shown only when enabled for log output (by `color.diff`, `color.ui`, or `--color`, and respecting the `auto` settings of the former if we are going to a terminal). `%C(auto,...)` is accepted as a historical synonym for the default (e.g., `%C(auto,red)`). Specifying `%C(always,...)` will show the colors even when color is not otherwise enabled (though consider just using `--color=always` to enable color for the whole output, including this format and anything else git might color).  `auto` alone (i.e. `%C(auto)`) will turn on auto coloring on the next placeholders until the color is switched again."
 msgstr ""
 
@@ -57391,7 +57388,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/pull-fetch-param.txt:45
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "Whether that update is allowed without `--force` depends on the ref namespace it's being fetched to, the type of object being fetched, and whether the update is considered to be a fast-forward. Generally, the same rules apply for fetching as when pushing, see the `<refspec>...` section of linkgit:git-push[1] for what those are. Exceptions to those rules particular to 'git fetch' are noted below."
 msgstr ""
 
@@ -57862,13 +57859,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/revisions.txt:280
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "The '...' (three-dot) Symmetric Difference Notation"
 msgstr ""
 
 #. type: Plain text
 #: en/revisions.txt:286
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "A similar notation 'r1\\...r2' is called symmetric difference of 'r1' and 'r2' and is defined as 'r1 r2 --not $(git merge-base --all r1 r2)'.  It is the set of commits that are reachable from either one of 'r1' (left side) or 'r2' (right side) but not from both."
 msgstr ""
 
@@ -57958,7 +57955,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/revisions.txt:331
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'<rev1>\\...<rev2>'"
 msgstr ""
 
@@ -58012,7 +58009,7 @@ msgstr ""
 
 #. type: delimited block .
 #: en/revisions.txt:377
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "   Args   Expanded arguments    Selected commits\n"
 "   D                            G H D\n"
@@ -58502,7 +58499,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:256
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "For example, `--cherry-pick --right-only A...B` omits those commits from `B` which are in `A` or are patch-equivalent to a commit in `A`. In other words, this lists the `+` commits from `git cherry A B`.  More precisely, `--cherry-pick --right-only --no-merges` gives the exact list."
 msgstr ""
 
@@ -58514,7 +58511,7 @@ msgstr "--cherry"
 
 #. type: Plain text
 #: en/rev-list-options.txt:263
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "A synonym for `--right-only --cherry-mark --no-merges`; useful to limit the output to the commits on our side and mark those that have been applied to the other side of a forked history with `git log --cherry upstream...mybranch`, similar to `git cherry upstream mybranch`."
 msgstr ""
 
@@ -58526,7 +58523,7 @@ msgstr "--walk-reflogs"
 
 #. type: Plain text
 #: en/rev-list-options.txt:271
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Instead of walking the commit ancestry chain, walk reflog entries from the most recent one to older ones.  When this option is used you cannot specify commits to exclude (that is, '{caret}commit', 'commit1..commit2', and 'commit1\\...commit2' notations cannot be used)."
 msgstr ""
 
@@ -59519,7 +59516,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:875
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "`--date=format:...` feeds the format `...` to your system `strftime`, except for %z and %Z, which are handled internally.  Use `--date=format:%c` to show the date in your system locale's preferred format.  See the `strftime` manual for a complete list of format placeholders. When using `-local`, the correct syntax is `--date=format-local:...`."
 msgstr ""
 
@@ -59555,7 +59552,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:892
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Print also the parents of the commit (in the form \"commit parent...\").  Also enables parent rewriting, see 'History Simplification' above."
 msgstr ""
 
@@ -59567,7 +59564,7 @@ msgstr "--children"
 
 #. type: Plain text
 #: en/rev-list-options.txt:896
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Print also the children of the commit (in the form \"commit child...\").  Also enables parent rewriting, see 'History Simplification' above."
 msgstr ""
 
@@ -59620,13 +59617,13 @@ msgstr ""
 
 #. type: delimited block -
 #: en/rev-list-options.txt:922
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "\t$ git rev-list --left-right --boundary --pretty=oneline A...B\n"
 msgstr ""
 
 #. type: delimited block -
 #: en/rev-list-options.txt:929
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "\t>bbbbbbb... 3rd on b\n"
 "\t>bbbbbbb... 2nd on b\n"

--- a/po/documentation.nb_NO.po
+++ b/po/documentation.nb_NO.po
@@ -2435,7 +2435,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/config.txt:256
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The value for many variables that specify various sizes can be suffixed with `k`, `M`,... to mean \"scale the number by 1024\", \"by 1024x1024\", etc."
 msgstr ""
 
@@ -2825,7 +2825,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-format.txt:16
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "git-diff-tree [-r] <tree-ish-1> <tree-ish-2> [<pattern>...]"
 msgstr ""
 
@@ -2837,7 +2837,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-format.txt:19
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "git-diff-files [<pattern>...]"
 msgstr ""
 
@@ -3517,7 +3517,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/diff-generate-patch.txt:179
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Unlike the traditional 'unified' diff format, which shows two files A and B with a single column that has `-` (minus -- appears in A but removed in B), `+` (plus -- missing in A but added to B), or `\" \"` (space -- unchanged) prefix, this format compares two or more files file1, file2,... with one file X, and shows how X differs from each of fileN.  One column for each of fileN is prepended to the output line to note how X's line is different from it."
 msgstr ""
 
@@ -3840,7 +3840,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:137
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Generate a diffstat. By default, as much space as necessary will be used for the filename part, and the rest for the graph part. Maximum width defaults to terminal width, or 80 columns if not connected to a terminal, and can be overridden by `<width>`. The width of the filename part can be limited by giving another width `<name-width>` after a comma. The width of the graph part can be limited by using `--stat-graph-width=<width>` (affects all commands generating a stat graph) or by setting `diff.statGraphWidth=<width>` (does not affect `git format-patch`).  By giving a third parameter `<count>`, you can limit the output to the first `<count>` lines, followed by `...` if there are more."
 msgstr ""
 
@@ -3888,13 +3888,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:161
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "-X[<param1,param2,...>]"
 msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:162
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--dirstat[=<param1,param2,...>]"
 msgstr ""
 
@@ -3984,13 +3984,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:209
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--dirstat-by-file[=<param1,param2>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:211
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Synonym for --dirstat=files,param1,param2..."
 msgstr ""
 
@@ -4651,13 +4651,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:527
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--diff-filter=[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:538
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Select only files that are Added (`A`), Copied (`C`), Deleted (`D`), Modified (`M`), Renamed (`R`), have their type (i.e. regular file, symlink, submodule, ...) changed (`T`), are Unmerged (`U`), are Unknown (`X`), or have had their pairing Broken (`B`).  Any combination of the filter characters (including none) can be used.  When `*` (All-or-none) is added to the combination, all paths are selected if there is any file that matches other criteria in the comparison; if there is no file that matches other criteria, nothing is selected."
 msgstr ""
 
@@ -4717,7 +4717,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/diff-options.txt:573
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "+    return !regexec(regexp, two->ptr, 1, &regmatch, 0);\n"
 "...\n"
@@ -5640,7 +5640,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-add.txt:15
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "'git add' [--verbose | -v] [--dry-run | -n] [--force | -f] [--interactive | -i] [--patch | -p]\n"
 "\t  [--edit | -e] [--[no-]all | --[no-]ignore-removal | [--update | -u]]\n"
@@ -5698,7 +5698,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-add.txt:52 en/git-grep.txt:308 en/git-status.txt:148
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid "<pathspec>..."
 msgstr ""
 
@@ -5842,7 +5842,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-add.txt:145
-#, priority:300
+#, ignore-ellipsis, priority:300
 msgid "This option is primarily to help users who are used to older versions of Git, whose \"git add <pathspec>...\" was a synonym for \"git add --no-all <pathspec>...\", i.e. ignored removed files."
 msgstr ""
 
@@ -6340,7 +6340,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-am.txt:20
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git am' [--signoff] [--keep] [--[no-]keep-cr] [--[no-]utf8]\n"
 "\t [--[no-]3way] [--interactive] [--committer-date-is-author-date]\n"
@@ -6360,7 +6360,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-am.txt:29
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "(<mbox>|<Maildir>)..."
 msgstr ""
 
@@ -6896,7 +6896,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-apply.txt:20
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git apply' [--stat] [--numstat] [--summary] [--check] [--index | --intent-to-add] [--3way]\n"
 "\t  [--apply] [--no-add] [--build-fake-ancestor=<file>] [-R | --reverse]\n"
@@ -6922,7 +6922,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-apply.txt:37
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<patch>..."
 msgstr ""
 
@@ -7336,7 +7336,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-archimport.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git archimport' [-h] [-v] [-o] [-a] [-f] [-T] [-D depth] [-t tempdir]\n"
 "               <archive/branch>[:<git-branch>] ...\n"
@@ -7500,7 +7500,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-archive.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git archive' [--format=<fmt>] [--list] [--prefix=<prefix>/] [<extra>]\n"
 "\t      [-o <file> | --output=<file>] [--worktree-attributes]\n"
@@ -7888,7 +7888,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bisect.txt:31
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 " git bisect start [--term-{old,good}=<term> --term-{new,bad}=<term>]\n"
 "\t\t  [--no-checkout] [<bad> [<good>...]] [--] [<paths>...]\n"
@@ -8083,7 +8083,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-bisect.txt:158
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git bisect new [<rev>...]\n"
 msgstr ""
 
@@ -8113,7 +8113,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bisect.txt:175
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If you would like to use your own terms instead of \"bad\"/\"good\" or \"new\"/\"old\", you can choose any names you like (except existing bisect subcommands like `reset`, `start`, ...) by starting the bisection using"
 msgstr ""
 
@@ -8553,7 +8553,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-bisect.txt:463
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git bisect start HEAD <known-good-commit> [ <boundary-commit> ... ] --no-checkout\n"
 "$ git bisect run sh -c '\n"
@@ -9021,7 +9021,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:26
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git branch' [--color[=<when>] | --no-color] [--show-current]\n"
 "\t[-v [--abbrev=<length> | --no-abbrev]]\n"
@@ -9066,7 +9066,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:61
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "The command's second form creates a new branch head named <branchname> which points to the current `HEAD`, or <start-point> if given. As a special case, for <start-point>, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -9264,7 +9264,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:176
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "List branches.  With optional `<pattern>...`, e.g. `git branch --list 'maint-*'`, list only the branches that match the pattern(s)."
 msgstr ""
 
@@ -9510,7 +9510,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:291
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "Sort based on the key given. Prefix `-` to sort in descending order of the value. You may use the --sort=<key> option multiple times, in which case the last key becomes the primary key. The keys supported are the same as those in `git for-each-ref`. Sort order defaults to the value configured for the `branch.sort` variable if exists, or to sorting based on the full refname (including `refs/...` prefix). This lists detached HEAD (if present) first, then local branches and finally remote-tracking branches. See linkgit:git-config[1]."
 msgstr ""
 
@@ -9552,7 +9552,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-branch.txt:317
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git clone git://git.kernel.org/pub/scm/.../linux-2.6 my2.6\n"
 "$ cd my2.6\n"
@@ -9574,7 +9574,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-branch.txt:329
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git clone git://git.kernel.org/.../git.git my.git\n"
 "$ cd my.git\n"
@@ -9688,7 +9688,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bundle.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git bundle' create <file> <git-rev-list-args>\n"
 "'git bundle' verify <file>\n"
@@ -9764,7 +9764,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-bundle.txt:71
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<refname>...]"
 msgstr ""
 
@@ -10540,7 +10540,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-attr.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git check-attr' [-a | --all | <attr>...] [--] <pathname>...\n"
 "'git check-attr' --stdin [-z] [-a | --all | <attr>...]\n"
@@ -10781,7 +10781,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-ignore.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git check-ignore' [<options>] <pathname>...\n"
 "'git check-ignore' [<options>] --stdin\n"
@@ -10957,7 +10957,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-mailmap.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git check-mailmap' [<options>] <contact>...\n"
 msgstr ""
 
@@ -10993,7 +10993,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout-index.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git checkout-index' [-u] [-q] [-a] [-f] [-n] [--prefix=<string>]\n"
 "\t\t   [--stage=<number>|all]\n"
@@ -11268,7 +11268,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:18
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git checkout' [-q] [-f] [-m] [<branch>]\n"
 "'git checkout' [-q] [-f] [-m] --detach [<branch>]\n"
@@ -11379,7 +11379,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-checkout.txt:82
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git checkout' [<tree-ish>] [--] <pathspec>..."
 msgstr ""
 
@@ -11397,7 +11397,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-checkout.txt:98
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git checkout' (-p|--patch) [<tree-ish>] [--] [<pathspec>...]"
 msgstr ""
 
@@ -11739,7 +11739,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:326 en/git-switch.txt:58
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "As a special case, you may use `A...B` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -11769,7 +11769,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:337
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "As a special case, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -12340,7 +12340,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git cherry-pick' [--edit] [-n] [-m parent-number] [-s] [-x] [--ff]\n"
 "\t\t  [-S[<keyid>]] <commit>...\n"
@@ -12397,13 +12397,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-cherry-pick.txt:43 en/git-merge.txt:116 en/git-revert.txt:36 en/git-verify-commit.txt:27
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "<commit>..."
 msgstr ""
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:52
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Commits to cherry-pick.  For a more complete list of ways to spell commits, see linkgit:gitrevisions[7].  Sets of commits can be passed but no traversal is done by default, as if the `--no-walk` option was specified, see linkgit:git-rev-list[1]. Note that specifying a range will feed all <commit>... arguments to a single revision walk (see a later example that uses 'maint master..next')."
 msgstr ""
 
@@ -12433,7 +12433,7 @@ msgstr "-x"
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:78
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When recording the commit, append a line that says \"(cherry picked from commit ...)\" to the original commit message in order to indicate which commit this change was cherry-picked from.  This is done only for cherry picks without conflicts.  Do not use this option if you are cherry-picking from your private branch because the information is useless to the recipient.  If on the other hand you are cherry-picking between two publicly visible branches (e.g. backporting a fix to a maintenance branch for an older release from a development branch), adding this information can be useful."
 msgstr ""
 
@@ -12791,7 +12791,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:58
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git checkout -b topic origin/master\n"
 "# work and create some commits\n"
@@ -12827,7 +12827,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git log --graph --oneline --decorate --boundary origin/master...topic\n"
 "* 7654321 (origin/master) upstream tip commit\n"
@@ -12850,7 +12850,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:96
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git cherry origin/master topic\n"
 "- cccc000... commit C\n"
@@ -12878,7 +12878,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:126
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git log --graph --oneline --decorate --boundary origin/master...topic\n"
 "* 7654321 (origin/master) upstream tip commit\n"
@@ -12904,7 +12904,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:136
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git cherry origin/master topic base\n"
 "- cccc000... commit C\n"
@@ -12956,7 +12956,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-clean.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git clean' [-d] [-f] [-i] [-n] [-q] [-e <pattern>] [-x | -X] [--] <path>...\n"
 msgstr ""
 
@@ -12974,7 +12974,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-clean.txt:25
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If any optional `<path>...` arguments are given, only those paths are affected."
 msgstr ""
 
@@ -13585,7 +13585,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-clone.txt:306
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "$ git clone git://git.kernel.org/pub/scm/.../linux.git my-linux\n"
 "$ cd my-linux\n"
@@ -13615,7 +13615,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-clone.txt:325
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "$ git clone --reference /git/linux.git \\\n"
 "\tgit://git.kernel.org/pub/scm/.../linux.git \\\n"
@@ -13808,7 +13808,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-commit-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git commit-tree' <tree> [(-p <parent>)...]\n"
 "'git commit-tree' [(-p <parent>)...] [-S[<keyid>]] [(-m <message>)...]\n"
@@ -14009,7 +14009,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-commit.txt:17
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git commit' [-a | --interactive | --patch] [-s] [-v] [-u<mode>] [--amend]\n"
 "\t   [--dry-run] [(-c | -C | --fixup | --squash) <commit>]\n"
@@ -14429,7 +14429,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-commit.txt:248
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "\t$ git reset --soft HEAD^\n"
 "\t$ ... do something else to come up with the right tree ...\n"
@@ -14594,7 +14594,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-commit.txt:346 en/git-rm.txt:29
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "<file>..."
 msgstr ""
 
@@ -15571,7 +15571,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-config.txt:428
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "However, if you really only want to replace the line for the default proxy, i.e. the one without a \"for ...\" postfix, do something like this:"
 msgstr ""
 
@@ -16929,7 +16929,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-cvsserver.txt:26
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git-cvsserver' [<options>] [pserver|server] [<directory> ...]\n"
 msgstr ""
 
@@ -17627,7 +17627,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-daemon.txt:25
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git daemon' [--verbose] [--syslog] [--export-all]\n"
 "\t     [--timeout=<n>] [--init-timeout=<n>] [--max-connections=<n>]\n"
@@ -18193,7 +18193,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-describe.txt:14
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "'git describe' [--all] [--tags] [--contains] [--abbrev=<n>] [<commit-ish>...]\n"
 "'git describe' [--all] [--tags] [--contains] [--abbrev=<n>] --dirty[=<mark>]\n"
@@ -18220,7 +18220,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-describe.txt:37
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "<commit-ish>..."
 msgstr ""
 
@@ -18316,7 +18316,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-describe.txt:95
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Always output the long format (the tag, the number of commits and the abbreviated commit name) even when it matches a tag.  This is useful when you want to see parts of the commit object name in \"describe\" output, even when the commit in question happens to be a tagged version.  Instead of just emitting the tag name, it will describe such a commit as v1.2-0-gdeadbee (0th commit since tag v1.2 that points at object deadbee....)."
 msgstr ""
 
@@ -18494,7 +18494,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-files.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git diff-files' [-q] [-0|-1|-2|-3|-c|--cc] [<common diff options>] [<path>...]\n"
 msgstr ""
 
@@ -18566,7 +18566,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-index.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git diff-index' [-m] [--cached] [<common diff options>] <tree-ish> [<path>...]\n"
 msgstr ""
 
@@ -18705,7 +18705,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-index.txt:102
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "  torvalds@ppc970:~/v2.6/linux> git diff-index --abbrev HEAD\n"
 "  :100644 100664 7476bb... 000000...      kernel/sched.c\n"
@@ -18743,7 +18743,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-difftool.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git difftool' [<options>] [<commit> [<commit>]] [--] [<path>...]\n"
 msgstr ""
 
@@ -19055,7 +19055,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git diff-tree' [--stdin] [-m] [-s] [-v] [--no-commit-id] [--pretty]\n"
 "\t      [-t] [-r] [-c | --cc] [--combined-all-paths] [--root]\n"
@@ -19088,7 +19088,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff-tree.txt:32 en/git-diff.txt:114 en/git-submodule.txt:422
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "<path>..."
 msgstr ""
 
@@ -19214,7 +19214,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:17
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git diff' [<options>] [<commit>] [--] [<path>...]\n"
 "'git diff' [<options>] --cached [<commit>] [--] [<path>...]\n"
@@ -19231,7 +19231,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:24
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] [--] [<path>...]"
 msgstr ""
 
@@ -19255,7 +19255,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:41
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] --cached [<commit>] [--] [<path>...]"
 msgstr ""
 
@@ -19267,7 +19267,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:51
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit> [--] [<path>...]"
 msgstr ""
 
@@ -19279,7 +19279,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:59
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit> <commit> [--] [<path>...]"
 msgstr ""
 
@@ -19291,7 +19291,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:64
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit>..<commit> [--] [<path>...]"
 msgstr ""
 
@@ -19303,13 +19303,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:70
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit>\\...<commit> [--] [<path>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:77
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "This form is to view the changes on the branch containing and up to the second <commit>, starting at a common ancestor of both <commit>.  \"git diff A\\...B\" is equivalent to \"git diff $(git merge-base A B) B\".  You can omit any one of <commit>, which has the same effect as using HEAD instead."
 msgstr ""
 
@@ -19321,7 +19321,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:89
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "For a more complete list of ways to spell <commit>, see \"SPECIFYING REVISIONS\" section in linkgit:gitrevisions[7].  However, \"diff\" is about comparing two _endpoints_, not ranges, and the range notations (\"<commit>..<commit>\" and \"<commit>\\...<commit>\") do not mean a range as defined in the \"SPECIFYING RANGES\" section in linkgit:gitrevisions[7]."
 msgstr ""
 
@@ -19429,7 +19429,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-diff.txt:160
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git diff topic master    <1>\n"
 "$ git diff topic..master   <2>\n"
@@ -19749,7 +19749,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:143
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<git-rev-list-args>...]"
 msgstr ""
 
@@ -19830,7 +19830,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-fast-export.txt:215
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git init anon-repo\n"
 "$ cd anon-repo\n"
@@ -22140,7 +22140,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch-pack.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git fetch-pack' [--all] [--quiet|-q] [--keep|-k] [--thin] [--include-tag]\n"
 "\t[--upload-pack=<git-upload-pack>]\n"
@@ -22294,7 +22294,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fetch-pack.txt:117 en/git-ls-remote.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<refs>..."
 msgstr ""
 
@@ -22324,7 +22324,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch.txt:16
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git fetch' [<options>] [<repository> [<refspec>...]]\n"
 "'git fetch' [<options>] <group>\n"
@@ -22665,7 +22665,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch.txt:226
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "For a successfully fetched ref, the summary shows the old and new values of the ref in a form suitable for using as an argument to `git log` (this is `<old>..<new>` in most cases, and `<old>...<new>` for forced non-fast-forward updates)."
 msgstr ""
 
@@ -22787,7 +22787,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:18
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git filter-branch' [--setup <command>] [--subdirectory-filter <directory>]\n"
 "\t[--env-filter <command>] [--tree-filter <command>]\n"
@@ -22926,7 +22926,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:117
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for rewriting the index.  It is similar to the tree filter but does not check out the tree, which makes it much faster.  Frequently used with `git rm --cached --ignore-unmatch ...`, see EXAMPLES below.  For hairy cases, see linkgit:git-update-index[1]."
 msgstr ""
 
@@ -22938,7 +22938,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:125
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for rewriting the commit's parent list.  It will receive the parent string on stdin and shall output the new parent string on stdout.  The parent string is in the format described in linkgit:git-commit-tree[1]: empty for the initial commit, \"-p parent\" for a normal commit and \"-p parent1 -p parent2 -p parent3 ...\" for a merge commit."
 msgstr ""
 
@@ -22962,7 +22962,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:138
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for performing the commit.  If this filter is specified, it will be called instead of the 'git commit-tree' command, with arguments of the form \"<TREE_ID> [(-p <PARENT_COMMIT_ID>)...]\" and the log message on stdin.  The commit id is expected on stdout."
 msgstr ""
 
@@ -23064,7 +23064,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-filter-branch.txt:207
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<rev-list options>..."
 msgstr ""
 
@@ -23325,7 +23325,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-filter-branch.txt:388
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git filter-branch ... C..H\n"
 msgstr ""
 
@@ -23337,7 +23337,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-filter-branch.txt:395
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "git filter-branch ... C..H --not D\n"
 "git filter-branch ... D..H --not C\n"
@@ -23576,7 +23576,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git for-each-ref' [--count=<count>] [--shell|--perl|--python|--tcl]\n"
 "\t\t   [(--sort=<key>)...] [--format=<format>] [<pattern>...]\n"
@@ -23593,7 +23593,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-for-each-ref.txt:29 en/git-show-ref.txt:88
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<pattern>..."
 msgstr ""
 
@@ -23881,7 +23881,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:197
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Left-, middle-, or right-align the content between %(align:...) and %(end). The \"align:\" is followed by `width=<width>` and `position=<position>` in any order separated by a comma, where the `<position>` is either left, right or middle, default being left and `<width>` is the total length of the content with alignment. For brevity, the \"width=\" and/or \"position=\" prefixes may be omitted, and bare <width> and <position> used instead.  For instance, `%(align:<width>,<position>)`. If the contents length is more than the width then no alignment is performed. If used with `--quote` everything in between %(align:...) and %(end) is quoted, but if nested then only the topmost level performs quoting."
 msgstr ""
 
@@ -23893,7 +23893,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:210
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Used as %(if)...%(then)...%(end) or %(if)...%(then)...%(else)...%(end).  If there is an atom with value or string literal after the %(if) then everything after the %(then) is printed, else if the %(else) atom is used, then everything after %(else) is printed. We ignore space when evaluating the string before %(then), this is useful when we use the %(HEAD) atom which prints either \"*\" or \" \" and we want to apply the 'if' condition only on the 'HEAD' ref.  Append \":equals=<string>\" or \":notequals=<string>\" to compare the value between the %(if:...) and %(then) atoms with the given string."
 msgstr ""
 
@@ -24114,7 +24114,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:361
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "An example to show the usage of %(if)...%(then)...%(else)...%(end).  This prefixes the current branch with a star."
 msgstr ""
 
@@ -24126,7 +24126,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:369
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "An example to show the usage of %(if)...%(then)...%(end).  This prints the authorname, if present."
 msgstr ""
 
@@ -24772,7 +24772,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:372
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "Do the same for ia64 so we can have sleek & trim looking\n"
 "...\n"
@@ -24780,7 +24780,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:380
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Typically it will be placed in a MUA's drafts folder, edited to add timely commentary that should not go in the changelog after the three dashes, and then sent as a message whose body, in our example, starts with \"arch/arm config files were...\".  On the receiving end, readers can save interesting patches in a UNIX mailbox and apply them with linkgit:git-am[1]."
 msgstr ""
 
@@ -24792,7 +24792,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:390
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "...\n"
 "> So we should do such-and-such.\n"
@@ -24814,7 +24814,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:398
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "arch/arm config files were slimmed down using a python script\n"
 "...\n"
@@ -24988,7 +24988,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:499
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Configure your mail server composition as plain text: Edit...Account Settings...Composition & Addressing, uncheck \"Compose Messages in HTML\"."
 msgstr ""
 
@@ -25125,7 +25125,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:573
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Use Message -> Insert file... and insert the patch."
 msgstr ""
 
@@ -25300,7 +25300,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fsck-objects.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git fsck-objects' ...\n"
 msgstr ""
 
@@ -25688,7 +25688,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-gc.txt:55
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Once housekeeping is triggered by exceeding the limits of configuration options such as `gc.auto` and `gc.autoPackLimit`, all other housekeeping tasks (e.g. rerere, working trees, reflog...) will be performed as well."
 msgstr ""
 
@@ -25862,7 +25862,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-grep.txt:32
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git grep' [-a | --text] [-I] [--textconv] [-i | --ignore-case] [-w | --word-regexp]\n"
 "\t   [-v | --invert-match] [-h|-H] [--full-name]\n"
@@ -26470,7 +26470,7 @@ msgstr "--not"
 
 #. type: Labeled list
 #: en/git-grep.txt:284
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "( ... )"
 msgstr ""
 
@@ -26500,7 +26500,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-grep.txt:300
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<tree>..."
 msgstr ""
 
@@ -26818,7 +26818,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-hash-object.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git hash-object' [-t <type>] [-w] [--path=<file>|--no-filters] [--stdin [--literally]] [--] <file>...\n"
 "'git hash-object' [-t <type>] [-w] --stdin-paths [--no-filters]\n"
@@ -26948,7 +26948,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-help.txt:38
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Note that `git --help ...` is identical to `git help ...` because the former is internally converted into the latter."
 msgstr ""
 
@@ -27398,7 +27398,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:102
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tAuthType Basic\n"
 "\tAuthName \"Git Access\"\n"
@@ -27416,7 +27416,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:115
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "<LocationMatch \"^/git/.*/git-receive-pack$\">\n"
 "\tAuthType Basic\n"
@@ -27440,7 +27440,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:136
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "<Location /git/private>\n"
 "\tAuthType Basic\n"
@@ -27590,7 +27590,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:231
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "auth.require = (\n"
 "\t\"/\" => (\n"
@@ -27793,7 +27793,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-http-push.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git http-push' [--all] [--dry-run] [--force] [--verbose] <url> <ref> [<ref>...]\n"
 msgstr ""
 
@@ -27862,7 +27862,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-http-push.txt:54 en/git-send-pack.txt:98
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<ref>..."
 msgstr ""
 
@@ -28727,7 +28727,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-interpret-trailers.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git interpret-trailers' [<options>] [(--trailer <token>[(=|:)<value>])...] [<file>...]\n"
 "'git interpret-trailers' [<options>] [--parse] [<file>...]\n"
@@ -29397,7 +29397,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-log.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'git log' [<options>] [<revision range>] [[--] <path>...]\n"
 msgstr ""
 
@@ -29493,7 +29493,7 @@ msgstr "--full-diff"
 
 #. type: Plain text
 #: en/git-log.txt:63
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Without this flag, `git log -p <path>...` shows commits that touch the specified paths, and diffs about the same specified paths.  With this, the full diff is shown for commits that touch the specified paths; this means that \"<path>...\" limits only commits, and doesn't limit diff for those commits."
 msgstr ""
 
@@ -29547,7 +29547,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-log.txt:93 en/git-shortlog.txt:72
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "[--] <path>..."
 msgstr ""
 
@@ -29823,7 +29823,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-files.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-files' [-z] [-t] [-v] [-f]\n"
 "\t\t(--[cached|deleted|others|ignored|stage|unmerged|killed|modified])*\n"
@@ -30304,7 +30304,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-remote.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-remote' [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
 "\t      [-q | --quiet] [--exit-code] [--get-url] [--sort=<key>]\n"
@@ -30409,7 +30409,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-remote.txt:91
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When unspecified, all references, after filtering done with --heads and --tags, are shown.  When <refs>... are specified, only references matching the given patterns are displayed."
 msgstr ""
 
@@ -30454,7 +30454,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-tree' [-d] [-r] [-t] [-l] [-z]\n"
 "\t    [--name-only] [--name-status] [--full-name] [--full-tree] [--abbrev[=<n>]]\n"
@@ -30535,7 +30535,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-ls-tree.txt:76
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<path>...]"
 msgstr ""
 
@@ -30745,7 +30745,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mailsplit.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git mailsplit' [-b] [-f<nn>] [-d<prec>] [--keep-cr] [--mboxrd]\n"
 "\t\t-o<directory> [--] [(<mbox>|<Maildir>)...]\n"
@@ -30867,7 +30867,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git merge-base' [-a|--all] <commit> <commit>...\n"
 "'git merge-base' [-a|--all] --octopus <commit>...\n"
@@ -31064,7 +31064,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:139
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tA=$(git rev-parse --verify A)\n"
 "\tif test \"$A\" = \"$(git merge-base A B)\"\n"
@@ -31081,7 +31081,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:146
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tif git merge-base --is-ancestor A B\n"
 "\tthen\n"
@@ -31568,7 +31568,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mergetool.txt:12
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git mergetool' [--tool=<tool>] [-y | --[no-]prompt] [<file>...]\n"
 msgstr ""
 
@@ -31730,7 +31730,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge.txt:17
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git merge' [-n] [--stat] [--no-commit] [--squash] [--[no-]edit]\n"
 "\t[-s <strategy>] [-X <strategy-option>] [-S[<keyid>]]\n"
@@ -32323,7 +32323,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mv.txt:13
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git mv' <options>... <args>...\n"
 msgstr ""
 
@@ -32335,7 +32335,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mv.txt:20
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 " git mv [-v] [-f] [-n] [-k] <source> <destination>\n"
 " git mv [-v] [-f] [-n] [-k] <source> ... <destination directory>\n"
@@ -32403,7 +32403,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-name-rev.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git name-rev' [--tags] [--refs=<pattern>]\n"
 "\t       ( --all | --stdin | <commit-ish>... )\n"
@@ -32521,7 +32521,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-notes.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git notes' [list [<object>]]\n"
 "'git notes' add [-f] [--allow-empty] [-F <file> | -m <msg> | (-c | -C) <object>] [<object>]\n"
@@ -32857,7 +32857,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-notes.txt:229
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Commit notes are blobs containing extra information about an object (usually information to supplement a commit's message).  These blobs are taken from notes refs.  A notes ref is usually a branch which contains \"files\" whose paths are the object names for the objects they describe, with some directory separators included for performance reasons footnote:[Permitted pathnames have the form 'ab'`/`'cd'`/`'ef'`/`'...'`/`'abcdef...': a sequence of directory names of two hexadecimal digits each followed by a filename with the rest of the object ID.]."
 msgstr ""
 
@@ -32923,7 +32923,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-notes.txt:288
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git notes add -m 'Tested-by: Johannes Sixt <j6t@kdbg.org>' 72a144e2\n"
 "$ git show -s 72a144e\n"
@@ -33142,7 +33142,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-p4.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git p4 clone' [<sync options>] [<clone options>] <p4 depot path>...\n"
 "'git p4 sync' [<sync options>] [<p4 depot path>...]\n"
@@ -33975,7 +33975,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-p4.txt:445
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The full syntax for a p4 view is documented in 'p4 help views'.  'git p4' knows only a subset of the view syntax.  It understands multi-line mappings, overlays with '+', exclusions with '-' and double-quotes around whitespace.  Of the possible wildcards, 'git p4' only handles '...', and only when it is at the end of the path.  'git p4' will complain if it encounters an unhandled wildcard."
 msgstr ""
 
@@ -34017,7 +34017,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-p4.txt:475
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "//depot/main/...\n"
 "//depot/branch1/...\n"
@@ -34031,7 +34031,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-p4.txt:480
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "//depot/main/... //depot/branch1/...\n"
 msgstr ""
 
@@ -35148,7 +35148,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-pack-redundant.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git pack-redundant' [ --verbose ] [ --alt-odb ] < --all | .pack filename ... >\n"
 msgstr ""
 
@@ -35448,7 +35448,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-prune.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git prune' [-n] [-v] [--progress] [--expire <time>] [--] [<head>...]\n"
 msgstr ""
 
@@ -35502,7 +35502,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-prune.txt:54
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<head>..."
 msgstr ""
 
@@ -35556,7 +35556,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-pull.txt:13
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "'git pull' [<options>] [<repository> [<refspec>...]]\n"
 msgstr ""
 
@@ -35904,7 +35904,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:18
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git push' [--all | --mirror | --tags] [--follow-tags] [--atomic] [-n | --dry-run] [--receive-pack=<git-receive-pack>]\n"
 "\t   [--repo=<repository>] [-f | --force] [-d | --delete] [--prune] [-v | --verbose]\n"
@@ -35934,7 +35934,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:39
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "When the command line does not specify what to push with `<refspec>...` arguments or `--all`, `--mirror`, `--tags` options, the command finds the default `<refspec>` by consulting `remote.*.push` configuration, and if it is not found, honors `push.default` configuration to decide what to push (See linkgit:git-config[1] for the meaning of `push.default`)."
 msgstr ""
 
@@ -35958,7 +35958,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:56
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "<refspec>..."
 msgstr ""
 
@@ -36318,7 +36318,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:343
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "Note that `--force` applies to all the refs that are pushed, hence using it with `push.default` set to `matching` or with multiple push destinations configured with `remote.*.push` may overwrite refs other than the current branch (including local refs that are strictly behind their remote counterpart).  To force a push to only one branch, use a `+` in front of the refspec to push (e.g `git push origin +master` to force a push to the `master` branch). See the `<refspec>...` section above for details."
 msgstr ""
 
@@ -36450,7 +36450,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:445
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "For a successfully pushed ref, the summary shows the old and new values of the ref in a form suitable for using as an argument to `git log` (this is `<old>..<new>` in most cases, and `<old>...<new>` for forced non-fast-forward updates)."
 msgstr ""
 
@@ -36711,7 +36711,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:616
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "See the section describing `<refspec>...` above for a discussion of the matching semantics."
 msgstr ""
 
@@ -37412,7 +37412,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-read-tree.txt:357
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git fetch git://.... linus\n"
 "$ LT=`git rev-parse FETCH_HEAD`\n"
@@ -37466,7 +37466,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-read-tree.txt:405
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "'git read-tree' and other merge-based commands ('git merge', 'git checkout'...) can help maintaining the skip-worktree bitmap and working directory update. `$GIT_DIR/info/sparse-checkout` is used to define the skip-worktree reference bitmap. When 'git read-tree' needs to update the working directory, it resets the skip-worktree bit in the index based on this file, which uses the same syntax as .gitignore files.  If an entry matches a pattern in this file, skip-worktree will not be set on that entry. Otherwise, skip-worktree will be set."
 msgstr ""
 
@@ -37846,7 +37846,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:219
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "As a special case, you may use \"A\\...B\" as a shortcut for the merge base of A and B if there is exactly one merge base. You can leave out at most one of A and B, in which case it defaults to HEAD."
 msgstr ""
 
@@ -38110,7 +38110,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:430
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "It is currently only possible to recreate the merge commits using the `recursive` merge strategy; Different merge strategies can be used only via explicit `exec git merge -s <strategy> [...]` commands."
 msgstr ""
 
@@ -38164,7 +38164,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:457
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "\tgit rebase -i --exec \"cmd1 && cmd2 && ...\"\n"
 msgstr ""
 
@@ -38176,7 +38176,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:461
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "\tgit rebase -i --exec \"cmd1\" --exec \"cmd2\" --exec ...\n"
 msgstr ""
 
@@ -38212,7 +38212,7 @@ msgstr "--no-autosquash"
 
 #. type: Plain text
 #: en/git-rebase.txt:495
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When the commit log message begins with \"squash! ...\" (or \"fixup! ...\"), and there is already a commit in the todo list that matches the same `...`, automatically modify the todo list of rebase -i so that the commit marked for squashing comes right after the commit to be modified, and change the action of the moved commit from `pick` to `squash` (or `fixup`).  A commit matches the `...` if the commit subject matches, or if the `...` refers to the commit's hash. As a fall-back, partial matches of the commit subject work, too.  The recommended way to create fixup/squash commits is by using the `--fixup`/`--squash` options of linkgit:git-commit[1]."
 msgstr ""
 
@@ -38539,7 +38539,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:636
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "pick deadbee The oneline of this commit\n"
 "pick fa1afe1 The oneline of the next commit\n"
@@ -38643,7 +38643,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:710
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "pick deadbee Implement feature XXX\n"
 "fixup f1a5c00 Fix to feature XXX\n"
@@ -38662,7 +38662,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:720
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The \"exec\" command launches the command in a shell (the one specified in `$SHELL`, or the default shell if `$SHELL` is not set), so you can use shell features (like \"cd\", \">\", \";\" ...). The command is run from the root of the working tree."
 msgstr ""
 
@@ -38806,7 +38806,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:815
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "    o---o---o---o---o---o---o---o  master\n"
 "\t \\\t\t\t \\\n"
@@ -39604,7 +39604,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reflog.txt:27
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git reflog' ['show'] [log-options] [<ref>]\n"
 "'git reflog expire' [--expire=<time>] [--expire-unreachable=<time>]\n"
@@ -39791,7 +39791,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-remote-ext.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git remote add <nick> \"ext::<command>[ <arguments>...]\"\n"
 msgstr ""
 
@@ -39929,7 +39929,7 @@ msgstr "GIT_EXT_SERVICE"
 
 #. type: Plain text
 #: en/git-remote-ext.txt:70
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Set to long name (git-upload-pack, etc...) of service helper needs to invoke."
 msgstr ""
 
@@ -39941,7 +39941,7 @@ msgstr "GIT_EXT_SERVICE_NOPREFIX"
 
 #. type: Plain text
 #: en/git-remote-ext.txt:74
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Set to long name (upload-pack, etc...) of service helper needs to invoke."
 msgstr ""
 
@@ -40121,7 +40121,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-remote.txt:25
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git remote' [-v | --verbose]\n"
 "'git remote add' [-t <branch>] [-m <master>] [-f] [--[no-]tags] [--mirror=<fetch|push>] <name> <url>\n"
@@ -40440,7 +40440,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-remote.txt:235
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "$ git remote\n"
 "origin\n"
@@ -40684,7 +40684,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-replace.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git replace' [-f] <object> <replacement>\n"
 "'git replace' [-f] --edit <object>\n"
@@ -40804,13 +40804,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-replace.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--graft <commit> [<parent>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/git-replace.txt:93
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Create a graft commit. A new commit is created with the same content as <commit> except that its parents will be [<parent>...] instead of <commit>'s parents. A replacement ref is then created to replace <commit> with the newly created commit. Use `--convert-graft-file` to convert a `$GIT_DIR/info/grafts` file and use replace refs instead."
 msgstr ""
 
@@ -41232,7 +41232,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rerere.txt:121
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git switch topic\n"
 "\t$ git merge master\n"
@@ -41264,7 +41264,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rerere.txt:145
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git switch topic\n"
 "\t$ git merge master\n"
@@ -41369,7 +41369,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reset.txt:14
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git reset' [-q] [<tree-ish>] [--] <paths>...\n"
 "'git reset' (--patch | -p) [<tree-ish>] [--] [<paths>...]\n"
@@ -41384,7 +41384,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-reset.txt:22
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git reset' [-q] [<tree-ish>] [--] <paths>..."
 msgstr ""
 
@@ -41396,7 +41396,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reset.txt:30
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "This means that `git reset <paths>` is the opposite of `git add <paths>`. This command is equivalent to `git restore [--source=<tree-ish>] --staged <paths>...`."
 msgstr ""
 
@@ -41408,7 +41408,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-reset.txt:38
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git reset' (--patch | -p) [<tree-ish>] [--] [<paths>...]"
 msgstr ""
 
@@ -41563,7 +41563,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:138
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git commit ...\n"
 "$ git reset --soft HEAD^      <1>\n"
@@ -41636,7 +41636,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:170
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git commit ...\n"
 "$ git reset --hard HEAD~3   <1>\n"
@@ -41656,7 +41656,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:190
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git pull                         <1>\n"
 "Auto-merging nitfol\n"
@@ -41701,7 +41701,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:215
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git pull                         <1>\n"
 "Auto-merging nitfol\n"
@@ -41827,7 +41827,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:289
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git tag start\n"
 "$ git switch -c branch1\n"
@@ -41870,7 +41870,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:317
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git reset -N HEAD^                        <1>\n"
 "$ git add -p                                <2>\n"
@@ -42096,7 +42096,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-restore.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git restore' [<options>] [--source=<tree>] [--staged] [--worktree] <pathspec>...\n"
 "'git restore' (-p|--patch) [<options>] [--source=<tree>] [--staged] [--worktree] [<pathspec>...]\n"
@@ -42349,7 +42349,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-revert.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git revert' [--[no-]edit] [-n] [-m parent-number] [-s] [-S[<keyid>]] <commit>...\n"
 "'git revert' (--continue | --skip | --abort | --quit)\n"
@@ -42453,7 +42453,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-list.txt:65
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git rev-list' [ --max-count=<number> ]\n"
 "\t     [ --skip=<number> ]\n"
@@ -42556,13 +42556,13 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-list.txt:102
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Another special notation is \"'<commit1>'...'<commit2>'\" which is useful for merges.  The resulting set of commits is the symmetric difference between the two operands.  The following two commands are equivalent:"
 msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-list.txt:106
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git rev-list A B --not $(git merge-base --all A B)\n"
 "\t$ git rev-list A...B\n"
@@ -42588,7 +42588,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-parse.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git rev-parse' [<options>] <args>...\n"
 msgstr ""
 
@@ -43072,7 +43072,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-parse.txt:253
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Resolve \"$GIT_DIR/<path>\" and takes other path relocation variables such as $GIT_OBJECT_DIRECTORY, $GIT_INDEX_FILE... into account. For example, if $GIT_OBJECT_DIRECTORY is set to /foo/bar then \"git rev-parse --git-path objects/abc\" returns /foo/bar/abc."
 msgstr ""
 
@@ -43180,7 +43180,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:290
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<args>..."
 msgstr ""
 
@@ -43312,7 +43312,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:364
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "OPTS_SPEC=\"\\\n"
 "some-command [<options>] <args>...\n"
@@ -43370,7 +43370,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:389
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "usage: some-command [<options>] <args>...\n"
 msgstr ""
 
@@ -43382,7 +43382,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:397
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "    -h, --help            show the help\n"
 "    --foo                 some nifty option --foo\n"
@@ -43393,7 +43393,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:400
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "An option group Header\n"
 "    -C[...]               option C with an optional argument\n"
@@ -43498,7 +43498,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rm.txt:12
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git rm' [-f | --force] [-n] [-r] [--cached] [--ignore-unmatch] [--quiet] [--] <file>...\n"
 msgstr ""
 
@@ -43726,7 +43726,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-email.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git send-email' [<options>] <file|directory|rev-list options>...\n"
 "'git send-email' --dump-aliases\n"
@@ -43794,7 +43794,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:53
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--bcc=<address>,..."
 msgstr ""
 
@@ -43812,7 +43812,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:59
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--cc=<address>,..."
 msgstr ""
 
@@ -43896,7 +43896,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-email.txt:110
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "  [PATCH 0/2] Here is what I did...\n"
 "    [PATCH 1/2] Clean up and tests\n"
@@ -43927,7 +43927,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:119
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--to=<address>,..."
 msgstr ""
 
@@ -44059,7 +44059,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-send-email.txt:188
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "$ git send-email --smtp-auth=\"PLAIN LOGIN GSSAPI\" ...\n"
 msgstr ""
 
@@ -44755,7 +44755,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-pack.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git send-pack' [--all] [--dry-run] [--force] [--receive-pack=<git-receive-pack>]\n"
 "\t\t[--verbose] [--thin] [--atomic]\n"
@@ -45128,7 +45128,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-shortlog.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "'git shortlog' [<options>] [<revision range>] [[--] <path>...]\n"
 "git log --pretty=short | 'git shortlog' [<options>]\n"
@@ -45256,7 +45256,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show-branch.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git show-branch' [-a|--all] [-r|--remotes] [--topo-order | --date-order]\n"
 "\t\t[--current] [--color[=<when>] | --no-color] [--sparse]\n"
@@ -45617,7 +45617,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show-ref.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git show-ref' [-q|--quiet] [--verify] [--head] [-d|--dereference]\n"
 "\t     [-s|--hash[=<n>]] [--abbrev[=<n>]] [--tags]\n"
@@ -45765,7 +45765,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-show-ref.txt:111
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git show-ref --head --dereference\n"
 "832e76a9899f560a90ffd62ae2ce83bbeff58f54 HEAD\n"
@@ -45786,7 +45786,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-show-ref.txt:121
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git show-ref --heads --hash\n"
 "2e3ba0114a1f52b47df29743d6915d056be13278\n"
@@ -45907,7 +45907,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'git show' [<options>] [<object>...]\n"
 msgstr ""
 
@@ -45955,7 +45955,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-show.txt:37
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "<object>..."
 msgstr ""
 
@@ -46213,7 +46213,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stage.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git stage' args...\n"
 msgstr ""
 
@@ -46237,7 +46237,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stash.txt:22
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git stash' list [<options>]\n"
 "'git stash' show [<options>] [<stash>]\n"
@@ -46260,7 +46260,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stash.txt:38
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "The modifications stashed away by this command can be listed with `git stash list`, inspected with `git stash show`, and restored (potentially on top of a different commit) with `git stash apply`.  Calling `git stash` without any arguments is equivalent to `git stash push`.  A stash is by default listed as \"WIP on 'branchname' ...\", but you can give a more descriptive message on the command line when you create one."
 msgstr ""
 
@@ -46272,7 +46272,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-stash.txt:49
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "push [-p|--patch] [-k|--[no-]keep-index] [-u|--include-untracked] [-a|--all] [-q|--quiet] [-m|--message <message>] [--] [<pathspec>...]"
 msgstr ""
 
@@ -46344,7 +46344,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:104
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "stash@{0}: WIP on submit: 6ebd0e2... Update git-stash documentation\n"
 "stash@{1}: On master: 9cc0589... Add git-stash\n"
@@ -46517,7 +46517,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:227
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git pull\n"
 " ...\n"
@@ -46535,7 +46535,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:246
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git switch -c my_wip\n"
@@ -46556,7 +46556,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:257
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git stash\n"
@@ -46580,7 +46580,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:275
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git add --patch foo            # add just first part to the index\n"
@@ -46634,7 +46634,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-status.txt:13
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git status' [<options>...] [--] [<pathspec>...]\n"
 msgstr ""
 
@@ -47111,7 +47111,7 @@ msgstr ""
 
 #. type: delimited block .
 #: en/git-status.txt:345
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "Field       Meaning\n"
 "--------------------------------------------------------\n"
@@ -47432,7 +47432,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-submodule.txt:23
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git submodule' [--quiet] [--cached]\n"
 "'git submodule' [--quiet] add [<options>] [--] <repository> [<path>]\n"
@@ -47503,7 +47503,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:74
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "status [--cached] [--recursive] [--] [<path>...]"
 msgstr ""
 
@@ -47527,7 +47527,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:91
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "init [--] [<path>...]"
 msgstr ""
 
@@ -47557,7 +47557,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:114
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "deinit [-f|--force] (--all|[--] <path>...)"
 msgstr ""
 
@@ -47587,7 +47587,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:132
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "update [--init] [--remote] [-N|--no-fetch] [--[no-]recommend-shallow] [-f|--force] [--checkout|--rebase|--merge] [--reference <repository>] [--depth <depth>] [--recursive] [--jobs <n>] [--] [<path>...]"
 msgstr ""
 
@@ -47711,7 +47711,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:182
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "summary [--cached|--files] [(-n|--summary-limit) <n>] [commit] [--] [<path>...]"
 msgstr ""
 
@@ -47753,7 +47753,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:224
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "sync [--recursive] [--] [<path>...]"
 msgstr ""
 
@@ -48279,7 +48279,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:127
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Fetch unfetched revisions from the Subversion remote we are tracking.  The name of the [svn-remote \"...\"] section in the $GIT_DIR/config file may be specified as an optional command-line argument."
 msgstr ""
 
@@ -48725,7 +48725,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:366
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "is supported, non-numeric args are not: HEAD, NEXT, BASE, PREV, etc ..."
 msgstr ""
 
@@ -49626,7 +49626,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-svn.txt:876
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "# Clone a repo (like git clone):\n"
 "\tgit svn clone http://svn.example.com/project/trunk\n"
@@ -49679,7 +49679,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-svn.txt:924
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "# Do the initial import on a server\n"
 "\tssh server \"cd /pub && git svn clone http://svn.example.com/project [options...]\"\n"
@@ -50394,7 +50394,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-tag.txt:20
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git tag' [-a | -s | -u <keyid>] [-f] [-m <msg> | -F <file>] [-e]\n"
 "\t<tagname> [<commit> | <object>]\n"
@@ -50540,7 +50540,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-tag.txt:103
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "List tags. With optional `<pattern>...`, e.g. `git tag --list 'v-*'`, list only the tags that match the pattern(s)."
 msgstr ""
 
@@ -50830,13 +50830,13 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:319
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "\tgit://git..../proj.git master\n"
 msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:321
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "to get the following updates...\n"
 msgstr ""
 
@@ -50848,7 +50848,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:327
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "$ git pull git://git..../proj.git master\n"
 msgstr ""
 
@@ -50968,7 +50968,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git.txt:55
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Other options are available to control how the manual page is displayed. See linkgit:git-help[1] for more information, because `git --help ...` is converted internally into `git help ...`."
 msgstr ""
 
@@ -51012,7 +51012,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git.txt:82
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Note that omitting the `=` in `git -c foo.bar ...` is allowed and sets `foo.bar` to the boolean true value (just like `[foo]bar` would in a config file). Including the equals but with an empty value (like `git -c foo.bar= ...`) sets `foo.bar` to the empty string which `git config --type=bool` will convert to `false`."
 msgstr ""
 
@@ -51216,7 +51216,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:169
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--list-cmds=group[,group...]"
 msgstr ""
 
@@ -51719,7 +51719,7 @@ msgstr "`GIT_COMMON_DIR`"
 
 #. type: Plain text
 #: en/git.txt:481
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If this variable is set to a path, non-worktree files that are normally in $GIT_DIR will be taken from this path instead. Worktree-specific files such as HEAD or index are taken from $GIT_DIR. See linkgit:gitrepository-layout[5] and linkgit:git-worktree[1] for details. This variable has lower precedence than other path variables such as GIT_INDEX_FILE, GIT_OBJECT_DIRECTORY..."
 msgstr ""
 
@@ -52190,10 +52190,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:685
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2`"
-msgstr "`GIT_TRACE`"
+msgstr "`GIT_TRACE2`"
 
 #. type: Plain text
 #: en/git.txt:689
@@ -52221,10 +52220,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:720
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE_SETUP`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2_EVENT`"
-msgstr "`GIT_TRACE_SETUP`"
+msgstr "`GIT_TRACE2_EVENT`"
 
 #. type: Plain text
 #: en/git.txt:725
@@ -52234,10 +52232,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:726
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE_PERFORMANCE`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2_PERF`"
-msgstr "`GIT_TRACE_PERFORMANCE`"
+msgstr "`GIT_TRACE2_PERF`"
 
 #. type: Plain text
 #: en/git.txt:732
@@ -52676,7 +52673,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-update-index.txt:29
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git update-index'\n"
 "\t     [--add] [--remove | --force-remove] [--replace]\n"
@@ -53236,7 +53233,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-update-index.txt:348
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The command looks at `core.ignorestat` configuration variable.  When this is true, paths updated with `git update-index paths...` and paths updated with other Git commands that update both index and working tree (e.g. 'git apply --index', 'git checkout-index -u', and 'git read-tree -u') are automatically marked as \"assume unchanged\".  Note that \"assume unchanged\" bit is *not* set if `git update-index --refresh` finds the working tree file matches the index (use `git update-index --really-refresh` if you want to mark them as \"assume unchanged\")."
 msgstr ""
 
@@ -54105,7 +54102,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-commit.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-commit' <commit>...\n"
 msgstr ""
 
@@ -54147,7 +54144,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-pack.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-pack' [-v|--verbose] [-s|--stat-only] [--] <pack>.idx ...\n"
 msgstr ""
 
@@ -54159,7 +54156,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-verify-pack.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<pack>.idx ..."
 msgstr ""
 
@@ -54237,7 +54234,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-tag.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-tag' [--format=<format>] <tag>...\n"
 msgstr ""
 
@@ -54255,7 +54252,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-verify-tag.txt:27
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<tag>..."
 msgstr ""
 
@@ -54279,7 +54276,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-web--browse.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git web{litdd}browse' [<options>] <url|file>...\n"
 msgstr ""
 
@@ -54553,7 +54550,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-whatchanged.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git whatchanged' <option>...\n"
 msgstr ""
 
@@ -55083,7 +55080,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-worktree.txt:372
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git worktree add -b emergency-fix ../temp master\n"
 "$ pushd ../temp\n"
@@ -56285,7 +56282,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/pretty-formats.txt:115
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'%C(...)'"
 msgstr ""
 
@@ -56297,7 +56294,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/pretty-formats.txt:129
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "\"CONFIGURATION FILE\" section of linkgit:git-config[1].  By default, colors are shown only when enabled for log output (by `color.diff`, `color.ui`, or `--color`, and respecting the `auto` settings of the former if we are going to a terminal). `%C(auto,...)` is accepted as a historical synonym for the default (e.g., `%C(auto,red)`). Specifying `%C(always,...)` will show the colors even when color is not otherwise enabled (though consider just using `--color=always` to enable color for the whole output, including this format and anything else git might color).  `auto` alone (i.e. `%C(auto)`) will turn on auto coloring on the next placeholders until the color is switched again."
 msgstr ""
 
@@ -57389,7 +57386,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/pull-fetch-param.txt:45
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "Whether that update is allowed without `--force` depends on the ref namespace it's being fetched to, the type of object being fetched, and whether the update is considered to be a fast-forward. Generally, the same rules apply for fetching as when pushing, see the `<refspec>...` section of linkgit:git-push[1] for what those are. Exceptions to those rules particular to 'git fetch' are noted below."
 msgstr ""
 
@@ -57860,13 +57857,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/revisions.txt:280
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "The '...' (three-dot) Symmetric Difference Notation"
 msgstr ""
 
 #. type: Plain text
 #: en/revisions.txt:286
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "A similar notation 'r1\\...r2' is called symmetric difference of 'r1' and 'r2' and is defined as 'r1 r2 --not $(git merge-base --all r1 r2)'.  It is the set of commits that are reachable from either one of 'r1' (left side) or 'r2' (right side) but not from both."
 msgstr ""
 
@@ -57956,7 +57953,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/revisions.txt:331
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'<rev1>\\...<rev2>'"
 msgstr ""
 
@@ -58010,7 +58007,7 @@ msgstr ""
 
 #. type: delimited block .
 #: en/revisions.txt:377
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "   Args   Expanded arguments    Selected commits\n"
 "   D                            G H D\n"
@@ -58500,7 +58497,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:256
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "For example, `--cherry-pick --right-only A...B` omits those commits from `B` which are in `A` or are patch-equivalent to a commit in `A`. In other words, this lists the `+` commits from `git cherry A B`.  More precisely, `--cherry-pick --right-only --no-merges` gives the exact list."
 msgstr ""
 
@@ -58512,7 +58509,7 @@ msgstr "--cherry"
 
 #. type: Plain text
 #: en/rev-list-options.txt:263
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "A synonym for `--right-only --cherry-mark --no-merges`; useful to limit the output to the commits on our side and mark those that have been applied to the other side of a forked history with `git log --cherry upstream...mybranch`, similar to `git cherry upstream mybranch`."
 msgstr ""
 
@@ -58524,7 +58521,7 @@ msgstr "--walk-reflogs"
 
 #. type: Plain text
 #: en/rev-list-options.txt:271
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Instead of walking the commit ancestry chain, walk reflog entries from the most recent one to older ones.  When this option is used you cannot specify commits to exclude (that is, '{caret}commit', 'commit1..commit2', and 'commit1\\...commit2' notations cannot be used)."
 msgstr ""
 
@@ -59517,7 +59514,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:875
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "`--date=format:...` feeds the format `...` to your system `strftime`, except for %z and %Z, which are handled internally.  Use `--date=format:%c` to show the date in your system locale's preferred format.  See the `strftime` manual for a complete list of format placeholders. When using `-local`, the correct syntax is `--date=format-local:...`."
 msgstr ""
 
@@ -59553,7 +59550,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:892
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Print also the parents of the commit (in the form \"commit parent...\").  Also enables parent rewriting, see 'History Simplification' above."
 msgstr ""
 
@@ -59565,7 +59562,7 @@ msgstr "--children"
 
 #. type: Plain text
 #: en/rev-list-options.txt:896
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Print also the children of the commit (in the form \"commit child...\").  Also enables parent rewriting, see 'History Simplification' above."
 msgstr ""
 
@@ -59618,13 +59615,13 @@ msgstr ""
 
 #. type: delimited block -
 #: en/rev-list-options.txt:922
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "\t$ git rev-list --left-right --boundary --pretty=oneline A...B\n"
 msgstr ""
 
 #. type: delimited block -
 #: en/rev-list-options.txt:929
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "\t>bbbbbbb... 3rd on b\n"
 "\t>bbbbbbb... 2nd on b\n"

--- a/po/documentation.nl.po
+++ b/po/documentation.nl.po
@@ -2437,7 +2437,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/config.txt:256
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The value for many variables that specify various sizes can be suffixed with `k`, `M`,... to mean \"scale the number by 1024\", \"by 1024x1024\", etc."
 msgstr ""
 
@@ -2828,7 +2828,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-format.txt:16
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "git-diff-tree [-r] <tree-ish-1> <tree-ish-2> [<pattern>...]"
 msgstr ""
 
@@ -2840,7 +2840,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-format.txt:19
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "git-diff-files [<pattern>...]"
 msgstr ""
 
@@ -3520,7 +3520,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/diff-generate-patch.txt:179
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Unlike the traditional 'unified' diff format, which shows two files A and B with a single column that has `-` (minus -- appears in A but removed in B), `+` (plus -- missing in A but added to B), or `\" \"` (space -- unchanged) prefix, this format compares two or more files file1, file2,... with one file X, and shows how X differs from each of fileN.  One column for each of fileN is prepended to the output line to note how X's line is different from it."
 msgstr ""
 
@@ -3844,7 +3844,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:137
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Generate a diffstat. By default, as much space as necessary will be used for the filename part, and the rest for the graph part. Maximum width defaults to terminal width, or 80 columns if not connected to a terminal, and can be overridden by `<width>`. The width of the filename part can be limited by giving another width `<name-width>` after a comma. The width of the graph part can be limited by using `--stat-graph-width=<width>` (affects all commands generating a stat graph) or by setting `diff.statGraphWidth=<width>` (does not affect `git format-patch`).  By giving a third parameter `<count>`, you can limit the output to the first `<count>` lines, followed by `...` if there are more."
 msgstr ""
 
@@ -3892,13 +3892,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:161
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "-X[<param1,param2,...>]"
 msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:162
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--dirstat[=<param1,param2,...>]"
 msgstr ""
 
@@ -3988,13 +3988,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:209
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--dirstat-by-file[=<param1,param2>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:211
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Synonym for --dirstat=files,param1,param2..."
 msgstr ""
 
@@ -4655,13 +4655,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:527
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--diff-filter=[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:538
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Select only files that are Added (`A`), Copied (`C`), Deleted (`D`), Modified (`M`), Renamed (`R`), have their type (i.e. regular file, symlink, submodule, ...) changed (`T`), are Unmerged (`U`), are Unknown (`X`), or have had their pairing Broken (`B`).  Any combination of the filter characters (including none) can be used.  When `*` (All-or-none) is added to the combination, all paths are selected if there is any file that matches other criteria in the comparison; if there is no file that matches other criteria, nothing is selected."
 msgstr ""
 
@@ -4721,7 +4721,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/diff-options.txt:573
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "+    return !regexec(regexp, two->ptr, 1, &regmatch, 0);\n"
 "...\n"
@@ -5646,7 +5646,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-add.txt:15
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "'git add' [--verbose | -v] [--dry-run | -n] [--force | -f] [--interactive | -i] [--patch | -p]\n"
 "\t  [--edit | -e] [--[no-]all | --[no-]ignore-removal | [--update | -u]]\n"
@@ -5704,7 +5704,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-add.txt:52 en/git-grep.txt:308 en/git-status.txt:148
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid "<pathspec>..."
 msgstr ""
 
@@ -5848,7 +5848,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-add.txt:145
-#, priority:300
+#, ignore-ellipsis, priority:300
 msgid "This option is primarily to help users who are used to older versions of Git, whose \"git add <pathspec>...\" was a synonym for \"git add --no-all <pathspec>...\", i.e. ignored removed files."
 msgstr ""
 
@@ -6346,7 +6346,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-am.txt:20
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git am' [--signoff] [--keep] [--[no-]keep-cr] [--[no-]utf8]\n"
 "\t [--[no-]3way] [--interactive] [--committer-date-is-author-date]\n"
@@ -6366,7 +6366,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-am.txt:29
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "(<mbox>|<Maildir>)..."
 msgstr ""
 
@@ -6902,7 +6902,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-apply.txt:20
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git apply' [--stat] [--numstat] [--summary] [--check] [--index | --intent-to-add] [--3way]\n"
 "\t  [--apply] [--no-add] [--build-fake-ancestor=<file>] [-R | --reverse]\n"
@@ -6928,7 +6928,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-apply.txt:37
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<patch>..."
 msgstr ""
 
@@ -7342,7 +7342,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-archimport.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git archimport' [-h] [-v] [-o] [-a] [-f] [-T] [-D depth] [-t tempdir]\n"
 "               <archive/branch>[:<git-branch>] ...\n"
@@ -7506,7 +7506,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-archive.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git archive' [--format=<fmt>] [--list] [--prefix=<prefix>/] [<extra>]\n"
 "\t      [-o <file> | --output=<file>] [--worktree-attributes]\n"
@@ -7894,7 +7894,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bisect.txt:31
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 " git bisect start [--term-{old,good}=<term> --term-{new,bad}=<term>]\n"
 "\t\t  [--no-checkout] [<bad> [<good>...]] [--] [<paths>...]\n"
@@ -8089,7 +8089,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-bisect.txt:158
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git bisect new [<rev>...]\n"
 msgstr ""
 
@@ -8119,7 +8119,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bisect.txt:175
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If you would like to use your own terms instead of \"bad\"/\"good\" or \"new\"/\"old\", you can choose any names you like (except existing bisect subcommands like `reset`, `start`, ...) by starting the bisection using"
 msgstr ""
 
@@ -8559,7 +8559,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-bisect.txt:463
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git bisect start HEAD <known-good-commit> [ <boundary-commit> ... ] --no-checkout\n"
 "$ git bisect run sh -c '\n"
@@ -9027,7 +9027,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:26
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git branch' [--color[=<when>] | --no-color] [--show-current]\n"
 "\t[-v [--abbrev=<length> | --no-abbrev]]\n"
@@ -9072,7 +9072,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:61
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "The command's second form creates a new branch head named <branchname> which points to the current `HEAD`, or <start-point> if given. As a special case, for <start-point>, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -9270,7 +9270,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:176
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "List branches.  With optional `<pattern>...`, e.g. `git branch --list 'maint-*'`, list only the branches that match the pattern(s)."
 msgstr ""
 
@@ -9517,7 +9517,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:291
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "Sort based on the key given. Prefix `-` to sort in descending order of the value. You may use the --sort=<key> option multiple times, in which case the last key becomes the primary key. The keys supported are the same as those in `git for-each-ref`. Sort order defaults to the value configured for the `branch.sort` variable if exists, or to sorting based on the full refname (including `refs/...` prefix). This lists detached HEAD (if present) first, then local branches and finally remote-tracking branches. See linkgit:git-config[1]."
 msgstr ""
 
@@ -9559,7 +9559,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-branch.txt:317
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git clone git://git.kernel.org/pub/scm/.../linux-2.6 my2.6\n"
 "$ cd my2.6\n"
@@ -9581,7 +9581,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-branch.txt:329
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git clone git://git.kernel.org/.../git.git my.git\n"
 "$ cd my.git\n"
@@ -9695,7 +9695,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bundle.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git bundle' create <file> <git-rev-list-args>\n"
 "'git bundle' verify <file>\n"
@@ -9771,7 +9771,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-bundle.txt:71
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<refname>...]"
 msgstr ""
 
@@ -10547,7 +10547,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-attr.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git check-attr' [-a | --all | <attr>...] [--] <pathname>...\n"
 "'git check-attr' --stdin [-z] [-a | --all | <attr>...]\n"
@@ -10788,7 +10788,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-ignore.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git check-ignore' [<options>] <pathname>...\n"
 "'git check-ignore' [<options>] --stdin\n"
@@ -10964,7 +10964,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-mailmap.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git check-mailmap' [<options>] <contact>...\n"
 msgstr ""
 
@@ -11000,7 +11000,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout-index.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git checkout-index' [-u] [-q] [-a] [-f] [-n] [--prefix=<string>]\n"
 "\t\t   [--stage=<number>|all]\n"
@@ -11275,7 +11275,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:18
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git checkout' [-q] [-f] [-m] [<branch>]\n"
 "'git checkout' [-q] [-f] [-m] --detach [<branch>]\n"
@@ -11386,7 +11386,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-checkout.txt:82
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git checkout' [<tree-ish>] [--] <pathspec>..."
 msgstr ""
 
@@ -11404,7 +11404,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-checkout.txt:98
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git checkout' (-p|--patch) [<tree-ish>] [--] [<pathspec>...]"
 msgstr ""
 
@@ -11746,7 +11746,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:326 en/git-switch.txt:58
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "As a special case, you may use `A...B` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -11776,7 +11776,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:337
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "As a special case, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -12347,7 +12347,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git cherry-pick' [--edit] [-n] [-m parent-number] [-s] [-x] [--ff]\n"
 "\t\t  [-S[<keyid>]] <commit>...\n"
@@ -12404,13 +12404,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-cherry-pick.txt:43 en/git-merge.txt:116 en/git-revert.txt:36 en/git-verify-commit.txt:27
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "<commit>..."
 msgstr ""
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:52
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Commits to cherry-pick.  For a more complete list of ways to spell commits, see linkgit:gitrevisions[7].  Sets of commits can be passed but no traversal is done by default, as if the `--no-walk` option was specified, see linkgit:git-rev-list[1]. Note that specifying a range will feed all <commit>... arguments to a single revision walk (see a later example that uses 'maint master..next')."
 msgstr ""
 
@@ -12440,7 +12440,7 @@ msgstr "-x"
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:78
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When recording the commit, append a line that says \"(cherry picked from commit ...)\" to the original commit message in order to indicate which commit this change was cherry-picked from.  This is done only for cherry picks without conflicts.  Do not use this option if you are cherry-picking from your private branch because the information is useless to the recipient.  If on the other hand you are cherry-picking between two publicly visible branches (e.g. backporting a fix to a maintenance branch for an older release from a development branch), adding this information can be useful."
 msgstr ""
 
@@ -12798,7 +12798,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:58
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git checkout -b topic origin/master\n"
 "# work and create some commits\n"
@@ -12834,7 +12834,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git log --graph --oneline --decorate --boundary origin/master...topic\n"
 "* 7654321 (origin/master) upstream tip commit\n"
@@ -12857,7 +12857,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:96
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git cherry origin/master topic\n"
 "- cccc000... commit C\n"
@@ -12885,7 +12885,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:126
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git log --graph --oneline --decorate --boundary origin/master...topic\n"
 "* 7654321 (origin/master) upstream tip commit\n"
@@ -12911,7 +12911,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:136
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git cherry origin/master topic base\n"
 "- cccc000... commit C\n"
@@ -12963,7 +12963,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-clean.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git clean' [-d] [-f] [-i] [-n] [-q] [-e <pattern>] [-x | -X] [--] <path>...\n"
 msgstr ""
 
@@ -12981,7 +12981,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-clean.txt:25
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If any optional `<path>...` arguments are given, only those paths are affected."
 msgstr ""
 
@@ -13593,7 +13593,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-clone.txt:306
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "$ git clone git://git.kernel.org/pub/scm/.../linux.git my-linux\n"
 "$ cd my-linux\n"
@@ -13623,7 +13623,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-clone.txt:325
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "$ git clone --reference /git/linux.git \\\n"
 "\tgit://git.kernel.org/pub/scm/.../linux.git \\\n"
@@ -13816,7 +13816,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-commit-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git commit-tree' <tree> [(-p <parent>)...]\n"
 "'git commit-tree' [(-p <parent>)...] [-S[<keyid>]] [(-m <message>)...]\n"
@@ -14017,7 +14017,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-commit.txt:17
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git commit' [-a | --interactive | --patch] [-s] [-v] [-u<mode>] [--amend]\n"
 "\t   [--dry-run] [(-c | -C | --fixup | --squash) <commit>]\n"
@@ -14437,7 +14437,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-commit.txt:248
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "\t$ git reset --soft HEAD^\n"
 "\t$ ... do something else to come up with the right tree ...\n"
@@ -14602,7 +14602,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-commit.txt:346 en/git-rm.txt:29
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "<file>..."
 msgstr ""
 
@@ -15579,7 +15579,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-config.txt:428
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "However, if you really only want to replace the line for the default proxy, i.e. the one without a \"for ...\" postfix, do something like this:"
 msgstr ""
 
@@ -16937,7 +16937,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-cvsserver.txt:26
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git-cvsserver' [<options>] [pserver|server] [<directory> ...]\n"
 msgstr ""
 
@@ -17635,7 +17635,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-daemon.txt:25
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git daemon' [--verbose] [--syslog] [--export-all]\n"
 "\t     [--timeout=<n>] [--init-timeout=<n>] [--max-connections=<n>]\n"
@@ -18202,7 +18202,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-describe.txt:14
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "'git describe' [--all] [--tags] [--contains] [--abbrev=<n>] [<commit-ish>...]\n"
 "'git describe' [--all] [--tags] [--contains] [--abbrev=<n>] --dirty[=<mark>]\n"
@@ -18229,7 +18229,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-describe.txt:37
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "<commit-ish>..."
 msgstr ""
 
@@ -18325,7 +18325,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-describe.txt:95
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Always output the long format (the tag, the number of commits and the abbreviated commit name) even when it matches a tag.  This is useful when you want to see parts of the commit object name in \"describe\" output, even when the commit in question happens to be a tagged version.  Instead of just emitting the tag name, it will describe such a commit as v1.2-0-gdeadbee (0th commit since tag v1.2 that points at object deadbee....)."
 msgstr ""
 
@@ -18503,7 +18503,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-files.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git diff-files' [-q] [-0|-1|-2|-3|-c|--cc] [<common diff options>] [<path>...]\n"
 msgstr ""
 
@@ -18575,7 +18575,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-index.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git diff-index' [-m] [--cached] [<common diff options>] <tree-ish> [<path>...]\n"
 msgstr ""
 
@@ -18714,7 +18714,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-index.txt:102
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "  torvalds@ppc970:~/v2.6/linux> git diff-index --abbrev HEAD\n"
 "  :100644 100664 7476bb... 000000...      kernel/sched.c\n"
@@ -18752,7 +18752,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-difftool.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git difftool' [<options>] [<commit> [<commit>]] [--] [<path>...]\n"
 msgstr ""
 
@@ -19064,7 +19064,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git diff-tree' [--stdin] [-m] [-s] [-v] [--no-commit-id] [--pretty]\n"
 "\t      [-t] [-r] [-c | --cc] [--combined-all-paths] [--root]\n"
@@ -19097,7 +19097,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff-tree.txt:32 en/git-diff.txt:114 en/git-submodule.txt:422
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "<path>..."
 msgstr ""
 
@@ -19223,7 +19223,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:17
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git diff' [<options>] [<commit>] [--] [<path>...]\n"
 "'git diff' [<options>] --cached [<commit>] [--] [<path>...]\n"
@@ -19240,7 +19240,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:24
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] [--] [<path>...]"
 msgstr ""
 
@@ -19264,7 +19264,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:41
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] --cached [<commit>] [--] [<path>...]"
 msgstr ""
 
@@ -19276,7 +19276,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:51
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit> [--] [<path>...]"
 msgstr ""
 
@@ -19288,7 +19288,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:59
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit> <commit> [--] [<path>...]"
 msgstr ""
 
@@ -19300,7 +19300,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:64
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit>..<commit> [--] [<path>...]"
 msgstr ""
 
@@ -19312,13 +19312,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:70
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit>\\...<commit> [--] [<path>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:77
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "This form is to view the changes on the branch containing and up to the second <commit>, starting at a common ancestor of both <commit>.  \"git diff A\\...B\" is equivalent to \"git diff $(git merge-base A B) B\".  You can omit any one of <commit>, which has the same effect as using HEAD instead."
 msgstr ""
 
@@ -19330,7 +19330,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:89
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "For a more complete list of ways to spell <commit>, see \"SPECIFYING REVISIONS\" section in linkgit:gitrevisions[7].  However, \"diff\" is about comparing two _endpoints_, not ranges, and the range notations (\"<commit>..<commit>\" and \"<commit>\\...<commit>\") do not mean a range as defined in the \"SPECIFYING RANGES\" section in linkgit:gitrevisions[7]."
 msgstr ""
 
@@ -19438,7 +19438,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-diff.txt:160
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git diff topic master    <1>\n"
 "$ git diff topic..master   <2>\n"
@@ -19758,7 +19758,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:143
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<git-rev-list-args>...]"
 msgstr ""
 
@@ -19839,7 +19839,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-fast-export.txt:215
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git init anon-repo\n"
 "$ cd anon-repo\n"
@@ -22149,7 +22149,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch-pack.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git fetch-pack' [--all] [--quiet|-q] [--keep|-k] [--thin] [--include-tag]\n"
 "\t[--upload-pack=<git-upload-pack>]\n"
@@ -22303,7 +22303,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fetch-pack.txt:117 en/git-ls-remote.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<refs>..."
 msgstr ""
 
@@ -22333,7 +22333,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch.txt:16
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git fetch' [<options>] [<repository> [<refspec>...]]\n"
 "'git fetch' [<options>] <group>\n"
@@ -22674,7 +22674,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch.txt:226
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "For a successfully fetched ref, the summary shows the old and new values of the ref in a form suitable for using as an argument to `git log` (this is `<old>..<new>` in most cases, and `<old>...<new>` for forced non-fast-forward updates)."
 msgstr ""
 
@@ -22796,7 +22796,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:18
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git filter-branch' [--setup <command>] [--subdirectory-filter <directory>]\n"
 "\t[--env-filter <command>] [--tree-filter <command>]\n"
@@ -22936,7 +22936,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:117
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for rewriting the index.  It is similar to the tree filter but does not check out the tree, which makes it much faster.  Frequently used with `git rm --cached --ignore-unmatch ...`, see EXAMPLES below.  For hairy cases, see linkgit:git-update-index[1]."
 msgstr ""
 
@@ -22948,7 +22948,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:125
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for rewriting the commit's parent list.  It will receive the parent string on stdin and shall output the new parent string on stdout.  The parent string is in the format described in linkgit:git-commit-tree[1]: empty for the initial commit, \"-p parent\" for a normal commit and \"-p parent1 -p parent2 -p parent3 ...\" for a merge commit."
 msgstr ""
 
@@ -22972,7 +22972,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:138
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for performing the commit.  If this filter is specified, it will be called instead of the 'git commit-tree' command, with arguments of the form \"<TREE_ID> [(-p <PARENT_COMMIT_ID>)...]\" and the log message on stdin.  The commit id is expected on stdout."
 msgstr ""
 
@@ -23074,7 +23074,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-filter-branch.txt:207
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<rev-list options>..."
 msgstr ""
 
@@ -23335,7 +23335,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-filter-branch.txt:388
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git filter-branch ... C..H\n"
 msgstr ""
 
@@ -23347,7 +23347,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-filter-branch.txt:395
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "git filter-branch ... C..H --not D\n"
 "git filter-branch ... D..H --not C\n"
@@ -23586,7 +23586,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git for-each-ref' [--count=<count>] [--shell|--perl|--python|--tcl]\n"
 "\t\t   [(--sort=<key>)...] [--format=<format>] [<pattern>...]\n"
@@ -23603,7 +23603,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-for-each-ref.txt:29 en/git-show-ref.txt:88
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<pattern>..."
 msgstr ""
 
@@ -23896,7 +23896,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:197
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Left-, middle-, or right-align the content between %(align:...) and %(end). The \"align:\" is followed by `width=<width>` and `position=<position>` in any order separated by a comma, where the `<position>` is either left, right or middle, default being left and `<width>` is the total length of the content with alignment. For brevity, the \"width=\" and/or \"position=\" prefixes may be omitted, and bare <width> and <position> used instead.  For instance, `%(align:<width>,<position>)`. If the contents length is more than the width then no alignment is performed. If used with `--quote` everything in between %(align:...) and %(end) is quoted, but if nested then only the topmost level performs quoting."
 msgstr ""
 
@@ -23908,7 +23908,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:210
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Used as %(if)...%(then)...%(end) or %(if)...%(then)...%(else)...%(end).  If there is an atom with value or string literal after the %(if) then everything after the %(then) is printed, else if the %(else) atom is used, then everything after %(else) is printed. We ignore space when evaluating the string before %(then), this is useful when we use the %(HEAD) atom which prints either \"*\" or \" \" and we want to apply the 'if' condition only on the 'HEAD' ref.  Append \":equals=<string>\" or \":notequals=<string>\" to compare the value between the %(if:...) and %(then) atoms with the given string."
 msgstr ""
 
@@ -24129,7 +24129,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:361
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "An example to show the usage of %(if)...%(then)...%(else)...%(end).  This prefixes the current branch with a star."
 msgstr ""
 
@@ -24141,7 +24141,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:369
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "An example to show the usage of %(if)...%(then)...%(end).  This prints the authorname, if present."
 msgstr ""
 
@@ -24787,7 +24787,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:372
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "Do the same for ia64 so we can have sleek & trim looking\n"
 "...\n"
@@ -24795,7 +24795,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:380
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Typically it will be placed in a MUA's drafts folder, edited to add timely commentary that should not go in the changelog after the three dashes, and then sent as a message whose body, in our example, starts with \"arch/arm config files were...\".  On the receiving end, readers can save interesting patches in a UNIX mailbox and apply them with linkgit:git-am[1]."
 msgstr ""
 
@@ -24807,7 +24807,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:390
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "...\n"
 "> So we should do such-and-such.\n"
@@ -24829,7 +24829,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:398
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "arch/arm config files were slimmed down using a python script\n"
 "...\n"
@@ -25003,7 +25003,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:499
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Configure your mail server composition as plain text: Edit...Account Settings...Composition & Addressing, uncheck \"Compose Messages in HTML\"."
 msgstr ""
 
@@ -25140,7 +25140,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:573
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Use Message -> Insert file... and insert the patch."
 msgstr ""
 
@@ -25315,7 +25315,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fsck-objects.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git fsck-objects' ...\n"
 msgstr ""
 
@@ -25703,7 +25703,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-gc.txt:55
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Once housekeeping is triggered by exceeding the limits of configuration options such as `gc.auto` and `gc.autoPackLimit`, all other housekeeping tasks (e.g. rerere, working trees, reflog...) will be performed as well."
 msgstr ""
 
@@ -25877,7 +25877,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-grep.txt:32
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git grep' [-a | --text] [-I] [--textconv] [-i | --ignore-case] [-w | --word-regexp]\n"
 "\t   [-v | --invert-match] [-h|-H] [--full-name]\n"
@@ -26486,7 +26486,7 @@ msgstr "--not"
 
 #. type: Labeled list
 #: en/git-grep.txt:284
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "( ... )"
 msgstr ""
 
@@ -26516,7 +26516,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-grep.txt:300
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<tree>..."
 msgstr ""
 
@@ -26834,7 +26834,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-hash-object.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git hash-object' [-t <type>] [-w] [--path=<file>|--no-filters] [--stdin [--literally]] [--] <file>...\n"
 "'git hash-object' [-t <type>] [-w] --stdin-paths [--no-filters]\n"
@@ -26964,7 +26964,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-help.txt:38
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Note that `git --help ...` is identical to `git help ...` because the former is internally converted into the latter."
 msgstr ""
 
@@ -27414,7 +27414,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:102
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tAuthType Basic\n"
 "\tAuthName \"Git Access\"\n"
@@ -27432,7 +27432,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:115
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "<LocationMatch \"^/git/.*/git-receive-pack$\">\n"
 "\tAuthType Basic\n"
@@ -27456,7 +27456,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:136
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "<Location /git/private>\n"
 "\tAuthType Basic\n"
@@ -27606,7 +27606,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:231
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "auth.require = (\n"
 "\t\"/\" => (\n"
@@ -27809,7 +27809,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-http-push.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git http-push' [--all] [--dry-run] [--force] [--verbose] <url> <ref> [<ref>...]\n"
 msgstr ""
 
@@ -27878,7 +27878,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-http-push.txt:54 en/git-send-pack.txt:98
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<ref>..."
 msgstr ""
 
@@ -28743,7 +28743,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-interpret-trailers.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git interpret-trailers' [<options>] [(--trailer <token>[(=|:)<value>])...] [<file>...]\n"
 "'git interpret-trailers' [<options>] [--parse] [<file>...]\n"
@@ -29415,7 +29415,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-log.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'git log' [<options>] [<revision range>] [[--] <path>...]\n"
 msgstr ""
 
@@ -29513,7 +29513,7 @@ msgstr "--full-diff"
 
 #. type: Plain text
 #: en/git-log.txt:63
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Without this flag, `git log -p <path>...` shows commits that touch the specified paths, and diffs about the same specified paths.  With this, the full diff is shown for commits that touch the specified paths; this means that \"<path>...\" limits only commits, and doesn't limit diff for those commits."
 msgstr ""
 
@@ -29567,7 +29567,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-log.txt:93 en/git-shortlog.txt:72
-#, fuzzy, no-wrap, priority:260
+#, fuzzy, ignore-ellipsis, no-wrap, priority:260
 #| msgid "--path"
 msgid "[--] <path>..."
 msgstr "--path"
@@ -29844,7 +29844,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-files.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-files' [-z] [-t] [-v] [-f]\n"
 "\t\t(--[cached|deleted|others|ignored|stage|unmerged|killed|modified])*\n"
@@ -30325,7 +30325,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-remote.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-remote' [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
 "\t      [-q | --quiet] [--exit-code] [--get-url] [--sort=<key>]\n"
@@ -30430,7 +30430,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-remote.txt:91
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When unspecified, all references, after filtering done with --heads and --tags, are shown.  When <refs>... are specified, only references matching the given patterns are displayed."
 msgstr ""
 
@@ -30476,7 +30476,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-tree' [-d] [-r] [-t] [-l] [-z]\n"
 "\t    [--name-only] [--name-status] [--full-name] [--full-tree] [--abbrev[=<n>]]\n"
@@ -30557,7 +30557,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-ls-tree.txt:76
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<path>...]"
 msgstr ""
 
@@ -30767,7 +30767,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mailsplit.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git mailsplit' [-b] [-f<nn>] [-d<prec>] [--keep-cr] [--mboxrd]\n"
 "\t\t-o<directory> [--] [(<mbox>|<Maildir>)...]\n"
@@ -30889,7 +30889,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git merge-base' [-a|--all] <commit> <commit>...\n"
 "'git merge-base' [-a|--all] --octopus <commit>...\n"
@@ -31086,7 +31086,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:139
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tA=$(git rev-parse --verify A)\n"
 "\tif test \"$A\" = \"$(git merge-base A B)\"\n"
@@ -31103,7 +31103,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:146
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tif git merge-base --is-ancestor A B\n"
 "\tthen\n"
@@ -31590,7 +31590,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mergetool.txt:12
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git mergetool' [--tool=<tool>] [-y | --[no-]prompt] [<file>...]\n"
 msgstr ""
 
@@ -31752,7 +31752,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge.txt:17
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git merge' [-n] [--stat] [--no-commit] [--squash] [--[no-]edit]\n"
 "\t[-s <strategy>] [-X <strategy-option>] [-S[<keyid>]]\n"
@@ -32345,7 +32345,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mv.txt:13
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git mv' <options>... <args>...\n"
 msgstr ""
 
@@ -32357,7 +32357,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mv.txt:20
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 " git mv [-v] [-f] [-n] [-k] <source> <destination>\n"
 " git mv [-v] [-f] [-n] [-k] <source> ... <destination directory>\n"
@@ -32425,7 +32425,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-name-rev.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git name-rev' [--tags] [--refs=<pattern>]\n"
 "\t       ( --all | --stdin | <commit-ish>... )\n"
@@ -32543,7 +32543,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-notes.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git notes' [list [<object>]]\n"
 "'git notes' add [-f] [--allow-empty] [-F <file> | -m <msg> | (-c | -C) <object>] [<object>]\n"
@@ -32879,7 +32879,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-notes.txt:229
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Commit notes are blobs containing extra information about an object (usually information to supplement a commit's message).  These blobs are taken from notes refs.  A notes ref is usually a branch which contains \"files\" whose paths are the object names for the objects they describe, with some directory separators included for performance reasons footnote:[Permitted pathnames have the form 'ab'`/`'cd'`/`'ef'`/`'...'`/`'abcdef...': a sequence of directory names of two hexadecimal digits each followed by a filename with the rest of the object ID.]."
 msgstr ""
 
@@ -32945,7 +32945,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-notes.txt:288
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git notes add -m 'Tested-by: Johannes Sixt <j6t@kdbg.org>' 72a144e2\n"
 "$ git show -s 72a144e\n"
@@ -33164,7 +33164,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-p4.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git p4 clone' [<sync options>] [<clone options>] <p4 depot path>...\n"
 "'git p4 sync' [<sync options>] [<p4 depot path>...]\n"
@@ -33998,7 +33998,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-p4.txt:445
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The full syntax for a p4 view is documented in 'p4 help views'.  'git p4' knows only a subset of the view syntax.  It understands multi-line mappings, overlays with '+', exclusions with '-' and double-quotes around whitespace.  Of the possible wildcards, 'git p4' only handles '...', and only when it is at the end of the path.  'git p4' will complain if it encounters an unhandled wildcard."
 msgstr ""
 
@@ -34040,7 +34040,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-p4.txt:475
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "//depot/main/...\n"
 "//depot/branch1/...\n"
@@ -34054,7 +34054,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-p4.txt:480
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "//depot/main/... //depot/branch1/...\n"
 msgstr ""
 
@@ -35172,7 +35172,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-pack-redundant.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git pack-redundant' [ --verbose ] [ --alt-odb ] < --all | .pack filename ... >\n"
 msgstr ""
 
@@ -35472,7 +35472,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-prune.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git prune' [-n] [-v] [--progress] [--expire <time>] [--] [<head>...]\n"
 msgstr ""
 
@@ -35527,7 +35527,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-prune.txt:54
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<head>..."
 msgstr ""
 
@@ -35581,7 +35581,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-pull.txt:13
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "'git pull' [<options>] [<repository> [<refspec>...]]\n"
 msgstr ""
 
@@ -35929,7 +35929,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:18
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git push' [--all | --mirror | --tags] [--follow-tags] [--atomic] [-n | --dry-run] [--receive-pack=<git-receive-pack>]\n"
 "\t   [--repo=<repository>] [-f | --force] [-d | --delete] [--prune] [-v | --verbose]\n"
@@ -35959,7 +35959,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:39
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "When the command line does not specify what to push with `<refspec>...` arguments or `--all`, `--mirror`, `--tags` options, the command finds the default `<refspec>` by consulting `remote.*.push` configuration, and if it is not found, honors `push.default` configuration to decide what to push (See linkgit:git-config[1] for the meaning of `push.default`)."
 msgstr ""
 
@@ -35983,7 +35983,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:56
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "<refspec>..."
 msgstr ""
 
@@ -36344,7 +36344,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:343
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "Note that `--force` applies to all the refs that are pushed, hence using it with `push.default` set to `matching` or with multiple push destinations configured with `remote.*.push` may overwrite refs other than the current branch (including local refs that are strictly behind their remote counterpart).  To force a push to only one branch, use a `+` in front of the refspec to push (e.g `git push origin +master` to force a push to the `master` branch). See the `<refspec>...` section above for details."
 msgstr ""
 
@@ -36476,7 +36476,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:445
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "For a successfully pushed ref, the summary shows the old and new values of the ref in a form suitable for using as an argument to `git log` (this is `<old>..<new>` in most cases, and `<old>...<new>` for forced non-fast-forward updates)."
 msgstr ""
 
@@ -36737,7 +36737,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:616
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "See the section describing `<refspec>...` above for a discussion of the matching semantics."
 msgstr ""
 
@@ -37438,7 +37438,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-read-tree.txt:357
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git fetch git://.... linus\n"
 "$ LT=`git rev-parse FETCH_HEAD`\n"
@@ -37492,7 +37492,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-read-tree.txt:405
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "'git read-tree' and other merge-based commands ('git merge', 'git checkout'...) can help maintaining the skip-worktree bitmap and working directory update. `$GIT_DIR/info/sparse-checkout` is used to define the skip-worktree reference bitmap. When 'git read-tree' needs to update the working directory, it resets the skip-worktree bit in the index based on this file, which uses the same syntax as .gitignore files.  If an entry matches a pattern in this file, skip-worktree will not be set on that entry. Otherwise, skip-worktree will be set."
 msgstr ""
 
@@ -37872,7 +37872,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:219
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "As a special case, you may use \"A\\...B\" as a shortcut for the merge base of A and B if there is exactly one merge base. You can leave out at most one of A and B, in which case it defaults to HEAD."
 msgstr ""
 
@@ -38136,7 +38136,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:430
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "It is currently only possible to recreate the merge commits using the `recursive` merge strategy; Different merge strategies can be used only via explicit `exec git merge -s <strategy> [...]` commands."
 msgstr ""
 
@@ -38190,7 +38190,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:457
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "\tgit rebase -i --exec \"cmd1 && cmd2 && ...\"\n"
 msgstr ""
 
@@ -38202,7 +38202,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:461
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "\tgit rebase -i --exec \"cmd1\" --exec \"cmd2\" --exec ...\n"
 msgstr ""
 
@@ -38238,7 +38238,7 @@ msgstr "--no-autosquash"
 
 #. type: Plain text
 #: en/git-rebase.txt:495
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When the commit log message begins with \"squash! ...\" (or \"fixup! ...\"), and there is already a commit in the todo list that matches the same `...`, automatically modify the todo list of rebase -i so that the commit marked for squashing comes right after the commit to be modified, and change the action of the moved commit from `pick` to `squash` (or `fixup`).  A commit matches the `...` if the commit subject matches, or if the `...` refers to the commit's hash. As a fall-back, partial matches of the commit subject work, too.  The recommended way to create fixup/squash commits is by using the `--fixup`/`--squash` options of linkgit:git-commit[1]."
 msgstr ""
 
@@ -38568,7 +38568,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:636
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "pick deadbee The oneline of this commit\n"
 "pick fa1afe1 The oneline of the next commit\n"
@@ -38672,7 +38672,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:710
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "pick deadbee Implement feature XXX\n"
 "fixup f1a5c00 Fix to feature XXX\n"
@@ -38691,7 +38691,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:720
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The \"exec\" command launches the command in a shell (the one specified in `$SHELL`, or the default shell if `$SHELL` is not set), so you can use shell features (like \"cd\", \">\", \";\" ...). The command is run from the root of the working tree."
 msgstr ""
 
@@ -38835,7 +38835,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:815
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "    o---o---o---o---o---o---o---o  master\n"
 "\t \\\t\t\t \\\n"
@@ -39633,7 +39633,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reflog.txt:27
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git reflog' ['show'] [log-options] [<ref>]\n"
 "'git reflog expire' [--expire=<time>] [--expire-unreachable=<time>]\n"
@@ -39820,7 +39820,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-remote-ext.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git remote add <nick> \"ext::<command>[ <arguments>...]\"\n"
 msgstr ""
 
@@ -39958,7 +39958,7 @@ msgstr "GIT_EXT_SERVICE"
 
 #. type: Plain text
 #: en/git-remote-ext.txt:70
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Set to long name (git-upload-pack, etc...) of service helper needs to invoke."
 msgstr ""
 
@@ -39970,7 +39970,7 @@ msgstr "GIT_EXT_SERVICE_NOPREFIX"
 
 #. type: Plain text
 #: en/git-remote-ext.txt:74
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Set to long name (upload-pack, etc...) of service helper needs to invoke."
 msgstr ""
 
@@ -40150,7 +40150,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-remote.txt:25
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git remote' [-v | --verbose]\n"
 "'git remote add' [-t <branch>] [-m <master>] [-f] [--[no-]tags] [--mirror=<fetch|push>] <name> <url>\n"
@@ -40469,7 +40469,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-remote.txt:235
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "$ git remote\n"
 "origin\n"
@@ -40713,7 +40713,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-replace.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git replace' [-f] <object> <replacement>\n"
 "'git replace' [-f] --edit <object>\n"
@@ -40833,13 +40833,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-replace.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--graft <commit> [<parent>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/git-replace.txt:93
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Create a graft commit. A new commit is created with the same content as <commit> except that its parents will be [<parent>...] instead of <commit>'s parents. A replacement ref is then created to replace <commit> with the newly created commit. Use `--convert-graft-file` to convert a `$GIT_DIR/info/grafts` file and use replace refs instead."
 msgstr ""
 
@@ -41261,7 +41261,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rerere.txt:121
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git switch topic\n"
 "\t$ git merge master\n"
@@ -41293,7 +41293,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rerere.txt:145
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git switch topic\n"
 "\t$ git merge master\n"
@@ -41398,7 +41398,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reset.txt:14
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git reset' [-q] [<tree-ish>] [--] <paths>...\n"
 "'git reset' (--patch | -p) [<tree-ish>] [--] [<paths>...]\n"
@@ -41413,7 +41413,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-reset.txt:22
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git reset' [-q] [<tree-ish>] [--] <paths>..."
 msgstr ""
 
@@ -41425,7 +41425,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reset.txt:30
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "This means that `git reset <paths>` is the opposite of `git add <paths>`. This command is equivalent to `git restore [--source=<tree-ish>] --staged <paths>...`."
 msgstr ""
 
@@ -41437,7 +41437,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-reset.txt:38
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git reset' (--patch | -p) [<tree-ish>] [--] [<paths>...]"
 msgstr ""
 
@@ -41592,7 +41592,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:138
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git commit ...\n"
 "$ git reset --soft HEAD^      <1>\n"
@@ -41665,7 +41665,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:170
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git commit ...\n"
 "$ git reset --hard HEAD~3   <1>\n"
@@ -41685,7 +41685,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:190
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git pull                         <1>\n"
 "Auto-merging nitfol\n"
@@ -41730,7 +41730,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:215
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git pull                         <1>\n"
 "Auto-merging nitfol\n"
@@ -41856,7 +41856,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:289
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git tag start\n"
 "$ git switch -c branch1\n"
@@ -41899,7 +41899,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:317
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git reset -N HEAD^                        <1>\n"
 "$ git add -p                                <2>\n"
@@ -42125,7 +42125,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-restore.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git restore' [<options>] [--source=<tree>] [--staged] [--worktree] <pathspec>...\n"
 "'git restore' (-p|--patch) [<options>] [--source=<tree>] [--staged] [--worktree] [<pathspec>...]\n"
@@ -42378,7 +42378,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-revert.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git revert' [--[no-]edit] [-n] [-m parent-number] [-s] [-S[<keyid>]] <commit>...\n"
 "'git revert' (--continue | --skip | --abort | --quit)\n"
@@ -42482,7 +42482,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-list.txt:65
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git rev-list' [ --max-count=<number> ]\n"
 "\t     [ --skip=<number> ]\n"
@@ -42585,13 +42585,13 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-list.txt:102
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Another special notation is \"'<commit1>'...'<commit2>'\" which is useful for merges.  The resulting set of commits is the symmetric difference between the two operands.  The following two commands are equivalent:"
 msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-list.txt:106
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git rev-list A B --not $(git merge-base --all A B)\n"
 "\t$ git rev-list A...B\n"
@@ -42617,7 +42617,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-parse.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git rev-parse' [<options>] <args>...\n"
 msgstr ""
 
@@ -43102,7 +43102,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-parse.txt:253
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Resolve \"$GIT_DIR/<path>\" and takes other path relocation variables such as $GIT_OBJECT_DIRECTORY, $GIT_INDEX_FILE... into account. For example, if $GIT_OBJECT_DIRECTORY is set to /foo/bar then \"git rev-parse --git-path objects/abc\" returns /foo/bar/abc."
 msgstr ""
 
@@ -43210,7 +43210,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:290
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<args>..."
 msgstr ""
 
@@ -43342,7 +43342,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:364
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "OPTS_SPEC=\"\\\n"
 "some-command [<options>] <args>...\n"
@@ -43400,7 +43400,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:389
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "usage: some-command [<options>] <args>...\n"
 msgstr ""
 
@@ -43412,7 +43412,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:397
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "    -h, --help            show the help\n"
 "    --foo                 some nifty option --foo\n"
@@ -43423,7 +43423,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:400
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "An option group Header\n"
 "    -C[...]               option C with an optional argument\n"
@@ -43528,7 +43528,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rm.txt:12
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git rm' [-f | --force] [-n] [-r] [--cached] [--ignore-unmatch] [--quiet] [--] <file>...\n"
 msgstr ""
 
@@ -43756,7 +43756,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-email.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git send-email' [<options>] <file|directory|rev-list options>...\n"
 "'git send-email' --dump-aliases\n"
@@ -43824,7 +43824,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:53
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--bcc=<address>,..."
 msgstr ""
 
@@ -43842,7 +43842,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:59
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--cc=<address>,..."
 msgstr ""
 
@@ -43926,7 +43926,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-email.txt:110
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "  [PATCH 0/2] Here is what I did...\n"
 "    [PATCH 1/2] Clean up and tests\n"
@@ -43957,7 +43957,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:119
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--to=<address>,..."
 msgstr ""
 
@@ -44089,7 +44089,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-send-email.txt:188
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "$ git send-email --smtp-auth=\"PLAIN LOGIN GSSAPI\" ...\n"
 msgstr ""
 
@@ -44785,7 +44785,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-pack.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git send-pack' [--all] [--dry-run] [--force] [--receive-pack=<git-receive-pack>]\n"
 "\t\t[--verbose] [--thin] [--atomic]\n"
@@ -45159,7 +45159,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-shortlog.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "'git shortlog' [<options>] [<revision range>] [[--] <path>...]\n"
 "git log --pretty=short | 'git shortlog' [<options>]\n"
@@ -45287,7 +45287,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show-branch.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git show-branch' [-a|--all] [-r|--remotes] [--topo-order | --date-order]\n"
 "\t\t[--current] [--color[=<when>] | --no-color] [--sparse]\n"
@@ -45648,7 +45648,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show-ref.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git show-ref' [-q|--quiet] [--verify] [--head] [-d|--dereference]\n"
 "\t     [-s|--hash[=<n>]] [--abbrev[=<n>]] [--tags]\n"
@@ -45796,7 +45796,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-show-ref.txt:111
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git show-ref --head --dereference\n"
 "832e76a9899f560a90ffd62ae2ce83bbeff58f54 HEAD\n"
@@ -45817,7 +45817,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-show-ref.txt:121
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git show-ref --heads --hash\n"
 "2e3ba0114a1f52b47df29743d6915d056be13278\n"
@@ -45938,7 +45938,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'git show' [<options>] [<object>...]\n"
 msgstr ""
 
@@ -45986,7 +45986,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-show.txt:37
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "<object>..."
 msgstr ""
 
@@ -46244,7 +46244,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stage.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git stage' args...\n"
 msgstr ""
 
@@ -46268,7 +46268,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stash.txt:22
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git stash' list [<options>]\n"
 "'git stash' show [<options>] [<stash>]\n"
@@ -46291,7 +46291,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stash.txt:38
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "The modifications stashed away by this command can be listed with `git stash list`, inspected with `git stash show`, and restored (potentially on top of a different commit) with `git stash apply`.  Calling `git stash` without any arguments is equivalent to `git stash push`.  A stash is by default listed as \"WIP on 'branchname' ...\", but you can give a more descriptive message on the command line when you create one."
 msgstr ""
 
@@ -46303,7 +46303,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-stash.txt:49
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "push [-p|--patch] [-k|--[no-]keep-index] [-u|--include-untracked] [-a|--all] [-q|--quiet] [-m|--message <message>] [--] [<pathspec>...]"
 msgstr ""
 
@@ -46375,7 +46375,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:104
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "stash@{0}: WIP on submit: 6ebd0e2... Update git-stash documentation\n"
 "stash@{1}: On master: 9cc0589... Add git-stash\n"
@@ -46548,7 +46548,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:227
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git pull\n"
 " ...\n"
@@ -46566,7 +46566,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:246
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git switch -c my_wip\n"
@@ -46587,7 +46587,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:257
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git stash\n"
@@ -46611,7 +46611,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:275
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git add --patch foo            # add just first part to the index\n"
@@ -46665,7 +46665,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-status.txt:13
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git status' [<options>...] [--] [<pathspec>...]\n"
 msgstr ""
 
@@ -47145,7 +47145,7 @@ msgstr ""
 
 #. type: delimited block .
 #: en/git-status.txt:345
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "Field       Meaning\n"
 "--------------------------------------------------------\n"
@@ -47466,7 +47466,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-submodule.txt:23
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git submodule' [--quiet] [--cached]\n"
 "'git submodule' [--quiet] add [<options>] [--] <repository> [<path>]\n"
@@ -47537,7 +47537,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:74
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "status [--cached] [--recursive] [--] [<path>...]"
 msgstr ""
 
@@ -47561,7 +47561,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:91
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "init [--] [<path>...]"
 msgstr ""
 
@@ -47591,7 +47591,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:114
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "deinit [-f|--force] (--all|[--] <path>...)"
 msgstr ""
 
@@ -47621,7 +47621,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:132
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "update [--init] [--remote] [-N|--no-fetch] [--[no-]recommend-shallow] [-f|--force] [--checkout|--rebase|--merge] [--reference <repository>] [--depth <depth>] [--recursive] [--jobs <n>] [--] [<path>...]"
 msgstr ""
 
@@ -47745,7 +47745,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:182
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "summary [--cached|--files] [(-n|--summary-limit) <n>] [commit] [--] [<path>...]"
 msgstr ""
 
@@ -47787,7 +47787,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:224
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "sync [--recursive] [--] [<path>...]"
 msgstr ""
 
@@ -48315,7 +48315,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:127
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Fetch unfetched revisions from the Subversion remote we are tracking.  The name of the [svn-remote \"...\"] section in the $GIT_DIR/config file may be specified as an optional command-line argument."
 msgstr ""
 
@@ -48761,7 +48761,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:366
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "is supported, non-numeric args are not: HEAD, NEXT, BASE, PREV, etc ..."
 msgstr ""
 
@@ -49664,7 +49664,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-svn.txt:876
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "# Clone a repo (like git clone):\n"
 "\tgit svn clone http://svn.example.com/project/trunk\n"
@@ -49717,7 +49717,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-svn.txt:924
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "# Do the initial import on a server\n"
 "\tssh server \"cd /pub && git svn clone http://svn.example.com/project [options...]\"\n"
@@ -50432,7 +50432,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-tag.txt:20
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git tag' [-a | -s | -u <keyid>] [-f] [-m <msg> | -F <file>] [-e]\n"
 "\t<tagname> [<commit> | <object>]\n"
@@ -50578,7 +50578,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-tag.txt:103
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "List tags. With optional `<pattern>...`, e.g. `git tag --list 'v-*'`, list only the tags that match the pattern(s)."
 msgstr ""
 
@@ -50868,13 +50868,13 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:319
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "\tgit://git..../proj.git master\n"
 msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:321
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "to get the following updates...\n"
 msgstr ""
 
@@ -50886,7 +50886,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:327
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "$ git pull git://git..../proj.git master\n"
 msgstr ""
 
@@ -51006,7 +51006,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git.txt:55
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Other options are available to control how the manual page is displayed. See linkgit:git-help[1] for more information, because `git --help ...` is converted internally into `git help ...`."
 msgstr ""
 
@@ -51050,7 +51050,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git.txt:82
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Note that omitting the `=` in `git -c foo.bar ...` is allowed and sets `foo.bar` to the boolean true value (just like `[foo]bar` would in a config file). Including the equals but with an empty value (like `git -c foo.bar= ...`) sets `foo.bar` to the empty string which `git config --type=bool` will convert to `false`."
 msgstr ""
 
@@ -51254,7 +51254,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:169
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--list-cmds=group[,group...]"
 msgstr ""
 
@@ -51757,7 +51757,7 @@ msgstr "`GIT_COMMON_DIR`"
 
 #. type: Plain text
 #: en/git.txt:481
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If this variable is set to a path, non-worktree files that are normally in $GIT_DIR will be taken from this path instead. Worktree-specific files such as HEAD or index are taken from $GIT_DIR. See linkgit:gitrepository-layout[5] and linkgit:git-worktree[1] for details. This variable has lower precedence than other path variables such as GIT_INDEX_FILE, GIT_OBJECT_DIRECTORY..."
 msgstr ""
 
@@ -52228,10 +52228,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:685
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2`"
-msgstr "`GIT_TRACE`"
+msgstr "`GIT_TRACE2`"
 
 #. type: Plain text
 #: en/git.txt:689
@@ -52259,10 +52258,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:720
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE_SETUP`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2_EVENT`"
-msgstr "`GIT_TRACE_SETUP`"
+msgstr "`GIT_TRACE2_EVENT`"
 
 #. type: Plain text
 #: en/git.txt:725
@@ -52272,10 +52270,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:726
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE_PERFORMANCE`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2_PERF`"
-msgstr "`GIT_TRACE_PERFORMANCE`"
+msgstr "`GIT_TRACE2_PERF`"
 
 #. type: Plain text
 #: en/git.txt:732
@@ -52714,7 +52711,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-update-index.txt:29
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git update-index'\n"
 "\t     [--add] [--remove | --force-remove] [--replace]\n"
@@ -53274,7 +53271,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-update-index.txt:348
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The command looks at `core.ignorestat` configuration variable.  When this is true, paths updated with `git update-index paths...` and paths updated with other Git commands that update both index and working tree (e.g. 'git apply --index', 'git checkout-index -u', and 'git read-tree -u') are automatically marked as \"assume unchanged\".  Note that \"assume unchanged\" bit is *not* set if `git update-index --refresh` finds the working tree file matches the index (use `git update-index --really-refresh` if you want to mark them as \"assume unchanged\")."
 msgstr ""
 
@@ -54144,7 +54141,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-commit.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-commit' <commit>...\n"
 msgstr ""
 
@@ -54186,7 +54183,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-pack.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-pack' [-v|--verbose] [-s|--stat-only] [--] <pack>.idx ...\n"
 msgstr ""
 
@@ -54198,7 +54195,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-verify-pack.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<pack>.idx ..."
 msgstr ""
 
@@ -54276,7 +54273,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-tag.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-tag' [--format=<format>] <tag>...\n"
 msgstr ""
 
@@ -54294,7 +54291,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-verify-tag.txt:27
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<tag>..."
 msgstr ""
 
@@ -54318,7 +54315,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-web--browse.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git web{litdd}browse' [<options>] <url|file>...\n"
 msgstr ""
 
@@ -54592,7 +54589,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-whatchanged.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git whatchanged' <option>...\n"
 msgstr ""
 
@@ -55123,7 +55120,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-worktree.txt:372
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git worktree add -b emergency-fix ../temp master\n"
 "$ pushd ../temp\n"
@@ -56328,7 +56325,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/pretty-formats.txt:115
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'%C(...)'"
 msgstr ""
 
@@ -56340,7 +56337,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/pretty-formats.txt:129
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "\"CONFIGURATION FILE\" section of linkgit:git-config[1].  By default, colors are shown only when enabled for log output (by `color.diff`, `color.ui`, or `--color`, and respecting the `auto` settings of the former if we are going to a terminal). `%C(auto,...)` is accepted as a historical synonym for the default (e.g., `%C(auto,red)`). Specifying `%C(always,...)` will show the colors even when color is not otherwise enabled (though consider just using `--color=always` to enable color for the whole output, including this format and anything else git might color).  `auto` alone (i.e. `%C(auto)`) will turn on auto coloring on the next placeholders until the color is switched again."
 msgstr ""
 
@@ -57433,7 +57430,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/pull-fetch-param.txt:45
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "Whether that update is allowed without `--force` depends on the ref namespace it's being fetched to, the type of object being fetched, and whether the update is considered to be a fast-forward. Generally, the same rules apply for fetching as when pushing, see the `<refspec>...` section of linkgit:git-push[1] for what those are. Exceptions to those rules particular to 'git fetch' are noted below."
 msgstr ""
 
@@ -57904,13 +57901,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/revisions.txt:280
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "The '...' (three-dot) Symmetric Difference Notation"
 msgstr ""
 
 #. type: Plain text
 #: en/revisions.txt:286
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "A similar notation 'r1\\...r2' is called symmetric difference of 'r1' and 'r2' and is defined as 'r1 r2 --not $(git merge-base --all r1 r2)'.  It is the set of commits that are reachable from either one of 'r1' (left side) or 'r2' (right side) but not from both."
 msgstr ""
 
@@ -58000,7 +57997,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/revisions.txt:331
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'<rev1>\\...<rev2>'"
 msgstr ""
 
@@ -58054,7 +58051,7 @@ msgstr ""
 
 #. type: delimited block .
 #: en/revisions.txt:377
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "   Args   Expanded arguments    Selected commits\n"
 "   D                            G H D\n"
@@ -58544,7 +58541,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:256
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "For example, `--cherry-pick --right-only A...B` omits those commits from `B` which are in `A` or are patch-equivalent to a commit in `A`. In other words, this lists the `+` commits from `git cherry A B`.  More precisely, `--cherry-pick --right-only --no-merges` gives the exact list."
 msgstr ""
 
@@ -58556,7 +58553,7 @@ msgstr "--cherry"
 
 #. type: Plain text
 #: en/rev-list-options.txt:263
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "A synonym for `--right-only --cherry-mark --no-merges`; useful to limit the output to the commits on our side and mark those that have been applied to the other side of a forked history with `git log --cherry upstream...mybranch`, similar to `git cherry upstream mybranch`."
 msgstr ""
 
@@ -58568,7 +58565,7 @@ msgstr "--walk-reflogs"
 
 #. type: Plain text
 #: en/rev-list-options.txt:271
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Instead of walking the commit ancestry chain, walk reflog entries from the most recent one to older ones.  When this option is used you cannot specify commits to exclude (that is, '{caret}commit', 'commit1..commit2', and 'commit1\\...commit2' notations cannot be used)."
 msgstr ""
 
@@ -59561,7 +59558,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:875
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "`--date=format:...` feeds the format `...` to your system `strftime`, except for %z and %Z, which are handled internally.  Use `--date=format:%c` to show the date in your system locale's preferred format.  See the `strftime` manual for a complete list of format placeholders. When using `-local`, the correct syntax is `--date=format-local:...`."
 msgstr ""
 
@@ -59597,7 +59594,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:892
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Print also the parents of the commit (in the form \"commit parent...\").  Also enables parent rewriting, see 'History Simplification' above."
 msgstr ""
 
@@ -59609,7 +59606,7 @@ msgstr "--children"
 
 #. type: Plain text
 #: en/rev-list-options.txt:896
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Print also the children of the commit (in the form \"commit child...\").  Also enables parent rewriting, see 'History Simplification' above."
 msgstr ""
 
@@ -59662,13 +59659,13 @@ msgstr ""
 
 #. type: delimited block -
 #: en/rev-list-options.txt:922
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "\t$ git rev-list --left-right --boundary --pretty=oneline A...B\n"
 msgstr ""
 
 #. type: delimited block -
 #: en/rev-list-options.txt:929
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "\t>bbbbbbb... 3rd on b\n"
 "\t>bbbbbbb... 2nd on b\n"

--- a/po/documentation.pl.po
+++ b/po/documentation.pl.po
@@ -2437,7 +2437,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/config.txt:256
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The value for many variables that specify various sizes can be suffixed with `k`, `M`,... to mean \"scale the number by 1024\", \"by 1024x1024\", etc."
 msgstr ""
 
@@ -2828,7 +2828,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-format.txt:16
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "git-diff-tree [-r] <tree-ish-1> <tree-ish-2> [<pattern>...]"
 msgstr ""
 
@@ -2840,7 +2840,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-format.txt:19
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "git-diff-files [<pattern>...]"
 msgstr ""
 
@@ -3520,7 +3520,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/diff-generate-patch.txt:179
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Unlike the traditional 'unified' diff format, which shows two files A and B with a single column that has `-` (minus -- appears in A but removed in B), `+` (plus -- missing in A but added to B), or `\" \"` (space -- unchanged) prefix, this format compares two or more files file1, file2,... with one file X, and shows how X differs from each of fileN.  One column for each of fileN is prepended to the output line to note how X's line is different from it."
 msgstr ""
 
@@ -3844,7 +3844,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:137
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Generate a diffstat. By default, as much space as necessary will be used for the filename part, and the rest for the graph part. Maximum width defaults to terminal width, or 80 columns if not connected to a terminal, and can be overridden by `<width>`. The width of the filename part can be limited by giving another width `<name-width>` after a comma. The width of the graph part can be limited by using `--stat-graph-width=<width>` (affects all commands generating a stat graph) or by setting `diff.statGraphWidth=<width>` (does not affect `git format-patch`).  By giving a third parameter `<count>`, you can limit the output to the first `<count>` lines, followed by `...` if there are more."
 msgstr ""
 
@@ -3892,13 +3892,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:161
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "-X[<param1,param2,...>]"
 msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:162
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--dirstat[=<param1,param2,...>]"
 msgstr ""
 
@@ -3988,13 +3988,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:209
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--dirstat-by-file[=<param1,param2>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:211
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Synonym for --dirstat=files,param1,param2..."
 msgstr ""
 
@@ -4655,13 +4655,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:527
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--diff-filter=[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:538
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Select only files that are Added (`A`), Copied (`C`), Deleted (`D`), Modified (`M`), Renamed (`R`), have their type (i.e. regular file, symlink, submodule, ...) changed (`T`), are Unmerged (`U`), are Unknown (`X`), or have had their pairing Broken (`B`).  Any combination of the filter characters (including none) can be used.  When `*` (All-or-none) is added to the combination, all paths are selected if there is any file that matches other criteria in the comparison; if there is no file that matches other criteria, nothing is selected."
 msgstr ""
 
@@ -4721,7 +4721,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/diff-options.txt:573
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "+    return !regexec(regexp, two->ptr, 1, &regmatch, 0);\n"
 "...\n"
@@ -5646,7 +5646,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-add.txt:15
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "'git add' [--verbose | -v] [--dry-run | -n] [--force | -f] [--interactive | -i] [--patch | -p]\n"
 "\t  [--edit | -e] [--[no-]all | --[no-]ignore-removal | [--update | -u]]\n"
@@ -5704,7 +5704,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-add.txt:52 en/git-grep.txt:308 en/git-status.txt:148
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid "<pathspec>..."
 msgstr ""
 
@@ -5848,7 +5848,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-add.txt:145
-#, priority:300
+#, ignore-ellipsis, priority:300
 msgid "This option is primarily to help users who are used to older versions of Git, whose \"git add <pathspec>...\" was a synonym for \"git add --no-all <pathspec>...\", i.e. ignored removed files."
 msgstr ""
 
@@ -6346,7 +6346,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-am.txt:20
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git am' [--signoff] [--keep] [--[no-]keep-cr] [--[no-]utf8]\n"
 "\t [--[no-]3way] [--interactive] [--committer-date-is-author-date]\n"
@@ -6366,7 +6366,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-am.txt:29
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "(<mbox>|<Maildir>)..."
 msgstr ""
 
@@ -6902,7 +6902,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-apply.txt:20
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git apply' [--stat] [--numstat] [--summary] [--check] [--index | --intent-to-add] [--3way]\n"
 "\t  [--apply] [--no-add] [--build-fake-ancestor=<file>] [-R | --reverse]\n"
@@ -6928,7 +6928,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-apply.txt:37
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<patch>..."
 msgstr ""
 
@@ -7342,7 +7342,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-archimport.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git archimport' [-h] [-v] [-o] [-a] [-f] [-T] [-D depth] [-t tempdir]\n"
 "               <archive/branch>[:<git-branch>] ...\n"
@@ -7506,7 +7506,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-archive.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git archive' [--format=<fmt>] [--list] [--prefix=<prefix>/] [<extra>]\n"
 "\t      [-o <file> | --output=<file>] [--worktree-attributes]\n"
@@ -7894,7 +7894,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bisect.txt:31
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 " git bisect start [--term-{old,good}=<term> --term-{new,bad}=<term>]\n"
 "\t\t  [--no-checkout] [<bad> [<good>...]] [--] [<paths>...]\n"
@@ -8089,7 +8089,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-bisect.txt:158
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git bisect new [<rev>...]\n"
 msgstr ""
 
@@ -8119,7 +8119,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bisect.txt:175
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If you would like to use your own terms instead of \"bad\"/\"good\" or \"new\"/\"old\", you can choose any names you like (except existing bisect subcommands like `reset`, `start`, ...) by starting the bisection using"
 msgstr ""
 
@@ -8559,7 +8559,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-bisect.txt:463
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git bisect start HEAD <known-good-commit> [ <boundary-commit> ... ] --no-checkout\n"
 "$ git bisect run sh -c '\n"
@@ -9027,7 +9027,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:26
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git branch' [--color[=<when>] | --no-color] [--show-current]\n"
 "\t[-v [--abbrev=<length> | --no-abbrev]]\n"
@@ -9072,7 +9072,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:61
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "The command's second form creates a new branch head named <branchname> which points to the current `HEAD`, or <start-point> if given. As a special case, for <start-point>, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -9270,7 +9270,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:176
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "List branches.  With optional `<pattern>...`, e.g. `git branch --list 'maint-*'`, list only the branches that match the pattern(s)."
 msgstr ""
 
@@ -9517,7 +9517,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:291
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "Sort based on the key given. Prefix `-` to sort in descending order of the value. You may use the --sort=<key> option multiple times, in which case the last key becomes the primary key. The keys supported are the same as those in `git for-each-ref`. Sort order defaults to the value configured for the `branch.sort` variable if exists, or to sorting based on the full refname (including `refs/...` prefix). This lists detached HEAD (if present) first, then local branches and finally remote-tracking branches. See linkgit:git-config[1]."
 msgstr ""
 
@@ -9559,7 +9559,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-branch.txt:317
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git clone git://git.kernel.org/pub/scm/.../linux-2.6 my2.6\n"
 "$ cd my2.6\n"
@@ -9581,7 +9581,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-branch.txt:329
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git clone git://git.kernel.org/.../git.git my.git\n"
 "$ cd my.git\n"
@@ -9695,7 +9695,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bundle.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git bundle' create <file> <git-rev-list-args>\n"
 "'git bundle' verify <file>\n"
@@ -9771,7 +9771,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-bundle.txt:71
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<refname>...]"
 msgstr ""
 
@@ -10547,7 +10547,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-attr.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git check-attr' [-a | --all | <attr>...] [--] <pathname>...\n"
 "'git check-attr' --stdin [-z] [-a | --all | <attr>...]\n"
@@ -10788,7 +10788,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-ignore.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git check-ignore' [<options>] <pathname>...\n"
 "'git check-ignore' [<options>] --stdin\n"
@@ -10964,7 +10964,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-mailmap.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git check-mailmap' [<options>] <contact>...\n"
 msgstr ""
 
@@ -11000,7 +11000,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout-index.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git checkout-index' [-u] [-q] [-a] [-f] [-n] [--prefix=<string>]\n"
 "\t\t   [--stage=<number>|all]\n"
@@ -11275,7 +11275,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:18
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git checkout' [-q] [-f] [-m] [<branch>]\n"
 "'git checkout' [-q] [-f] [-m] --detach [<branch>]\n"
@@ -11386,7 +11386,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-checkout.txt:82
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git checkout' [<tree-ish>] [--] <pathspec>..."
 msgstr ""
 
@@ -11404,7 +11404,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-checkout.txt:98
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git checkout' (-p|--patch) [<tree-ish>] [--] [<pathspec>...]"
 msgstr ""
 
@@ -11746,7 +11746,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:326 en/git-switch.txt:58
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "As a special case, you may use `A...B` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -11776,7 +11776,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:337
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "As a special case, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -12347,7 +12347,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git cherry-pick' [--edit] [-n] [-m parent-number] [-s] [-x] [--ff]\n"
 "\t\t  [-S[<keyid>]] <commit>...\n"
@@ -12404,13 +12404,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-cherry-pick.txt:43 en/git-merge.txt:116 en/git-revert.txt:36 en/git-verify-commit.txt:27
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "<commit>..."
 msgstr ""
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:52
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Commits to cherry-pick.  For a more complete list of ways to spell commits, see linkgit:gitrevisions[7].  Sets of commits can be passed but no traversal is done by default, as if the `--no-walk` option was specified, see linkgit:git-rev-list[1]. Note that specifying a range will feed all <commit>... arguments to a single revision walk (see a later example that uses 'maint master..next')."
 msgstr ""
 
@@ -12440,7 +12440,7 @@ msgstr "-x"
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:78
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When recording the commit, append a line that says \"(cherry picked from commit ...)\" to the original commit message in order to indicate which commit this change was cherry-picked from.  This is done only for cherry picks without conflicts.  Do not use this option if you are cherry-picking from your private branch because the information is useless to the recipient.  If on the other hand you are cherry-picking between two publicly visible branches (e.g. backporting a fix to a maintenance branch for an older release from a development branch), adding this information can be useful."
 msgstr ""
 
@@ -12798,7 +12798,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:58
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git checkout -b topic origin/master\n"
 "# work and create some commits\n"
@@ -12834,7 +12834,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git log --graph --oneline --decorate --boundary origin/master...topic\n"
 "* 7654321 (origin/master) upstream tip commit\n"
@@ -12857,7 +12857,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:96
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git cherry origin/master topic\n"
 "- cccc000... commit C\n"
@@ -12885,7 +12885,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:126
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git log --graph --oneline --decorate --boundary origin/master...topic\n"
 "* 7654321 (origin/master) upstream tip commit\n"
@@ -12911,7 +12911,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:136
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git cherry origin/master topic base\n"
 "- cccc000... commit C\n"
@@ -12963,7 +12963,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-clean.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git clean' [-d] [-f] [-i] [-n] [-q] [-e <pattern>] [-x | -X] [--] <path>...\n"
 msgstr ""
 
@@ -12981,7 +12981,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-clean.txt:25
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If any optional `<path>...` arguments are given, only those paths are affected."
 msgstr ""
 
@@ -13593,7 +13593,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-clone.txt:306
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "$ git clone git://git.kernel.org/pub/scm/.../linux.git my-linux\n"
 "$ cd my-linux\n"
@@ -13623,7 +13623,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-clone.txt:325
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "$ git clone --reference /git/linux.git \\\n"
 "\tgit://git.kernel.org/pub/scm/.../linux.git \\\n"
@@ -13816,7 +13816,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-commit-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git commit-tree' <tree> [(-p <parent>)...]\n"
 "'git commit-tree' [(-p <parent>)...] [-S[<keyid>]] [(-m <message>)...]\n"
@@ -14017,7 +14017,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-commit.txt:17
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git commit' [-a | --interactive | --patch] [-s] [-v] [-u<mode>] [--amend]\n"
 "\t   [--dry-run] [(-c | -C | --fixup | --squash) <commit>]\n"
@@ -14437,7 +14437,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-commit.txt:248
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "\t$ git reset --soft HEAD^\n"
 "\t$ ... do something else to come up with the right tree ...\n"
@@ -14602,7 +14602,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-commit.txt:346 en/git-rm.txt:29
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "<file>..."
 msgstr ""
 
@@ -15579,7 +15579,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-config.txt:428
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "However, if you really only want to replace the line for the default proxy, i.e. the one without a \"for ...\" postfix, do something like this:"
 msgstr ""
 
@@ -16937,7 +16937,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-cvsserver.txt:26
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git-cvsserver' [<options>] [pserver|server] [<directory> ...]\n"
 msgstr ""
 
@@ -17635,7 +17635,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-daemon.txt:25
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git daemon' [--verbose] [--syslog] [--export-all]\n"
 "\t     [--timeout=<n>] [--init-timeout=<n>] [--max-connections=<n>]\n"
@@ -18202,7 +18202,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-describe.txt:14
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "'git describe' [--all] [--tags] [--contains] [--abbrev=<n>] [<commit-ish>...]\n"
 "'git describe' [--all] [--tags] [--contains] [--abbrev=<n>] --dirty[=<mark>]\n"
@@ -18229,7 +18229,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-describe.txt:37
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "<commit-ish>..."
 msgstr ""
 
@@ -18325,7 +18325,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-describe.txt:95
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Always output the long format (the tag, the number of commits and the abbreviated commit name) even when it matches a tag.  This is useful when you want to see parts of the commit object name in \"describe\" output, even when the commit in question happens to be a tagged version.  Instead of just emitting the tag name, it will describe such a commit as v1.2-0-gdeadbee (0th commit since tag v1.2 that points at object deadbee....)."
 msgstr ""
 
@@ -18503,7 +18503,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-files.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git diff-files' [-q] [-0|-1|-2|-3|-c|--cc] [<common diff options>] [<path>...]\n"
 msgstr ""
 
@@ -18575,7 +18575,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-index.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git diff-index' [-m] [--cached] [<common diff options>] <tree-ish> [<path>...]\n"
 msgstr ""
 
@@ -18714,7 +18714,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-index.txt:102
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "  torvalds@ppc970:~/v2.6/linux> git diff-index --abbrev HEAD\n"
 "  :100644 100664 7476bb... 000000...      kernel/sched.c\n"
@@ -18752,7 +18752,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-difftool.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git difftool' [<options>] [<commit> [<commit>]] [--] [<path>...]\n"
 msgstr ""
 
@@ -19064,7 +19064,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git diff-tree' [--stdin] [-m] [-s] [-v] [--no-commit-id] [--pretty]\n"
 "\t      [-t] [-r] [-c | --cc] [--combined-all-paths] [--root]\n"
@@ -19097,7 +19097,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff-tree.txt:32 en/git-diff.txt:114 en/git-submodule.txt:422
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "<path>..."
 msgstr ""
 
@@ -19223,7 +19223,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:17
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git diff' [<options>] [<commit>] [--] [<path>...]\n"
 "'git diff' [<options>] --cached [<commit>] [--] [<path>...]\n"
@@ -19240,7 +19240,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:24
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] [--] [<path>...]"
 msgstr ""
 
@@ -19264,7 +19264,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:41
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] --cached [<commit>] [--] [<path>...]"
 msgstr ""
 
@@ -19276,7 +19276,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:51
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit> [--] [<path>...]"
 msgstr ""
 
@@ -19288,7 +19288,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:59
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit> <commit> [--] [<path>...]"
 msgstr ""
 
@@ -19300,7 +19300,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:64
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit>..<commit> [--] [<path>...]"
 msgstr ""
 
@@ -19312,13 +19312,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:70
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit>\\...<commit> [--] [<path>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:77
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "This form is to view the changes on the branch containing and up to the second <commit>, starting at a common ancestor of both <commit>.  \"git diff A\\...B\" is equivalent to \"git diff $(git merge-base A B) B\".  You can omit any one of <commit>, which has the same effect as using HEAD instead."
 msgstr ""
 
@@ -19330,7 +19330,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:89
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "For a more complete list of ways to spell <commit>, see \"SPECIFYING REVISIONS\" section in linkgit:gitrevisions[7].  However, \"diff\" is about comparing two _endpoints_, not ranges, and the range notations (\"<commit>..<commit>\" and \"<commit>\\...<commit>\") do not mean a range as defined in the \"SPECIFYING RANGES\" section in linkgit:gitrevisions[7]."
 msgstr ""
 
@@ -19438,7 +19438,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-diff.txt:160
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git diff topic master    <1>\n"
 "$ git diff topic..master   <2>\n"
@@ -19758,7 +19758,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:143
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<git-rev-list-args>...]"
 msgstr ""
 
@@ -19839,7 +19839,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-fast-export.txt:215
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git init anon-repo\n"
 "$ cd anon-repo\n"
@@ -22149,7 +22149,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch-pack.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git fetch-pack' [--all] [--quiet|-q] [--keep|-k] [--thin] [--include-tag]\n"
 "\t[--upload-pack=<git-upload-pack>]\n"
@@ -22303,7 +22303,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fetch-pack.txt:117 en/git-ls-remote.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<refs>..."
 msgstr ""
 
@@ -22333,7 +22333,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch.txt:16
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git fetch' [<options>] [<repository> [<refspec>...]]\n"
 "'git fetch' [<options>] <group>\n"
@@ -22674,7 +22674,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch.txt:226
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "For a successfully fetched ref, the summary shows the old and new values of the ref in a form suitable for using as an argument to `git log` (this is `<old>..<new>` in most cases, and `<old>...<new>` for forced non-fast-forward updates)."
 msgstr ""
 
@@ -22796,7 +22796,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:18
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git filter-branch' [--setup <command>] [--subdirectory-filter <directory>]\n"
 "\t[--env-filter <command>] [--tree-filter <command>]\n"
@@ -22936,7 +22936,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:117
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for rewriting the index.  It is similar to the tree filter but does not check out the tree, which makes it much faster.  Frequently used with `git rm --cached --ignore-unmatch ...`, see EXAMPLES below.  For hairy cases, see linkgit:git-update-index[1]."
 msgstr ""
 
@@ -22948,7 +22948,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:125
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for rewriting the commit's parent list.  It will receive the parent string on stdin and shall output the new parent string on stdout.  The parent string is in the format described in linkgit:git-commit-tree[1]: empty for the initial commit, \"-p parent\" for a normal commit and \"-p parent1 -p parent2 -p parent3 ...\" for a merge commit."
 msgstr ""
 
@@ -22972,7 +22972,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:138
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for performing the commit.  If this filter is specified, it will be called instead of the 'git commit-tree' command, with arguments of the form \"<TREE_ID> [(-p <PARENT_COMMIT_ID>)...]\" and the log message on stdin.  The commit id is expected on stdout."
 msgstr ""
 
@@ -23074,7 +23074,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-filter-branch.txt:207
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<rev-list options>..."
 msgstr ""
 
@@ -23335,7 +23335,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-filter-branch.txt:388
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git filter-branch ... C..H\n"
 msgstr ""
 
@@ -23347,7 +23347,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-filter-branch.txt:395
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "git filter-branch ... C..H --not D\n"
 "git filter-branch ... D..H --not C\n"
@@ -23586,7 +23586,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git for-each-ref' [--count=<count>] [--shell|--perl|--python|--tcl]\n"
 "\t\t   [(--sort=<key>)...] [--format=<format>] [<pattern>...]\n"
@@ -23603,7 +23603,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-for-each-ref.txt:29 en/git-show-ref.txt:88
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<pattern>..."
 msgstr ""
 
@@ -23896,7 +23896,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:197
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Left-, middle-, or right-align the content between %(align:...) and %(end). The \"align:\" is followed by `width=<width>` and `position=<position>` in any order separated by a comma, where the `<position>` is either left, right or middle, default being left and `<width>` is the total length of the content with alignment. For brevity, the \"width=\" and/or \"position=\" prefixes may be omitted, and bare <width> and <position> used instead.  For instance, `%(align:<width>,<position>)`. If the contents length is more than the width then no alignment is performed. If used with `--quote` everything in between %(align:...) and %(end) is quoted, but if nested then only the topmost level performs quoting."
 msgstr ""
 
@@ -23908,7 +23908,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:210
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Used as %(if)...%(then)...%(end) or %(if)...%(then)...%(else)...%(end).  If there is an atom with value or string literal after the %(if) then everything after the %(then) is printed, else if the %(else) atom is used, then everything after %(else) is printed. We ignore space when evaluating the string before %(then), this is useful when we use the %(HEAD) atom which prints either \"*\" or \" \" and we want to apply the 'if' condition only on the 'HEAD' ref.  Append \":equals=<string>\" or \":notequals=<string>\" to compare the value between the %(if:...) and %(then) atoms with the given string."
 msgstr ""
 
@@ -24129,7 +24129,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:361
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "An example to show the usage of %(if)...%(then)...%(else)...%(end).  This prefixes the current branch with a star."
 msgstr ""
 
@@ -24141,7 +24141,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:369
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "An example to show the usage of %(if)...%(then)...%(end).  This prints the authorname, if present."
 msgstr ""
 
@@ -24787,7 +24787,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:372
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "Do the same for ia64 so we can have sleek & trim looking\n"
 "...\n"
@@ -24795,7 +24795,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:380
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Typically it will be placed in a MUA's drafts folder, edited to add timely commentary that should not go in the changelog after the three dashes, and then sent as a message whose body, in our example, starts with \"arch/arm config files were...\".  On the receiving end, readers can save interesting patches in a UNIX mailbox and apply them with linkgit:git-am[1]."
 msgstr ""
 
@@ -24807,7 +24807,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:390
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "...\n"
 "> So we should do such-and-such.\n"
@@ -24829,7 +24829,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:398
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "arch/arm config files were slimmed down using a python script\n"
 "...\n"
@@ -25003,7 +25003,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:499
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Configure your mail server composition as plain text: Edit...Account Settings...Composition & Addressing, uncheck \"Compose Messages in HTML\"."
 msgstr ""
 
@@ -25140,7 +25140,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:573
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Use Message -> Insert file... and insert the patch."
 msgstr ""
 
@@ -25315,7 +25315,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fsck-objects.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git fsck-objects' ...\n"
 msgstr ""
 
@@ -25703,7 +25703,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-gc.txt:55
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Once housekeeping is triggered by exceeding the limits of configuration options such as `gc.auto` and `gc.autoPackLimit`, all other housekeeping tasks (e.g. rerere, working trees, reflog...) will be performed as well."
 msgstr ""
 
@@ -25877,7 +25877,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-grep.txt:32
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git grep' [-a | --text] [-I] [--textconv] [-i | --ignore-case] [-w | --word-regexp]\n"
 "\t   [-v | --invert-match] [-h|-H] [--full-name]\n"
@@ -26486,7 +26486,7 @@ msgstr "--not"
 
 #. type: Labeled list
 #: en/git-grep.txt:284
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "( ... )"
 msgstr ""
 
@@ -26516,7 +26516,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-grep.txt:300
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<tree>..."
 msgstr ""
 
@@ -26834,7 +26834,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-hash-object.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git hash-object' [-t <type>] [-w] [--path=<file>|--no-filters] [--stdin [--literally]] [--] <file>...\n"
 "'git hash-object' [-t <type>] [-w] --stdin-paths [--no-filters]\n"
@@ -26964,7 +26964,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-help.txt:38
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Note that `git --help ...` is identical to `git help ...` because the former is internally converted into the latter."
 msgstr ""
 
@@ -27414,7 +27414,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:102
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tAuthType Basic\n"
 "\tAuthName \"Git Access\"\n"
@@ -27432,7 +27432,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:115
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "<LocationMatch \"^/git/.*/git-receive-pack$\">\n"
 "\tAuthType Basic\n"
@@ -27456,7 +27456,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:136
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "<Location /git/private>\n"
 "\tAuthType Basic\n"
@@ -27606,7 +27606,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:231
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "auth.require = (\n"
 "\t\"/\" => (\n"
@@ -27809,7 +27809,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-http-push.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git http-push' [--all] [--dry-run] [--force] [--verbose] <url> <ref> [<ref>...]\n"
 msgstr ""
 
@@ -27878,7 +27878,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-http-push.txt:54 en/git-send-pack.txt:98
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<ref>..."
 msgstr ""
 
@@ -28743,7 +28743,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-interpret-trailers.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git interpret-trailers' [<options>] [(--trailer <token>[(=|:)<value>])...] [<file>...]\n"
 "'git interpret-trailers' [<options>] [--parse] [<file>...]\n"
@@ -29415,7 +29415,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-log.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'git log' [<options>] [<revision range>] [[--] <path>...]\n"
 msgstr ""
 
@@ -29513,7 +29513,7 @@ msgstr "--full-diff"
 
 #. type: Plain text
 #: en/git-log.txt:63
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Without this flag, `git log -p <path>...` shows commits that touch the specified paths, and diffs about the same specified paths.  With this, the full diff is shown for commits that touch the specified paths; this means that \"<path>...\" limits only commits, and doesn't limit diff for those commits."
 msgstr ""
 
@@ -29567,7 +29567,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-log.txt:93 en/git-shortlog.txt:72
-#, fuzzy, no-wrap, priority:260
+#, fuzzy, ignore-ellipsis, no-wrap, priority:260
 #| msgid "--path"
 msgid "[--] <path>..."
 msgstr "--path"
@@ -29844,7 +29844,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-files.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-files' [-z] [-t] [-v] [-f]\n"
 "\t\t(--[cached|deleted|others|ignored|stage|unmerged|killed|modified])*\n"
@@ -30325,7 +30325,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-remote.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-remote' [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
 "\t      [-q | --quiet] [--exit-code] [--get-url] [--sort=<key>]\n"
@@ -30430,7 +30430,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-remote.txt:91
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When unspecified, all references, after filtering done with --heads and --tags, are shown.  When <refs>... are specified, only references matching the given patterns are displayed."
 msgstr ""
 
@@ -30476,7 +30476,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-tree' [-d] [-r] [-t] [-l] [-z]\n"
 "\t    [--name-only] [--name-status] [--full-name] [--full-tree] [--abbrev[=<n>]]\n"
@@ -30557,7 +30557,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-ls-tree.txt:76
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<path>...]"
 msgstr ""
 
@@ -30767,7 +30767,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mailsplit.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git mailsplit' [-b] [-f<nn>] [-d<prec>] [--keep-cr] [--mboxrd]\n"
 "\t\t-o<directory> [--] [(<mbox>|<Maildir>)...]\n"
@@ -30889,7 +30889,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git merge-base' [-a|--all] <commit> <commit>...\n"
 "'git merge-base' [-a|--all] --octopus <commit>...\n"
@@ -31086,7 +31086,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:139
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tA=$(git rev-parse --verify A)\n"
 "\tif test \"$A\" = \"$(git merge-base A B)\"\n"
@@ -31103,7 +31103,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:146
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tif git merge-base --is-ancestor A B\n"
 "\tthen\n"
@@ -31590,7 +31590,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mergetool.txt:12
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git mergetool' [--tool=<tool>] [-y | --[no-]prompt] [<file>...]\n"
 msgstr ""
 
@@ -31752,7 +31752,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge.txt:17
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git merge' [-n] [--stat] [--no-commit] [--squash] [--[no-]edit]\n"
 "\t[-s <strategy>] [-X <strategy-option>] [-S[<keyid>]]\n"
@@ -32345,7 +32345,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mv.txt:13
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git mv' <options>... <args>...\n"
 msgstr ""
 
@@ -32357,7 +32357,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mv.txt:20
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 " git mv [-v] [-f] [-n] [-k] <source> <destination>\n"
 " git mv [-v] [-f] [-n] [-k] <source> ... <destination directory>\n"
@@ -32425,7 +32425,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-name-rev.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git name-rev' [--tags] [--refs=<pattern>]\n"
 "\t       ( --all | --stdin | <commit-ish>... )\n"
@@ -32543,7 +32543,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-notes.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git notes' [list [<object>]]\n"
 "'git notes' add [-f] [--allow-empty] [-F <file> | -m <msg> | (-c | -C) <object>] [<object>]\n"
@@ -32879,7 +32879,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-notes.txt:229
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Commit notes are blobs containing extra information about an object (usually information to supplement a commit's message).  These blobs are taken from notes refs.  A notes ref is usually a branch which contains \"files\" whose paths are the object names for the objects they describe, with some directory separators included for performance reasons footnote:[Permitted pathnames have the form 'ab'`/`'cd'`/`'ef'`/`'...'`/`'abcdef...': a sequence of directory names of two hexadecimal digits each followed by a filename with the rest of the object ID.]."
 msgstr ""
 
@@ -32945,7 +32945,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-notes.txt:288
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git notes add -m 'Tested-by: Johannes Sixt <j6t@kdbg.org>' 72a144e2\n"
 "$ git show -s 72a144e\n"
@@ -33164,7 +33164,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-p4.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git p4 clone' [<sync options>] [<clone options>] <p4 depot path>...\n"
 "'git p4 sync' [<sync options>] [<p4 depot path>...]\n"
@@ -33998,7 +33998,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-p4.txt:445
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The full syntax for a p4 view is documented in 'p4 help views'.  'git p4' knows only a subset of the view syntax.  It understands multi-line mappings, overlays with '+', exclusions with '-' and double-quotes around whitespace.  Of the possible wildcards, 'git p4' only handles '...', and only when it is at the end of the path.  'git p4' will complain if it encounters an unhandled wildcard."
 msgstr ""
 
@@ -34040,7 +34040,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-p4.txt:475
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "//depot/main/...\n"
 "//depot/branch1/...\n"
@@ -34054,7 +34054,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-p4.txt:480
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "//depot/main/... //depot/branch1/...\n"
 msgstr ""
 
@@ -35172,7 +35172,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-pack-redundant.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git pack-redundant' [ --verbose ] [ --alt-odb ] < --all | .pack filename ... >\n"
 msgstr ""
 
@@ -35472,7 +35472,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-prune.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git prune' [-n] [-v] [--progress] [--expire <time>] [--] [<head>...]\n"
 msgstr ""
 
@@ -35527,7 +35527,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-prune.txt:54
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<head>..."
 msgstr ""
 
@@ -35581,7 +35581,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-pull.txt:13
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "'git pull' [<options>] [<repository> [<refspec>...]]\n"
 msgstr ""
 
@@ -35929,7 +35929,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:18
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git push' [--all | --mirror | --tags] [--follow-tags] [--atomic] [-n | --dry-run] [--receive-pack=<git-receive-pack>]\n"
 "\t   [--repo=<repository>] [-f | --force] [-d | --delete] [--prune] [-v | --verbose]\n"
@@ -35959,7 +35959,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:39
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "When the command line does not specify what to push with `<refspec>...` arguments or `--all`, `--mirror`, `--tags` options, the command finds the default `<refspec>` by consulting `remote.*.push` configuration, and if it is not found, honors `push.default` configuration to decide what to push (See linkgit:git-config[1] for the meaning of `push.default`)."
 msgstr ""
 
@@ -35983,7 +35983,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:56
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "<refspec>..."
 msgstr ""
 
@@ -36344,7 +36344,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:343
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "Note that `--force` applies to all the refs that are pushed, hence using it with `push.default` set to `matching` or with multiple push destinations configured with `remote.*.push` may overwrite refs other than the current branch (including local refs that are strictly behind their remote counterpart).  To force a push to only one branch, use a `+` in front of the refspec to push (e.g `git push origin +master` to force a push to the `master` branch). See the `<refspec>...` section above for details."
 msgstr ""
 
@@ -36476,7 +36476,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:445
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "For a successfully pushed ref, the summary shows the old and new values of the ref in a form suitable for using as an argument to `git log` (this is `<old>..<new>` in most cases, and `<old>...<new>` for forced non-fast-forward updates)."
 msgstr ""
 
@@ -36737,7 +36737,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:616
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "See the section describing `<refspec>...` above for a discussion of the matching semantics."
 msgstr ""
 
@@ -37438,7 +37438,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-read-tree.txt:357
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git fetch git://.... linus\n"
 "$ LT=`git rev-parse FETCH_HEAD`\n"
@@ -37492,7 +37492,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-read-tree.txt:405
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "'git read-tree' and other merge-based commands ('git merge', 'git checkout'...) can help maintaining the skip-worktree bitmap and working directory update. `$GIT_DIR/info/sparse-checkout` is used to define the skip-worktree reference bitmap. When 'git read-tree' needs to update the working directory, it resets the skip-worktree bit in the index based on this file, which uses the same syntax as .gitignore files.  If an entry matches a pattern in this file, skip-worktree will not be set on that entry. Otherwise, skip-worktree will be set."
 msgstr ""
 
@@ -37872,7 +37872,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:219
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "As a special case, you may use \"A\\...B\" as a shortcut for the merge base of A and B if there is exactly one merge base. You can leave out at most one of A and B, in which case it defaults to HEAD."
 msgstr ""
 
@@ -38136,7 +38136,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:430
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "It is currently only possible to recreate the merge commits using the `recursive` merge strategy; Different merge strategies can be used only via explicit `exec git merge -s <strategy> [...]` commands."
 msgstr ""
 
@@ -38190,7 +38190,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:457
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "\tgit rebase -i --exec \"cmd1 && cmd2 && ...\"\n"
 msgstr ""
 
@@ -38202,7 +38202,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:461
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "\tgit rebase -i --exec \"cmd1\" --exec \"cmd2\" --exec ...\n"
 msgstr ""
 
@@ -38238,7 +38238,7 @@ msgstr "--no-autosquash"
 
 #. type: Plain text
 #: en/git-rebase.txt:495
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When the commit log message begins with \"squash! ...\" (or \"fixup! ...\"), and there is already a commit in the todo list that matches the same `...`, automatically modify the todo list of rebase -i so that the commit marked for squashing comes right after the commit to be modified, and change the action of the moved commit from `pick` to `squash` (or `fixup`).  A commit matches the `...` if the commit subject matches, or if the `...` refers to the commit's hash. As a fall-back, partial matches of the commit subject work, too.  The recommended way to create fixup/squash commits is by using the `--fixup`/`--squash` options of linkgit:git-commit[1]."
 msgstr ""
 
@@ -38568,7 +38568,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:636
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "pick deadbee The oneline of this commit\n"
 "pick fa1afe1 The oneline of the next commit\n"
@@ -38672,7 +38672,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:710
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "pick deadbee Implement feature XXX\n"
 "fixup f1a5c00 Fix to feature XXX\n"
@@ -38691,7 +38691,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:720
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The \"exec\" command launches the command in a shell (the one specified in `$SHELL`, or the default shell if `$SHELL` is not set), so you can use shell features (like \"cd\", \">\", \";\" ...). The command is run from the root of the working tree."
 msgstr ""
 
@@ -38835,7 +38835,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:815
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "    o---o---o---o---o---o---o---o  master\n"
 "\t \\\t\t\t \\\n"
@@ -39633,7 +39633,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reflog.txt:27
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git reflog' ['show'] [log-options] [<ref>]\n"
 "'git reflog expire' [--expire=<time>] [--expire-unreachable=<time>]\n"
@@ -39820,7 +39820,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-remote-ext.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git remote add <nick> \"ext::<command>[ <arguments>...]\"\n"
 msgstr ""
 
@@ -39958,7 +39958,7 @@ msgstr "GIT_EXT_SERVICE"
 
 #. type: Plain text
 #: en/git-remote-ext.txt:70
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Set to long name (git-upload-pack, etc...) of service helper needs to invoke."
 msgstr ""
 
@@ -39970,7 +39970,7 @@ msgstr "GIT_EXT_SERVICE_NOPREFIX"
 
 #. type: Plain text
 #: en/git-remote-ext.txt:74
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Set to long name (upload-pack, etc...) of service helper needs to invoke."
 msgstr ""
 
@@ -40150,7 +40150,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-remote.txt:25
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git remote' [-v | --verbose]\n"
 "'git remote add' [-t <branch>] [-m <master>] [-f] [--[no-]tags] [--mirror=<fetch|push>] <name> <url>\n"
@@ -40469,7 +40469,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-remote.txt:235
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "$ git remote\n"
 "origin\n"
@@ -40713,7 +40713,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-replace.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git replace' [-f] <object> <replacement>\n"
 "'git replace' [-f] --edit <object>\n"
@@ -40833,13 +40833,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-replace.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--graft <commit> [<parent>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/git-replace.txt:93
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Create a graft commit. A new commit is created with the same content as <commit> except that its parents will be [<parent>...] instead of <commit>'s parents. A replacement ref is then created to replace <commit> with the newly created commit. Use `--convert-graft-file` to convert a `$GIT_DIR/info/grafts` file and use replace refs instead."
 msgstr ""
 
@@ -41261,7 +41261,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rerere.txt:121
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git switch topic\n"
 "\t$ git merge master\n"
@@ -41293,7 +41293,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rerere.txt:145
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git switch topic\n"
 "\t$ git merge master\n"
@@ -41398,7 +41398,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reset.txt:14
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git reset' [-q] [<tree-ish>] [--] <paths>...\n"
 "'git reset' (--patch | -p) [<tree-ish>] [--] [<paths>...]\n"
@@ -41413,7 +41413,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-reset.txt:22
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git reset' [-q] [<tree-ish>] [--] <paths>..."
 msgstr ""
 
@@ -41425,7 +41425,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reset.txt:30
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "This means that `git reset <paths>` is the opposite of `git add <paths>`. This command is equivalent to `git restore [--source=<tree-ish>] --staged <paths>...`."
 msgstr ""
 
@@ -41437,7 +41437,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-reset.txt:38
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git reset' (--patch | -p) [<tree-ish>] [--] [<paths>...]"
 msgstr ""
 
@@ -41592,7 +41592,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:138
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git commit ...\n"
 "$ git reset --soft HEAD^      <1>\n"
@@ -41665,7 +41665,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:170
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git commit ...\n"
 "$ git reset --hard HEAD~3   <1>\n"
@@ -41685,7 +41685,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:190
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git pull                         <1>\n"
 "Auto-merging nitfol\n"
@@ -41730,7 +41730,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:215
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git pull                         <1>\n"
 "Auto-merging nitfol\n"
@@ -41856,7 +41856,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:289
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git tag start\n"
 "$ git switch -c branch1\n"
@@ -41899,7 +41899,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:317
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git reset -N HEAD^                        <1>\n"
 "$ git add -p                                <2>\n"
@@ -42125,7 +42125,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-restore.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git restore' [<options>] [--source=<tree>] [--staged] [--worktree] <pathspec>...\n"
 "'git restore' (-p|--patch) [<options>] [--source=<tree>] [--staged] [--worktree] [<pathspec>...]\n"
@@ -42378,7 +42378,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-revert.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git revert' [--[no-]edit] [-n] [-m parent-number] [-s] [-S[<keyid>]] <commit>...\n"
 "'git revert' (--continue | --skip | --abort | --quit)\n"
@@ -42482,7 +42482,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-list.txt:65
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git rev-list' [ --max-count=<number> ]\n"
 "\t     [ --skip=<number> ]\n"
@@ -42585,13 +42585,13 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-list.txt:102
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Another special notation is \"'<commit1>'...'<commit2>'\" which is useful for merges.  The resulting set of commits is the symmetric difference between the two operands.  The following two commands are equivalent:"
 msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-list.txt:106
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git rev-list A B --not $(git merge-base --all A B)\n"
 "\t$ git rev-list A...B\n"
@@ -42617,7 +42617,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-parse.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git rev-parse' [<options>] <args>...\n"
 msgstr ""
 
@@ -43102,7 +43102,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-parse.txt:253
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Resolve \"$GIT_DIR/<path>\" and takes other path relocation variables such as $GIT_OBJECT_DIRECTORY, $GIT_INDEX_FILE... into account. For example, if $GIT_OBJECT_DIRECTORY is set to /foo/bar then \"git rev-parse --git-path objects/abc\" returns /foo/bar/abc."
 msgstr ""
 
@@ -43210,7 +43210,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:290
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<args>..."
 msgstr ""
 
@@ -43342,7 +43342,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:364
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "OPTS_SPEC=\"\\\n"
 "some-command [<options>] <args>...\n"
@@ -43400,7 +43400,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:389
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "usage: some-command [<options>] <args>...\n"
 msgstr ""
 
@@ -43412,7 +43412,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:397
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "    -h, --help            show the help\n"
 "    --foo                 some nifty option --foo\n"
@@ -43423,7 +43423,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:400
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "An option group Header\n"
 "    -C[...]               option C with an optional argument\n"
@@ -43528,7 +43528,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rm.txt:12
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git rm' [-f | --force] [-n] [-r] [--cached] [--ignore-unmatch] [--quiet] [--] <file>...\n"
 msgstr ""
 
@@ -43756,7 +43756,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-email.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git send-email' [<options>] <file|directory|rev-list options>...\n"
 "'git send-email' --dump-aliases\n"
@@ -43824,7 +43824,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:53
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--bcc=<address>,..."
 msgstr ""
 
@@ -43842,7 +43842,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:59
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--cc=<address>,..."
 msgstr ""
 
@@ -43926,7 +43926,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-email.txt:110
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "  [PATCH 0/2] Here is what I did...\n"
 "    [PATCH 1/2] Clean up and tests\n"
@@ -43957,7 +43957,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:119
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--to=<address>,..."
 msgstr ""
 
@@ -44089,7 +44089,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-send-email.txt:188
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "$ git send-email --smtp-auth=\"PLAIN LOGIN GSSAPI\" ...\n"
 msgstr ""
 
@@ -44785,7 +44785,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-pack.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git send-pack' [--all] [--dry-run] [--force] [--receive-pack=<git-receive-pack>]\n"
 "\t\t[--verbose] [--thin] [--atomic]\n"
@@ -45159,7 +45159,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-shortlog.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "'git shortlog' [<options>] [<revision range>] [[--] <path>...]\n"
 "git log --pretty=short | 'git shortlog' [<options>]\n"
@@ -45287,7 +45287,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show-branch.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git show-branch' [-a|--all] [-r|--remotes] [--topo-order | --date-order]\n"
 "\t\t[--current] [--color[=<when>] | --no-color] [--sparse]\n"
@@ -45648,7 +45648,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show-ref.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git show-ref' [-q|--quiet] [--verify] [--head] [-d|--dereference]\n"
 "\t     [-s|--hash[=<n>]] [--abbrev[=<n>]] [--tags]\n"
@@ -45796,7 +45796,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-show-ref.txt:111
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git show-ref --head --dereference\n"
 "832e76a9899f560a90ffd62ae2ce83bbeff58f54 HEAD\n"
@@ -45817,7 +45817,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-show-ref.txt:121
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git show-ref --heads --hash\n"
 "2e3ba0114a1f52b47df29743d6915d056be13278\n"
@@ -45938,7 +45938,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'git show' [<options>] [<object>...]\n"
 msgstr ""
 
@@ -45986,7 +45986,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-show.txt:37
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "<object>..."
 msgstr ""
 
@@ -46244,7 +46244,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stage.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git stage' args...\n"
 msgstr ""
 
@@ -46268,7 +46268,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stash.txt:22
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git stash' list [<options>]\n"
 "'git stash' show [<options>] [<stash>]\n"
@@ -46291,7 +46291,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stash.txt:38
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "The modifications stashed away by this command can be listed with `git stash list`, inspected with `git stash show`, and restored (potentially on top of a different commit) with `git stash apply`.  Calling `git stash` without any arguments is equivalent to `git stash push`.  A stash is by default listed as \"WIP on 'branchname' ...\", but you can give a more descriptive message on the command line when you create one."
 msgstr ""
 
@@ -46303,7 +46303,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-stash.txt:49
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "push [-p|--patch] [-k|--[no-]keep-index] [-u|--include-untracked] [-a|--all] [-q|--quiet] [-m|--message <message>] [--] [<pathspec>...]"
 msgstr ""
 
@@ -46375,7 +46375,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:104
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "stash@{0}: WIP on submit: 6ebd0e2... Update git-stash documentation\n"
 "stash@{1}: On master: 9cc0589... Add git-stash\n"
@@ -46548,7 +46548,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:227
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git pull\n"
 " ...\n"
@@ -46566,7 +46566,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:246
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git switch -c my_wip\n"
@@ -46587,7 +46587,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:257
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git stash\n"
@@ -46611,7 +46611,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:275
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git add --patch foo            # add just first part to the index\n"
@@ -46665,7 +46665,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-status.txt:13
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git status' [<options>...] [--] [<pathspec>...]\n"
 msgstr ""
 
@@ -47145,7 +47145,7 @@ msgstr ""
 
 #. type: delimited block .
 #: en/git-status.txt:345
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "Field       Meaning\n"
 "--------------------------------------------------------\n"
@@ -47466,7 +47466,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-submodule.txt:23
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git submodule' [--quiet] [--cached]\n"
 "'git submodule' [--quiet] add [<options>] [--] <repository> [<path>]\n"
@@ -47537,7 +47537,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:74
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "status [--cached] [--recursive] [--] [<path>...]"
 msgstr ""
 
@@ -47561,7 +47561,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:91
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "init [--] [<path>...]"
 msgstr ""
 
@@ -47591,7 +47591,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:114
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "deinit [-f|--force] (--all|[--] <path>...)"
 msgstr ""
 
@@ -47621,7 +47621,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:132
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "update [--init] [--remote] [-N|--no-fetch] [--[no-]recommend-shallow] [-f|--force] [--checkout|--rebase|--merge] [--reference <repository>] [--depth <depth>] [--recursive] [--jobs <n>] [--] [<path>...]"
 msgstr ""
 
@@ -47745,7 +47745,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:182
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "summary [--cached|--files] [(-n|--summary-limit) <n>] [commit] [--] [<path>...]"
 msgstr ""
 
@@ -47787,7 +47787,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:224
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "sync [--recursive] [--] [<path>...]"
 msgstr ""
 
@@ -48315,7 +48315,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:127
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Fetch unfetched revisions from the Subversion remote we are tracking.  The name of the [svn-remote \"...\"] section in the $GIT_DIR/config file may be specified as an optional command-line argument."
 msgstr ""
 
@@ -48761,7 +48761,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:366
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "is supported, non-numeric args are not: HEAD, NEXT, BASE, PREV, etc ..."
 msgstr ""
 
@@ -49664,7 +49664,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-svn.txt:876
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "# Clone a repo (like git clone):\n"
 "\tgit svn clone http://svn.example.com/project/trunk\n"
@@ -49717,7 +49717,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-svn.txt:924
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "# Do the initial import on a server\n"
 "\tssh server \"cd /pub && git svn clone http://svn.example.com/project [options...]\"\n"
@@ -50432,7 +50432,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-tag.txt:20
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git tag' [-a | -s | -u <keyid>] [-f] [-m <msg> | -F <file>] [-e]\n"
 "\t<tagname> [<commit> | <object>]\n"
@@ -50578,7 +50578,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-tag.txt:103
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "List tags. With optional `<pattern>...`, e.g. `git tag --list 'v-*'`, list only the tags that match the pattern(s)."
 msgstr ""
 
@@ -50868,13 +50868,13 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:319
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "\tgit://git..../proj.git master\n"
 msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:321
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "to get the following updates...\n"
 msgstr ""
 
@@ -50886,7 +50886,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:327
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "$ git pull git://git..../proj.git master\n"
 msgstr ""
 
@@ -51006,7 +51006,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git.txt:55
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Other options are available to control how the manual page is displayed. See linkgit:git-help[1] for more information, because `git --help ...` is converted internally into `git help ...`."
 msgstr ""
 
@@ -51050,7 +51050,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git.txt:82
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Note that omitting the `=` in `git -c foo.bar ...` is allowed and sets `foo.bar` to the boolean true value (just like `[foo]bar` would in a config file). Including the equals but with an empty value (like `git -c foo.bar= ...`) sets `foo.bar` to the empty string which `git config --type=bool` will convert to `false`."
 msgstr ""
 
@@ -51254,7 +51254,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:169
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--list-cmds=group[,group...]"
 msgstr ""
 
@@ -51757,7 +51757,7 @@ msgstr "`GIT_COMMON_DIR`"
 
 #. type: Plain text
 #: en/git.txt:481
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If this variable is set to a path, non-worktree files that are normally in $GIT_DIR will be taken from this path instead. Worktree-specific files such as HEAD or index are taken from $GIT_DIR. See linkgit:gitrepository-layout[5] and linkgit:git-worktree[1] for details. This variable has lower precedence than other path variables such as GIT_INDEX_FILE, GIT_OBJECT_DIRECTORY..."
 msgstr ""
 
@@ -52228,10 +52228,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:685
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2`"
-msgstr "`GIT_TRACE`"
+msgstr "`GIT_TRACE2`"
 
 #. type: Plain text
 #: en/git.txt:689
@@ -52259,10 +52258,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:720
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE_SETUP`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2_EVENT`"
-msgstr "`GIT_TRACE_SETUP`"
+msgstr "`GIT_TRACE2_EVENT`"
 
 #. type: Plain text
 #: en/git.txt:725
@@ -52272,10 +52270,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:726
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE_PERFORMANCE`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2_PERF`"
-msgstr "`GIT_TRACE_PERFORMANCE`"
+msgstr "`GIT_TRACE2_PERF`"
 
 #. type: Plain text
 #: en/git.txt:732
@@ -52714,7 +52711,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-update-index.txt:29
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git update-index'\n"
 "\t     [--add] [--remove | --force-remove] [--replace]\n"
@@ -53274,7 +53271,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-update-index.txt:348
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The command looks at `core.ignorestat` configuration variable.  When this is true, paths updated with `git update-index paths...` and paths updated with other Git commands that update both index and working tree (e.g. 'git apply --index', 'git checkout-index -u', and 'git read-tree -u') are automatically marked as \"assume unchanged\".  Note that \"assume unchanged\" bit is *not* set if `git update-index --refresh` finds the working tree file matches the index (use `git update-index --really-refresh` if you want to mark them as \"assume unchanged\")."
 msgstr ""
 
@@ -54144,7 +54141,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-commit.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-commit' <commit>...\n"
 msgstr ""
 
@@ -54186,7 +54183,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-pack.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-pack' [-v|--verbose] [-s|--stat-only] [--] <pack>.idx ...\n"
 msgstr ""
 
@@ -54198,7 +54195,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-verify-pack.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<pack>.idx ..."
 msgstr ""
 
@@ -54276,7 +54273,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-tag.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-tag' [--format=<format>] <tag>...\n"
 msgstr ""
 
@@ -54294,7 +54291,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-verify-tag.txt:27
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<tag>..."
 msgstr ""
 
@@ -54318,7 +54315,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-web--browse.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git web{litdd}browse' [<options>] <url|file>...\n"
 msgstr ""
 
@@ -54592,7 +54589,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-whatchanged.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git whatchanged' <option>...\n"
 msgstr ""
 
@@ -55123,7 +55120,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-worktree.txt:372
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git worktree add -b emergency-fix ../temp master\n"
 "$ pushd ../temp\n"
@@ -56328,7 +56325,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/pretty-formats.txt:115
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'%C(...)'"
 msgstr ""
 
@@ -56340,7 +56337,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/pretty-formats.txt:129
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "\"CONFIGURATION FILE\" section of linkgit:git-config[1].  By default, colors are shown only when enabled for log output (by `color.diff`, `color.ui`, or `--color`, and respecting the `auto` settings of the former if we are going to a terminal). `%C(auto,...)` is accepted as a historical synonym for the default (e.g., `%C(auto,red)`). Specifying `%C(always,...)` will show the colors even when color is not otherwise enabled (though consider just using `--color=always` to enable color for the whole output, including this format and anything else git might color).  `auto` alone (i.e. `%C(auto)`) will turn on auto coloring on the next placeholders until the color is switched again."
 msgstr ""
 
@@ -57433,7 +57430,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/pull-fetch-param.txt:45
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "Whether that update is allowed without `--force` depends on the ref namespace it's being fetched to, the type of object being fetched, and whether the update is considered to be a fast-forward. Generally, the same rules apply for fetching as when pushing, see the `<refspec>...` section of linkgit:git-push[1] for what those are. Exceptions to those rules particular to 'git fetch' are noted below."
 msgstr ""
 
@@ -57904,13 +57901,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/revisions.txt:280
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "The '...' (three-dot) Symmetric Difference Notation"
 msgstr ""
 
 #. type: Plain text
 #: en/revisions.txt:286
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "A similar notation 'r1\\...r2' is called symmetric difference of 'r1' and 'r2' and is defined as 'r1 r2 --not $(git merge-base --all r1 r2)'.  It is the set of commits that are reachable from either one of 'r1' (left side) or 'r2' (right side) but not from both."
 msgstr ""
 
@@ -58000,7 +57997,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/revisions.txt:331
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'<rev1>\\...<rev2>'"
 msgstr ""
 
@@ -58054,7 +58051,7 @@ msgstr ""
 
 #. type: delimited block .
 #: en/revisions.txt:377
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "   Args   Expanded arguments    Selected commits\n"
 "   D                            G H D\n"
@@ -58544,7 +58541,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:256
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "For example, `--cherry-pick --right-only A...B` omits those commits from `B` which are in `A` or are patch-equivalent to a commit in `A`. In other words, this lists the `+` commits from `git cherry A B`.  More precisely, `--cherry-pick --right-only --no-merges` gives the exact list."
 msgstr ""
 
@@ -58556,7 +58553,7 @@ msgstr "--cherry"
 
 #. type: Plain text
 #: en/rev-list-options.txt:263
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "A synonym for `--right-only --cherry-mark --no-merges`; useful to limit the output to the commits on our side and mark those that have been applied to the other side of a forked history with `git log --cherry upstream...mybranch`, similar to `git cherry upstream mybranch`."
 msgstr ""
 
@@ -58568,7 +58565,7 @@ msgstr "--walk-reflogs"
 
 #. type: Plain text
 #: en/rev-list-options.txt:271
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Instead of walking the commit ancestry chain, walk reflog entries from the most recent one to older ones.  When this option is used you cannot specify commits to exclude (that is, '{caret}commit', 'commit1..commit2', and 'commit1\\...commit2' notations cannot be used)."
 msgstr ""
 
@@ -59561,7 +59558,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:875
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "`--date=format:...` feeds the format `...` to your system `strftime`, except for %z and %Z, which are handled internally.  Use `--date=format:%c` to show the date in your system locale's preferred format.  See the `strftime` manual for a complete list of format placeholders. When using `-local`, the correct syntax is `--date=format-local:...`."
 msgstr ""
 
@@ -59597,7 +59594,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:892
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Print also the parents of the commit (in the form \"commit parent...\").  Also enables parent rewriting, see 'History Simplification' above."
 msgstr ""
 
@@ -59609,7 +59606,7 @@ msgstr "--children"
 
 #. type: Plain text
 #: en/rev-list-options.txt:896
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Print also the children of the commit (in the form \"commit child...\").  Also enables parent rewriting, see 'History Simplification' above."
 msgstr ""
 
@@ -59662,13 +59659,13 @@ msgstr ""
 
 #. type: delimited block -
 #: en/rev-list-options.txt:922
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "\t$ git rev-list --left-right --boundary --pretty=oneline A...B\n"
 msgstr ""
 
 #. type: delimited block -
 #: en/rev-list-options.txt:929
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "\t>bbbbbbb... 3rd on b\n"
 "\t>bbbbbbb... 2nd on b\n"

--- a/po/documentation.pt_BR.po
+++ b/po/documentation.pt_BR.po
@@ -2474,7 +2474,7 @@ msgstr "inteiro"
 
 #. type: Plain text
 #: en/config.txt:256
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The value for many variables that specify various sizes can be suffixed with `k`, `M`,... to mean \"scale the number by 1024\", \"by 1024x1024\", etc."
 msgstr "O valor de muitas variáveis que especificam vários tamanhos podem ter como sufixo `k`,`M`, para dizer \"escale o número por 1024\", \"por 1024x1024\", etc."
 
@@ -2865,7 +2865,7 @@ msgstr "compara o <tree-ish> e o índice."
 
 #. type: Labeled list
 #: en/diff-format.txt:16
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "git-diff-tree [-r] <tree-ish-1> <tree-ish-2> [<pattern>...]"
 msgstr "git-diff-árvore [-r] <tree-ish-1> <tree-ish-2> [<pattern>...]"
 
@@ -2877,7 +2877,7 @@ msgstr "compara as árvores nomeadas pelos dois argumentos."
 
 #. type: Labeled list
 #: en/diff-format.txt:19
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "git-diff-files [<pattern>...]"
 msgstr "git-diff-arquivos [<pattern>...]"
 
@@ -3613,7 +3613,7 @@ msgstr "Existem (números de pais + 1 caracteres `@` no cabeçalho do bloco para
 
 #. type: Plain text
 #: en/diff-generate-patch.txt:179
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Unlike the traditional 'unified' diff format, which shows two files A and B with a single column that has `-` (minus -- appears in A but removed in B), `+` (plus -- missing in A but added to B), or `\" \"` (space -- unchanged) prefix, this format compares two or more files file1, file2,... with one file X, and shows how X differs from each of fileN.  One column for each of fileN is prepended to the output line to note how X's line is different from it."
 msgstr "Ao contrário do formato diff tradicional 'unificado', que mostra dois arquivos A e B com uma única coluna que tem `-` (menos -- aparece em A, mas removido em B), `+` (mais -- faltando em A, mas adicionado para B), ou `\" \"` (espaço -- inalterado) prefixo, este formato compara dois ou mais arquivos file1, file2, ... com um arquivo X, e mostra como X difere de cada fileN. Uma coluna para cara arquivo fileN é anexada à linha de saída para observar como a linha do X é diferente dela."
 
@@ -3943,7 +3943,7 @@ msgstr "--stat[=<width>[,<name-width>[,<count>]]]"
 
 #. type: Plain text
 #: en/diff-options.txt:137
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Generate a diffstat. By default, as much space as necessary will be used for the filename part, and the rest for the graph part. Maximum width defaults to terminal width, or 80 columns if not connected to a terminal, and can be overridden by `<width>`. The width of the filename part can be limited by giving another width `<name-width>` after a comma. The width of the graph part can be limited by using `--stat-graph-width=<width>` (affects all commands generating a stat graph) or by setting `diff.statGraphWidth=<width>` (does not affect `git format-patch`).  By giving a third parameter `<count>`, you can limit the output to the first `<count>` lines, followed by `...` if there are more."
 msgstr "Gere um diffstat. Por padrão, o espaço necessário será usado para a parte do nome do arquivo e o restante para a parte do gráfico. A largura máxima é padronizada para a largura do terminal, ou 80 colunas, se não estiver conectada a um terminal, e pode ser substituída por `<width>`. A largura da parte do nome do arquivo pode ser limitada dando outra largura `<name-width>` após uma vírgula. A largura da parte do gráfico pode ser limitada usando `--stat-graph-width=<width>` (afeta todos os comandos que geram um stat graph) ou configurando `diff.statGraphWidth=<width>` (não afeta git format-patch`). Dando um terceiro parâmetro `<count>`, você pode limitar a saída para as primeiras linhas `<count>` seguidas por `...` se houver mais."
 
@@ -3991,14 +3991,14 @@ msgstr "Saída apenas a última linha do formato `--stat` contendo o número tot
 
 #. type: Labeled list
 #: en/diff-options.txt:161
-#, fuzzy, no-wrap, priority:280
+#, fuzzy, ignore-ellipsis, no-wrap, priority:280
 #| msgid "--dirstat[=<param1,param2,...>]"
 msgid "-X[<param1,param2,...>]"
 msgstr "--dirstat[=<param1,param2,...>]"
 
 #. type: Labeled list
 #: en/diff-options.txt:162
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--dirstat[=<param1,param2,...>]"
 msgstr "--dirstat[=<param1,param2,...>]"
 
@@ -4089,14 +4089,14 @@ msgstr "Sinônimo para `-p --stat`."
 
 #. type: Labeled list
 #: en/diff-options.txt:209
-#, fuzzy, no-wrap, priority:280
+#, fuzzy, ignore-ellipsis, no-wrap, priority:280
 #| msgid "--dirstat[=<param1,param2,...>]"
 msgid "--dirstat-by-file[=<param1,param2>...]"
 msgstr "--dirstat[=<param1,param2,...>]"
 
 #. type: Plain text
 #: en/diff-options.txt:211
-#, fuzzy, priority:280
+#, fuzzy, ignore-ellipsis, priority:280
 #| msgid "--dirstat[=<param1,param2,...>]"
 msgid "Synonym for --dirstat=files,param1,param2..."
 msgstr "--dirstat[=<param1,param2,...>]"
@@ -4779,13 +4779,13 @@ msgstr "As opções `-M` e` -C` requerem o tempo de processamento O (n^2), onde 
 
 #. type: Labeled list
 #: en/diff-options.txt:527
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--diff-filter=[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr "--diff-filtro=[(A|C|D|M|R|T|U|X|B)...[*]]"
 
 #. type: Plain text
 #: en/diff-options.txt:538
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Select only files that are Added (`A`), Copied (`C`), Deleted (`D`), Modified (`M`), Renamed (`R`), have their type (i.e. regular file, symlink, submodule, ...) changed (`T`), are Unmerged (`U`), are Unknown (`X`), or have had their pairing Broken (`B`).  Any combination of the filter characters (including none) can be used.  When `*` (All-or-none) is added to the combination, all paths are selected if there is any file that matches other criteria in the comparison; if there is no file that matches other criteria, nothing is selected."
 msgstr "Selecione apenas os arquivos que são adicionados (`A`), copiados (` C`), excluídos (`D`), modificados (` M`), renomeados (`R`), que têm seu tipo (ou seja, arquivo regular, symlink, submódulo, ...) alterado (`T`), são Unmerged (` U`), são desconhecidos (`X`), ou tiveram seu pareamento Broken (` B`). Qualquer combinação dos caracteres do filtro (incluindo nenhum) pode ser usada. Quando `*` (All-or-none) é adicionado à combinação, todos os caminhos são selecionados se houver algum arquivo que corresponda a outros critérios na comparação; se não houver nenhum arquivo que corresponda a outros critérios, nada será selecionado."
 
@@ -4845,7 +4845,7 @@ msgstr "Para ilustrar a diferença entre `-S <regex> --pickaxe-regex` e` -G <reg
 
 #. type: delimited block -
 #: en/diff-options.txt:573
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "+    return !regexec(regexp, two->ptr, 1, &regmatch, 0);\n"
 "...\n"
@@ -5774,7 +5774,7 @@ msgstr "SINOPSE"
 
 #. type: Plain text
 #: en/git-add.txt:15
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "'git add' [--verbose | -v] [--dry-run | -n] [--force | -f] [--interactive | -i] [--patch | -p]\n"
 "\t  [--edit | -e] [--[no-]all | --[no-]ignore-removal | [--update | -u]]\n"
@@ -5836,7 +5836,7 @@ msgstr "OPÇÕES"
 
 #. type: Labeled list
 #: en/git-add.txt:52 en/git-grep.txt:308 en/git-status.txt:148
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid "<pathspec>..."
 msgstr "<pathspec>..."
 
@@ -5980,7 +5980,7 @@ msgstr "Atualize o índice adicionando novos arquivos que são desconhecidos ao 
 
 #. type: Plain text
 #: en/git-add.txt:145
-#, priority:300
+#, ignore-ellipsis, priority:300
 msgid "This option is primarily to help users who are used to older versions of Git, whose \"git add <pathspec>...\" was a synonym for \"git add --no-all <pathspec>...\", i.e. ignored removed files."
 msgstr "Esta opção é principalmente para ajudar usuários que estão acostumados com versões mais antigas do Git, cujo \"git add <pathspec> ...\" era um sinônimo para \"git add --no-all <pathspec> ...\", isto é, ignorado removido arquivos."
 
@@ -6495,7 +6495,7 @@ msgstr "git-am - Aplica uma série de patches de uma caixa de correio"
 
 #. type: Plain text
 #: en/git-am.txt:20
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git am' [--signoff] [--keep] [--[no-]keep-cr] [--[no-]utf8]\n"
 "\t [--[no-]3way] [--interactive] [--committer-date-is-author-date]\n"
@@ -6523,7 +6523,7 @@ msgstr "Divide as mensagens de correio em uma caixa de correio em mensagens de l
 
 #. type: Labeled list
 #: en/git-am.txt:29
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "(<mbox>|<Maildir>)..."
 msgstr "(<mbox>|<Maildir>)..."
 
@@ -7063,7 +7063,7 @@ msgstr "git-apply - Aplica um patch aos arquivos e/ou ao índice"
 
 #. type: Plain text
 #: en/git-apply.txt:20
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git apply' [--stat] [--numstat] [--summary] [--check] [--index | --intent-to-add] [--3way]\n"
 "\t  [--apply] [--no-add] [--build-fake-ancestor=<file>] [-R | --reverse]\n"
@@ -7097,7 +7097,7 @@ msgstr "Este comando aplica o patch, mas não cria um commit.  Use linkgit:git-a
 
 #. type: Labeled list
 #: en/git-apply.txt:37
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<patch>..."
 msgstr "<patch>..."
 
@@ -7515,7 +7515,7 @@ msgstr "git-archimport - Importar um repositório do GNU Arch para o Git"
 
 #. type: Plain text
 #: en/git-archimport.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git archimport' [-h] [-v] [-o] [-a] [-f] [-T] [-D depth] [-t tempdir]\n"
 "               <archive/branch>[:<git-branch>] ...\n"
@@ -7681,7 +7681,7 @@ msgstr "git-archive - Cria um arquivo de arquivos de uma árvore nomeada"
 
 #. type: Plain text
 #: en/git-archive.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git archive' [--format=<fmt>] [--list] [--prefix=<prefix>/] [<extra>]\n"
 "\t      [-o <file> | --output=<file>] [--worktree-attributes]\n"
@@ -8071,7 +8071,7 @@ msgstr "O comando assume vários subcomandos e diferentes opções, dependendo d
 
 #. type: Plain text
 #: en/git-bisect.txt:31
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 " git bisect start [--term-{old,good}=<term> --term-{new,bad}=<term>]\n"
 "\t\t  [--no-checkout] [<bad> [<good>...]] [--] [<paths>...]\n"
@@ -8278,7 +8278,7 @@ msgstr "para indicar que um commit foi feito antes da mudança solicitada, ou"
 
 #. type: delimited block -
 #: en/git-bisect.txt:158
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git bisect new [<rev>...]\n"
 msgstr "git bisseta nova [<rev>...]\n"
 
@@ -8308,7 +8308,7 @@ msgstr "Você pode obter apenas o termo antigo (respectivamente novo) com `git b
 
 #. type: Plain text
 #: en/git-bisect.txt:175
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If you would like to use your own terms instead of \"bad\"/\"good\" or \"new\"/\"old\", you can choose any names you like (except existing bisect subcommands like `reset`, `start`, ...) by starting the bisection using"
 msgstr "Se você gostaria de usar seus próprios termos em vez de \"ruim\"/ \"bom\" ou \"novo\"/ \"velho\", você pode escolher qualquer nome que quiser (exceto os subcomandos bisect existentes como `reset`,` start`, .. .) iniciando a bissecção usando"
 
@@ -8756,7 +8756,7 @@ msgstr "Localize uma boa região do gráfico de objetos em um repositório danif
 
 #. type: delimited block -
 #: en/git-bisect.txt:463
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git bisect start HEAD <known-good-commit> [ <boundary-commit> ... ] --no-checkout\n"
 "$ git bisect run sh -c '\n"
@@ -9243,7 +9243,7 @@ msgstr "git-branch - Lista, cria ou exclui filiais"
 
 #. type: Plain text
 #: en/git-branch.txt:26
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git branch' [--color[=<when>] | --no-color] [--show-current]\n"
 "\t[-v [--abbrev=<length> | --no-abbrev]]\n"
@@ -9288,7 +9288,7 @@ msgstr "Com `--contains`, mostra apenas as ramificações que contêm o commit n
 
 #. type: Plain text
 #: en/git-branch.txt:61
-#, fuzzy, priority:240
+#, fuzzy, ignore-ellipsis, priority:240
 #| msgid "As a special case, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgid "The command's second form creates a new branch head named <branchname> which points to the current `HEAD`, or <start-point> if given. As a special case, for <start-point>, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr "Como um caso especial, você pode usar `\"A ... B\"` como um atalho para a base de mesclagem de `A` e` B` se houver exatamente uma base de merge. Você pode deixar de fora, no máximo, um de `A` e` B`, caso em que o padrão é `HEAD`."
@@ -9490,7 +9490,7 @@ msgstr "Listar filiais de rastreamento remoto e filiais locais."
 
 #. type: Plain text
 #: en/git-branch.txt:176
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "List branches.  With optional `<pattern>...`, e.g. `git branch --list 'maint-*'`, list only the branches that match the pattern(s)."
 msgstr "Listar branches.  Com o opcional `<pattern> ...`, por ex. `git branch --list 'maint - *'`, lista apenas as ramificações que correspondem ao(s) padrão(ões)."
 
@@ -9738,7 +9738,7 @@ msgstr "--ordenar=<chave>"
 
 #. type: Plain text
 #: en/git-branch.txt:291
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "Sort based on the key given. Prefix `-` to sort in descending order of the value. You may use the --sort=<key> option multiple times, in which case the last key becomes the primary key. The keys supported are the same as those in `git for-each-ref`. Sort order defaults to the value configured for the `branch.sort` variable if exists, or to sorting based on the full refname (including `refs/...` prefix). This lists detached HEAD (if present) first, then local branches and finally remote-tracking branches. See linkgit:git-config[1]."
 msgstr "Classifique com base na chave fornecida. Prefixo `-` para classificar em ordem decrescente do valor. Você pode usar a opção --ordenar = <chave> várias vezes, em cujo caso a última chave se torna a chave primária. As chaves suportadas são as mesmas do `git para-cada-ref`. A ordem de classificação é padronizada para o valor configurado para a variável branch.sort, se existir, ou para a classificação baseada no refnome completo (incluindo o prefixo `refs/...`). Isso lista HEAD separado (se presente) primeiro, depois as ramificações locais e, finalmente, as ramificações de rastreamento remoto. Veja linkgit:git-config[1]."
 
@@ -9780,7 +9780,7 @@ msgstr "Inicie o desenvolvimento a partir de uma tag conhecida"
 
 #. type: delimited block -
 #: en/git-branch.txt:317
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git clone git://git.kernel.org/pub/scm/.../linux-2.6 my2.6\n"
 "$ cd my2.6\n"
@@ -9802,7 +9802,7 @@ msgstr "Excluir um ramo desnecessário"
 
 #. type: delimited block -
 #: en/git-branch.txt:329
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git clone git://git.kernel.org/.../git.git my.git\n"
 "$ cd my.git\n"
@@ -9917,7 +9917,7 @@ msgstr "git-bundle - Mover objetos e refs por arquivo"
 
 #. type: Plain text
 #: en/git-bundle.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git bundle' create <file> <git-rev-list-args>\n"
 "'git bundle' verify <file>\n"
@@ -9997,7 +9997,7 @@ msgstr "Uma lista de argumentos, aceitável para 'git rev-parse' e 'git rev-list
 
 #. type: Labeled list
 #: en/git-bundle.txt:71
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<refname>...]"
 msgstr "[<refnome>...]"
 
@@ -10797,7 +10797,7 @@ msgstr "git-check-attr - Exibe informações sobre gitattributes"
 
 #. type: Plain text
 #: en/git-check-attr.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git check-attr' [-a | --all | <attr>...] [--] <pathname>...\n"
 "'git check-attr' --stdin [-z] [-a | --all | <attr>...]\n"
@@ -11038,7 +11038,7 @@ msgstr "git-verifique-ignorar - Depurar gitignorar / excluir arquivos"
 
 #. type: Plain text
 #: en/git-check-ignore.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git check-ignore' [<options>] <pathname>...\n"
 "'git check-ignore' [<options>] --stdin\n"
@@ -11216,7 +11216,7 @@ msgstr "git-check-mailmap - Mostra nomes canônicos e endereços de e-mail de co
 
 #. type: Plain text
 #: en/git-check-mailmap.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git check-mailmap' [<options>] <contact>...\n"
 msgstr "'git verificar-mailmap' [<opções>] <contato>...\n"
 
@@ -11252,7 +11252,7 @@ msgstr "git-checkout-index - Copia arquivos do índice para a árvore de trabalh
 
 #. type: Plain text
 #: en/git-checkout-index.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git checkout-index' [-u] [-q] [-a] [-f] [-n] [--prefix=<string>]\n"
 "\t\t   [--stage=<number>|all]\n"
@@ -11529,7 +11529,7 @@ msgstr "git-checkout - Alterne filiais ou restaure arquivos da árvore de trabal
 
 #. type: Plain text
 #: en/git-checkout.txt:18
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git checkout' [-q] [-f] [-m] [<branch>]\n"
 "'git checkout' [-q] [-f] [-m] --detach [<branch>]\n"
@@ -11650,7 +11650,7 @@ msgstr "Omitir <branch> desanexa o HEAD na ponta do ramo atual."
 
 #. type: Labeled list
 #: en/git-checkout.txt:82
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git checkout' [<tree-ish>] [--] <pathspec>..."
 msgstr "'git verificar' [<tree-ish>] [--] <pathspec>..."
 
@@ -11671,7 +11671,7 @@ msgstr "O índice pode conter entradas não mescladas devido a uma mesclagem ant
 
 #. type: Labeled list
 #: en/git-checkout.txt:98
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git checkout' (-p|--patch) [<tree-ish>] [--] [<pathspec>...]"
 msgstr "'git verificar' (-p|--patch) [<tree-ish>] [--] [<pathspec>...]"
 
@@ -12031,7 +12031,7 @@ msgstr "Você pode usar a sintaxe `\" @{- N}\"` para se referir à última branc
 
 #. type: Plain text
 #: en/git-checkout.txt:326 en/git-switch.txt:58
-#, fuzzy, priority:240
+#, fuzzy, ignore-ellipsis, priority:240
 #| msgid "As a special case, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgid "As a special case, you may use `A...B` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr "Como um caso especial, você pode usar `\"A ... B\"` como um atalho para a base de mesclagem de `A` e` B` se houver exatamente uma base de merge. Você pode deixar de fora, no máximo, um de `A` e` B`, caso em que o padrão é `HEAD`."
@@ -12063,7 +12063,7 @@ msgstr "O nome de um commit no qual iniciar o novo branch; veja linkgit:git-bran
 
 #. type: Plain text
 #: en/git-checkout.txt:337
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "As a special case, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr "Como um caso especial, você pode usar `\"A ... B\"` como um atalho para a base de mesclagem de `A` e` B` se houver exatamente uma base de merge. Você pode deixar de fora, no máximo, um de `A` e` B`, caso em que o padrão é `HEAD`."
 
@@ -12675,7 +12675,7 @@ msgstr "git-cherry-pick - Aplique as alterações introduzidas por alguns commit
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git cherry-pick' [--edit] [-n] [-m parent-number] [-s] [-x] [--ff]\n"
 "\t\t  [-S[<keyid>]] <commit>...\n"
@@ -12732,13 +12732,13 @@ msgstr "Veja linkgit:git-merge[1] para algumas dicas sobre como resolver tais co
 
 #. type: Labeled list
 #: en/git-cherry-pick.txt:43 en/git-merge.txt:116 en/git-revert.txt:36 en/git-verify-commit.txt:27
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "<commit>..."
 msgstr ""
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:52
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Commits to cherry-pick.  For a more complete list of ways to spell commits, see linkgit:gitrevisions[7].  Sets of commits can be passed but no traversal is done by default, as if the `--no-walk` option was specified, see linkgit:git-rev-list[1]. Note that specifying a range will feed all <commit>... arguments to a single revision walk (see a later example that uses 'maint master..next')."
 msgstr "Compromete-se a escolher. Para uma lista mais completa de maneiras de soletrar commits, veja linkgit:gitrevisions[7].  Conjuntos de commits podem ser passados, mas nenhuma passagem é feita por padrão, como se a opção `--não-caminhar` fosse especificada, veja linkgit:git-rev-list[1]. Note que especificar um intervalo alimentará todos os argumentos <commit> ... para um único passo de revisão (veja um exemplo posterior que usa 'maint master..next')."
 
@@ -12768,7 +12768,7 @@ msgstr "-x"
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:78
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When recording the commit, append a line that says \"(cherry picked from commit ...)\" to the original commit message in order to indicate which commit this change was cherry-picked from.  This is done only for cherry picks without conflicts.  Do not use this option if you are cherry-picking from your private branch because the information is useless to the recipient.  If on the other hand you are cherry-picking between two publicly visible branches (e.g. backporting a fix to a maintenance branch for an older release from a development branch), adding this information can be useful."
 msgstr "Ao gravar o commit, acrescente uma linha que diz \"(cherry picked from commit ...)\" à mensagem de commit original para indicar qual commit esta mudança foi escolhida. Isso é feito apenas para picaretas de cereja sem conflitos.  Não use esta opção se você estiver escolhendo o seu ramo privado porque a informação é inútil para o destinatário.  Se, por outro lado, você estiver escolhendo entre dois ramos publicamente visíveis (por exemplo, retrocedendo uma correção para um ramo de manutenção para uma versão mais antiga de um ramo de desenvolvimento), adicionar essa informação pode ser útil."
 
@@ -13130,7 +13130,7 @@ msgstr "O git-cherry é freqüentemente usado em fluxos de trabalho baseados em 
 
 #. type: delimited block -
 #: en/git-cherry.txt:58
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git checkout -b topic origin/master\n"
 "# work and create some commits\n"
@@ -13172,7 +13172,7 @@ msgstr "Em uma situação em que o tópico consistia em três commits e o manten
 
 #. type: delimited block -
 #: en/git-cherry.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git log --graph --oneline --decorate --boundary origin/master...topic\n"
 "* 7654321 (origin/master) upstream tip commit\n"
@@ -13195,7 +13195,7 @@ msgstr "Nesses casos, o git-cherry mostra um resumo conciso do que ainda precisa
 
 #. type: delimited block -
 #: en/git-cherry.txt:96
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git cherry origin/master topic\n"
 "- cccc000... commit C\n"
@@ -13223,7 +13223,7 @@ msgstr "O <limite> opcional é útil nos casos em que seu tópico é baseado em 
 
 #. type: delimited block -
 #: en/git-cherry.txt:126
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git log --graph --oneline --decorate --boundary origin/master...topic\n"
 "* 7654321 (origin/master) upstream tip commit\n"
@@ -13249,7 +13249,7 @@ msgstr "Especificando `base` como limite, você pode evitar listar commits entre
 
 #. type: delimited block -
 #: en/git-cherry.txt:136
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git cherry origin/master topic base\n"
 "- cccc000... commit C\n"
@@ -13305,7 +13305,7 @@ msgstr "git-clean - Remove arquivos não rastreados da árvore de trabalho"
 
 #. type: Plain text
 #: en/git-clean.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git clean' [-d] [-f] [-i] [-n] [-q] [-e <pattern>] [-x | -X] [--] <path>...\n"
 msgstr ""
 
@@ -13323,7 +13323,7 @@ msgstr "Normalmente, apenas arquivos desconhecidos para o Git são removidos, ma
 
 #. type: Plain text
 #: en/git-clean.txt:25
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If any optional `<path>...` arguments are given, only those paths are affected."
 msgstr "Se algum argumento opcional `<path>...` for dado, somente esses caminhos serão afetados."
 
@@ -13946,7 +13946,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-clone.txt:306
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "$ git clone git://git.kernel.org/pub/scm/.../linux.git my-linux\n"
 "$ cd my-linux\n"
@@ -13976,7 +13976,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-clone.txt:325
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "$ git clone --reference /git/linux.git \\\n"
 "\tgit://git.kernel.org/pub/scm/.../linux.git \\\n"
@@ -14169,7 +14169,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-commit-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git commit-tree' <tree> [(-p <parent>)...]\n"
 "'git commit-tree' [(-p <parent>)...] [-S[<keyid>]] [(-m <message>)...]\n"
@@ -14370,7 +14370,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-commit.txt:17
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git commit' [-a | --interactive | --patch] [-s] [-v] [-u<mode>] [--amend]\n"
 "\t   [--dry-run] [(-c | -C | --fixup | --squash) <commit>]\n"
@@ -14790,7 +14790,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-commit.txt:248
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "\t$ git reset --soft HEAD^\n"
 "\t$ ... do something else to come up with the right tree ...\n"
@@ -14955,7 +14955,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-commit.txt:346 en/git-rm.txt:29
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "<file>..."
 msgstr ""
 
@@ -15938,7 +15938,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-config.txt:428
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "However, if you really only want to replace the line for the default proxy, i.e. the one without a \"for ...\" postfix, do something like this:"
 msgstr ""
 
@@ -17296,7 +17296,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-cvsserver.txt:26
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git-cvsserver' [<options>] [pserver|server] [<directory> ...]\n"
 msgstr ""
 
@@ -17994,7 +17994,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-daemon.txt:25
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git daemon' [--verbose] [--syslog] [--export-all]\n"
 "\t     [--timeout=<n>] [--init-timeout=<n>] [--max-connections=<n>]\n"
@@ -18560,7 +18560,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-describe.txt:14
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "'git describe' [--all] [--tags] [--contains] [--abbrev=<n>] [<commit-ish>...]\n"
 "'git describe' [--all] [--tags] [--contains] [--abbrev=<n>] --dirty[=<mark>]\n"
@@ -18587,7 +18587,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-describe.txt:37
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "<commit-ish>..."
 msgstr ""
 
@@ -18683,7 +18683,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-describe.txt:95
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Always output the long format (the tag, the number of commits and the abbreviated commit name) even when it matches a tag.  This is useful when you want to see parts of the commit object name in \"describe\" output, even when the commit in question happens to be a tagged version.  Instead of just emitting the tag name, it will describe such a commit as v1.2-0-gdeadbee (0th commit since tag v1.2 that points at object deadbee....)."
 msgstr ""
 
@@ -18861,7 +18861,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-files.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git diff-files' [-q] [-0|-1|-2|-3|-c|--cc] [<common diff options>] [<path>...]\n"
 msgstr ""
 
@@ -18933,7 +18933,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-index.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git diff-index' [-m] [--cached] [<common diff options>] <tree-ish> [<path>...]\n"
 msgstr ""
 
@@ -19072,7 +19072,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-index.txt:102
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "  torvalds@ppc970:~/v2.6/linux> git diff-index --abbrev HEAD\n"
 "  :100644 100664 7476bb... 000000...      kernel/sched.c\n"
@@ -19110,7 +19110,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-difftool.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git difftool' [<options>] [<commit> [<commit>]] [--] [<path>...]\n"
 msgstr ""
 
@@ -19422,7 +19422,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git diff-tree' [--stdin] [-m] [-s] [-v] [--no-commit-id] [--pretty]\n"
 "\t      [-t] [-r] [-c | --cc] [--combined-all-paths] [--root]\n"
@@ -19455,7 +19455,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff-tree.txt:32 en/git-diff.txt:114 en/git-submodule.txt:422
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "<path>..."
 msgstr ""
 
@@ -19581,7 +19581,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:17
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git diff' [<options>] [<commit>] [--] [<path>...]\n"
 "'git diff' [<options>] --cached [<commit>] [--] [<path>...]\n"
@@ -19598,7 +19598,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:24
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] [--] [<path>...]"
 msgstr ""
 
@@ -19622,7 +19622,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:41
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] --cached [<commit>] [--] [<path>...]"
 msgstr ""
 
@@ -19634,7 +19634,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:51
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit> [--] [<path>...]"
 msgstr ""
 
@@ -19646,7 +19646,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:59
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit> <commit> [--] [<path>...]"
 msgstr ""
 
@@ -19658,7 +19658,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:64
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit>..<commit> [--] [<path>...]"
 msgstr ""
 
@@ -19670,13 +19670,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:70
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit>\\...<commit> [--] [<path>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:77
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "This form is to view the changes on the branch containing and up to the second <commit>, starting at a common ancestor of both <commit>.  \"git diff A\\...B\" is equivalent to \"git diff $(git merge-base A B) B\".  You can omit any one of <commit>, which has the same effect as using HEAD instead."
 msgstr ""
 
@@ -19688,7 +19688,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:89
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "For a more complete list of ways to spell <commit>, see \"SPECIFYING REVISIONS\" section in linkgit:gitrevisions[7].  However, \"diff\" is about comparing two _endpoints_, not ranges, and the range notations (\"<commit>..<commit>\" and \"<commit>\\...<commit>\") do not mean a range as defined in the \"SPECIFYING RANGES\" section in linkgit:gitrevisions[7]."
 msgstr ""
 
@@ -19796,7 +19796,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-diff.txt:160
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git diff topic master    <1>\n"
 "$ git diff topic..master   <2>\n"
@@ -20116,7 +20116,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:143
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<git-rev-list-args>...]"
 msgstr ""
 
@@ -20197,7 +20197,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-fast-export.txt:215
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git init anon-repo\n"
 "$ cd anon-repo\n"
@@ -22507,7 +22507,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch-pack.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git fetch-pack' [--all] [--quiet|-q] [--keep|-k] [--thin] [--include-tag]\n"
 "\t[--upload-pack=<git-upload-pack>]\n"
@@ -22661,7 +22661,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fetch-pack.txt:117 en/git-ls-remote.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<refs>..."
 msgstr ""
 
@@ -22691,7 +22691,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch.txt:16
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git fetch' [<options>] [<repository> [<refspec>...]]\n"
 "'git fetch' [<options>] <group>\n"
@@ -23032,7 +23032,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch.txt:226
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "For a successfully fetched ref, the summary shows the old and new values of the ref in a form suitable for using as an argument to `git log` (this is `<old>..<new>` in most cases, and `<old>...<new>` for forced non-fast-forward updates)."
 msgstr ""
 
@@ -23154,7 +23154,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:18
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git filter-branch' [--setup <command>] [--subdirectory-filter <directory>]\n"
 "\t[--env-filter <command>] [--tree-filter <command>]\n"
@@ -23293,7 +23293,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:117
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for rewriting the index.  It is similar to the tree filter but does not check out the tree, which makes it much faster.  Frequently used with `git rm --cached --ignore-unmatch ...`, see EXAMPLES below.  For hairy cases, see linkgit:git-update-index[1]."
 msgstr ""
 
@@ -23305,7 +23305,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:125
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for rewriting the commit's parent list.  It will receive the parent string on stdin and shall output the new parent string on stdout.  The parent string is in the format described in linkgit:git-commit-tree[1]: empty for the initial commit, \"-p parent\" for a normal commit and \"-p parent1 -p parent2 -p parent3 ...\" for a merge commit."
 msgstr ""
 
@@ -23329,7 +23329,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:138
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for performing the commit.  If this filter is specified, it will be called instead of the 'git commit-tree' command, with arguments of the form \"<TREE_ID> [(-p <PARENT_COMMIT_ID>)...]\" and the log message on stdin.  The commit id is expected on stdout."
 msgstr ""
 
@@ -23431,7 +23431,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-filter-branch.txt:207
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<rev-list options>..."
 msgstr ""
 
@@ -23692,7 +23692,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-filter-branch.txt:388
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git filter-branch ... C..H\n"
 msgstr ""
 
@@ -23704,7 +23704,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-filter-branch.txt:395
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "git filter-branch ... C..H --not D\n"
 "git filter-branch ... D..H --not C\n"
@@ -23943,7 +23943,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git for-each-ref' [--count=<count>] [--shell|--perl|--python|--tcl]\n"
 "\t\t   [(--sort=<key>)...] [--format=<format>] [<pattern>...]\n"
@@ -23960,7 +23960,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-for-each-ref.txt:29 en/git-show-ref.txt:88
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<pattern>..."
 msgstr ""
 
@@ -24248,7 +24248,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:197
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Left-, middle-, or right-align the content between %(align:...) and %(end). The \"align:\" is followed by `width=<width>` and `position=<position>` in any order separated by a comma, where the `<position>` is either left, right or middle, default being left and `<width>` is the total length of the content with alignment. For brevity, the \"width=\" and/or \"position=\" prefixes may be omitted, and bare <width> and <position> used instead.  For instance, `%(align:<width>,<position>)`. If the contents length is more than the width then no alignment is performed. If used with `--quote` everything in between %(align:...) and %(end) is quoted, but if nested then only the topmost level performs quoting."
 msgstr ""
 
@@ -24260,7 +24260,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:210
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Used as %(if)...%(then)...%(end) or %(if)...%(then)...%(else)...%(end).  If there is an atom with value or string literal after the %(if) then everything after the %(then) is printed, else if the %(else) atom is used, then everything after %(else) is printed. We ignore space when evaluating the string before %(then), this is useful when we use the %(HEAD) atom which prints either \"*\" or \" \" and we want to apply the 'if' condition only on the 'HEAD' ref.  Append \":equals=<string>\" or \":notequals=<string>\" to compare the value between the %(if:...) and %(then) atoms with the given string."
 msgstr ""
 
@@ -24481,7 +24481,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:361
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "An example to show the usage of %(if)...%(then)...%(else)...%(end).  This prefixes the current branch with a star."
 msgstr ""
 
@@ -24493,7 +24493,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:369
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "An example to show the usage of %(if)...%(then)...%(end).  This prints the authorname, if present."
 msgstr ""
 
@@ -25139,7 +25139,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:372
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "Do the same for ia64 so we can have sleek & trim looking\n"
 "...\n"
@@ -25147,7 +25147,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:380
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Typically it will be placed in a MUA's drafts folder, edited to add timely commentary that should not go in the changelog after the three dashes, and then sent as a message whose body, in our example, starts with \"arch/arm config files were...\".  On the receiving end, readers can save interesting patches in a UNIX mailbox and apply them with linkgit:git-am[1]."
 msgstr ""
 
@@ -25159,7 +25159,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:390
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "...\n"
 "> So we should do such-and-such.\n"
@@ -25181,7 +25181,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:398
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "arch/arm config files were slimmed down using a python script\n"
 "...\n"
@@ -25355,7 +25355,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:499
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Configure your mail server composition as plain text: Edit...Account Settings...Composition & Addressing, uncheck \"Compose Messages in HTML\"."
 msgstr ""
 
@@ -25492,7 +25492,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:573
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Use Message -> Insert file... and insert the patch."
 msgstr ""
 
@@ -25667,7 +25667,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fsck-objects.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git fsck-objects' ...\n"
 msgstr ""
 
@@ -26055,7 +26055,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-gc.txt:55
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Once housekeeping is triggered by exceeding the limits of configuration options such as `gc.auto` and `gc.autoPackLimit`, all other housekeeping tasks (e.g. rerere, working trees, reflog...) will be performed as well."
 msgstr ""
 
@@ -26229,7 +26229,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-grep.txt:32
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git grep' [-a | --text] [-I] [--textconv] [-i | --ignore-case] [-w | --word-regexp]\n"
 "\t   [-v | --invert-match] [-h|-H] [--full-name]\n"
@@ -26837,7 +26837,7 @@ msgstr "--not"
 
 #. type: Labeled list
 #: en/git-grep.txt:284
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "( ... )"
 msgstr ""
 
@@ -26867,7 +26867,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-grep.txt:300
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<tree>..."
 msgstr ""
 
@@ -27185,7 +27185,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-hash-object.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git hash-object' [-t <type>] [-w] [--path=<file>|--no-filters] [--stdin [--literally]] [--] <file>...\n"
 "'git hash-object' [-t <type>] [-w] --stdin-paths [--no-filters]\n"
@@ -27315,7 +27315,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-help.txt:38
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Note that `git --help ...` is identical to `git help ...` because the former is internally converted into the latter."
 msgstr ""
 
@@ -27765,7 +27765,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:102
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tAuthType Basic\n"
 "\tAuthName \"Git Access\"\n"
@@ -27783,7 +27783,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:115
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "<LocationMatch \"^/git/.*/git-receive-pack$\">\n"
 "\tAuthType Basic\n"
@@ -27807,7 +27807,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:136
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "<Location /git/private>\n"
 "\tAuthType Basic\n"
@@ -27957,7 +27957,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:231
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "auth.require = (\n"
 "\t\"/\" => (\n"
@@ -28160,7 +28160,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-http-push.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git http-push' [--all] [--dry-run] [--force] [--verbose] <url> <ref> [<ref>...]\n"
 msgstr ""
 
@@ -28229,7 +28229,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-http-push.txt:54 en/git-send-pack.txt:98
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<ref>..."
 msgstr ""
 
@@ -29095,7 +29095,7 @@ msgstr "Adiciona ou analisa informação estruturada em mensagens de commit."
 
 #. type: Plain text
 #: en/git-interpret-trailers.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git interpret-trailers' [<options>] [(--trailer <token>[(=|:)<value>])...] [<file>...]\n"
 "'git interpret-trailers' [<options>] [--parse] [<file>...]\n"
@@ -29765,7 +29765,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-log.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'git log' [<options>] [<revision range>] [[--] <path>...]\n"
 msgstr ""
 
@@ -29861,7 +29861,7 @@ msgstr "--full-diff"
 
 #. type: Plain text
 #: en/git-log.txt:63
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Without this flag, `git log -p <path>...` shows commits that touch the specified paths, and diffs about the same specified paths.  With this, the full diff is shown for commits that touch the specified paths; this means that \"<path>...\" limits only commits, and doesn't limit diff for those commits."
 msgstr ""
 
@@ -29915,7 +29915,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-log.txt:93 en/git-shortlog.txt:72
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "[--] <path>..."
 msgstr ""
 
@@ -30191,7 +30191,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-files.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-files' [-z] [-t] [-v] [-f]\n"
 "\t\t(--[cached|deleted|others|ignored|stage|unmerged|killed|modified])*\n"
@@ -30672,7 +30672,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-remote.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-remote' [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
 "\t      [-q | --quiet] [--exit-code] [--get-url] [--sort=<key>]\n"
@@ -30777,7 +30777,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-remote.txt:91
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When unspecified, all references, after filtering done with --heads and --tags, are shown.  When <refs>... are specified, only references matching the given patterns are displayed."
 msgstr ""
 
@@ -30822,7 +30822,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-tree' [-d] [-r] [-t] [-l] [-z]\n"
 "\t    [--name-only] [--name-status] [--full-name] [--full-tree] [--abbrev[=<n>]]\n"
@@ -30903,7 +30903,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-ls-tree.txt:76
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<path>...]"
 msgstr ""
 
@@ -31113,7 +31113,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mailsplit.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git mailsplit' [-b] [-f<nn>] [-d<prec>] [--keep-cr] [--mboxrd]\n"
 "\t\t-o<directory> [--] [(<mbox>|<Maildir>)...]\n"
@@ -31235,7 +31235,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git merge-base' [-a|--all] <commit> <commit>...\n"
 "'git merge-base' [-a|--all] --octopus <commit>...\n"
@@ -31432,7 +31432,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:139
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tA=$(git rev-parse --verify A)\n"
 "\tif test \"$A\" = \"$(git merge-base A B)\"\n"
@@ -31449,7 +31449,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:146
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tif git merge-base --is-ancestor A B\n"
 "\tthen\n"
@@ -31936,7 +31936,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mergetool.txt:12
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git mergetool' [--tool=<tool>] [-y | --[no-]prompt] [<file>...]\n"
 msgstr ""
 
@@ -32098,7 +32098,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge.txt:17
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git merge' [-n] [--stat] [--no-commit] [--squash] [--[no-]edit]\n"
 "\t[-s <strategy>] [-X <strategy-option>] [-S[<keyid>]]\n"
@@ -32692,7 +32692,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mv.txt:13
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git mv' <options>... <args>...\n"
 msgstr ""
 
@@ -32704,7 +32704,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mv.txt:20
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 " git mv [-v] [-f] [-n] [-k] <source> <destination>\n"
 " git mv [-v] [-f] [-n] [-k] <source> ... <destination directory>\n"
@@ -32772,7 +32772,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-name-rev.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git name-rev' [--tags] [--refs=<pattern>]\n"
 "\t       ( --all | --stdin | <commit-ish>... )\n"
@@ -32890,7 +32890,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-notes.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git notes' [list [<object>]]\n"
 "'git notes' add [-f] [--allow-empty] [-F <file> | -m <msg> | (-c | -C) <object>] [<object>]\n"
@@ -33226,7 +33226,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-notes.txt:229
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Commit notes are blobs containing extra information about an object (usually information to supplement a commit's message).  These blobs are taken from notes refs.  A notes ref is usually a branch which contains \"files\" whose paths are the object names for the objects they describe, with some directory separators included for performance reasons footnote:[Permitted pathnames have the form 'ab'`/`'cd'`/`'ef'`/`'...'`/`'abcdef...': a sequence of directory names of two hexadecimal digits each followed by a filename with the rest of the object ID.]."
 msgstr ""
 
@@ -33292,7 +33292,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-notes.txt:288
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git notes add -m 'Tested-by: Johannes Sixt <j6t@kdbg.org>' 72a144e2\n"
 "$ git show -s 72a144e\n"
@@ -33511,7 +33511,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-p4.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git p4 clone' [<sync options>] [<clone options>] <p4 depot path>...\n"
 "'git p4 sync' [<sync options>] [<p4 depot path>...]\n"
@@ -34344,7 +34344,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-p4.txt:445
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The full syntax for a p4 view is documented in 'p4 help views'.  'git p4' knows only a subset of the view syntax.  It understands multi-line mappings, overlays with '+', exclusions with '-' and double-quotes around whitespace.  Of the possible wildcards, 'git p4' only handles '...', and only when it is at the end of the path.  'git p4' will complain if it encounters an unhandled wildcard."
 msgstr ""
 
@@ -34386,7 +34386,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-p4.txt:475
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "//depot/main/...\n"
 "//depot/branch1/...\n"
@@ -34400,7 +34400,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-p4.txt:480
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "//depot/main/... //depot/branch1/...\n"
 msgstr ""
 
@@ -35517,7 +35517,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-pack-redundant.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git pack-redundant' [ --verbose ] [ --alt-odb ] < --all | .pack filename ... >\n"
 msgstr ""
 
@@ -35817,7 +35817,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-prune.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git prune' [-n] [-v] [--progress] [--expire <time>] [--] [<head>...]\n"
 msgstr ""
 
@@ -35871,7 +35871,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-prune.txt:54
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<head>..."
 msgstr ""
 
@@ -35925,7 +35925,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-pull.txt:13
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "'git pull' [<options>] [<repository> [<refspec>...]]\n"
 msgstr ""
 
@@ -36273,7 +36273,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:18
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git push' [--all | --mirror | --tags] [--follow-tags] [--atomic] [-n | --dry-run] [--receive-pack=<git-receive-pack>]\n"
 "\t   [--repo=<repository>] [-f | --force] [-d | --delete] [--prune] [-v | --verbose]\n"
@@ -36303,7 +36303,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:39
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "When the command line does not specify what to push with `<refspec>...` arguments or `--all`, `--mirror`, `--tags` options, the command finds the default `<refspec>` by consulting `remote.*.push` configuration, and if it is not found, honors `push.default` configuration to decide what to push (See linkgit:git-config[1] for the meaning of `push.default`)."
 msgstr ""
 
@@ -36327,7 +36327,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:56
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "<refspec>..."
 msgstr ""
 
@@ -36687,7 +36687,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:343
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "Note that `--force` applies to all the refs that are pushed, hence using it with `push.default` set to `matching` or with multiple push destinations configured with `remote.*.push` may overwrite refs other than the current branch (including local refs that are strictly behind their remote counterpart).  To force a push to only one branch, use a `+` in front of the refspec to push (e.g `git push origin +master` to force a push to the `master` branch). See the `<refspec>...` section above for details."
 msgstr ""
 
@@ -36819,7 +36819,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:445
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "For a successfully pushed ref, the summary shows the old and new values of the ref in a form suitable for using as an argument to `git log` (this is `<old>..<new>` in most cases, and `<old>...<new>` for forced non-fast-forward updates)."
 msgstr ""
 
@@ -37080,7 +37080,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:616
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "See the section describing `<refspec>...` above for a discussion of the matching semantics."
 msgstr ""
 
@@ -37781,7 +37781,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-read-tree.txt:357
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git fetch git://.... linus\n"
 "$ LT=`git rev-parse FETCH_HEAD`\n"
@@ -37835,7 +37835,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-read-tree.txt:405
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "'git read-tree' and other merge-based commands ('git merge', 'git checkout'...) can help maintaining the skip-worktree bitmap and working directory update. `$GIT_DIR/info/sparse-checkout` is used to define the skip-worktree reference bitmap. When 'git read-tree' needs to update the working directory, it resets the skip-worktree bit in the index based on this file, which uses the same syntax as .gitignore files.  If an entry matches a pattern in this file, skip-worktree will not be set on that entry. Otherwise, skip-worktree will be set."
 msgstr ""
 
@@ -38215,7 +38215,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:219
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "As a special case, you may use \"A\\...B\" as a shortcut for the merge base of A and B if there is exactly one merge base. You can leave out at most one of A and B, in which case it defaults to HEAD."
 msgstr ""
 
@@ -38479,7 +38479,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:430
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "It is currently only possible to recreate the merge commits using the `recursive` merge strategy; Different merge strategies can be used only via explicit `exec git merge -s <strategy> [...]` commands."
 msgstr ""
 
@@ -38533,7 +38533,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:457
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "\tgit rebase -i --exec \"cmd1 && cmd2 && ...\"\n"
 msgstr ""
 
@@ -38545,7 +38545,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:461
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "\tgit rebase -i --exec \"cmd1\" --exec \"cmd2\" --exec ...\n"
 msgstr ""
 
@@ -38581,7 +38581,7 @@ msgstr "--no-autosquash"
 
 #. type: Plain text
 #: en/git-rebase.txt:495
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When the commit log message begins with \"squash! ...\" (or \"fixup! ...\"), and there is already a commit in the todo list that matches the same `...`, automatically modify the todo list of rebase -i so that the commit marked for squashing comes right after the commit to be modified, and change the action of the moved commit from `pick` to `squash` (or `fixup`).  A commit matches the `...` if the commit subject matches, or if the `...` refers to the commit's hash. As a fall-back, partial matches of the commit subject work, too.  The recommended way to create fixup/squash commits is by using the `--fixup`/`--squash` options of linkgit:git-commit[1]."
 msgstr ""
 
@@ -38908,7 +38908,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:636
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "pick deadbee The oneline of this commit\n"
 "pick fa1afe1 The oneline of the next commit\n"
@@ -39012,7 +39012,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:710
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "pick deadbee Implement feature XXX\n"
 "fixup f1a5c00 Fix to feature XXX\n"
@@ -39031,7 +39031,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:720
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The \"exec\" command launches the command in a shell (the one specified in `$SHELL`, or the default shell if `$SHELL` is not set), so you can use shell features (like \"cd\", \">\", \";\" ...). The command is run from the root of the working tree."
 msgstr ""
 
@@ -39175,7 +39175,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:815
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "    o---o---o---o---o---o---o---o  master\n"
 "\t \\\t\t\t \\\n"
@@ -39973,7 +39973,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reflog.txt:27
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git reflog' ['show'] [log-options] [<ref>]\n"
 "'git reflog expire' [--expire=<time>] [--expire-unreachable=<time>]\n"
@@ -40160,7 +40160,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-remote-ext.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git remote add <nick> \"ext::<command>[ <arguments>...]\"\n"
 msgstr ""
 
@@ -40298,7 +40298,7 @@ msgstr "GIT_EXT_SERVICE"
 
 #. type: Plain text
 #: en/git-remote-ext.txt:70
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Set to long name (git-upload-pack, etc...) of service helper needs to invoke."
 msgstr ""
 
@@ -40310,7 +40310,7 @@ msgstr "GIT_EXT_SERVICE_NOPREFIX"
 
 #. type: Plain text
 #: en/git-remote-ext.txt:74
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Set to long name (upload-pack, etc...) of service helper needs to invoke."
 msgstr ""
 
@@ -40490,7 +40490,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-remote.txt:25
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git remote' [-v | --verbose]\n"
 "'git remote add' [-t <branch>] [-m <master>] [-f] [--[no-]tags] [--mirror=<fetch|push>] <name> <url>\n"
@@ -40809,7 +40809,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-remote.txt:235
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "$ git remote\n"
 "origin\n"
@@ -41053,7 +41053,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-replace.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git replace' [-f] <object> <replacement>\n"
 "'git replace' [-f] --edit <object>\n"
@@ -41173,13 +41173,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-replace.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--graft <commit> [<parent>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/git-replace.txt:93
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Create a graft commit. A new commit is created with the same content as <commit> except that its parents will be [<parent>...] instead of <commit>'s parents. A replacement ref is then created to replace <commit> with the newly created commit. Use `--convert-graft-file` to convert a `$GIT_DIR/info/grafts` file and use replace refs instead."
 msgstr ""
 
@@ -41601,7 +41601,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rerere.txt:121
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git switch topic\n"
 "\t$ git merge master\n"
@@ -41633,7 +41633,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rerere.txt:145
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git switch topic\n"
 "\t$ git merge master\n"
@@ -41738,7 +41738,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reset.txt:14
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git reset' [-q] [<tree-ish>] [--] <paths>...\n"
 "'git reset' (--patch | -p) [<tree-ish>] [--] [<paths>...]\n"
@@ -41753,7 +41753,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-reset.txt:22
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git reset' [-q] [<tree-ish>] [--] <paths>..."
 msgstr ""
 
@@ -41765,7 +41765,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reset.txt:30
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "This means that `git reset <paths>` is the opposite of `git add <paths>`. This command is equivalent to `git restore [--source=<tree-ish>] --staged <paths>...`."
 msgstr ""
 
@@ -41777,7 +41777,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-reset.txt:38
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git reset' (--patch | -p) [<tree-ish>] [--] [<paths>...]"
 msgstr ""
 
@@ -41932,7 +41932,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:138
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git commit ...\n"
 "$ git reset --soft HEAD^      <1>\n"
@@ -42012,7 +42012,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:170
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git commit ...\n"
 "$ git reset --hard HEAD~3   <1>\n"
@@ -42032,7 +42032,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:190
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git pull                         <1>\n"
 "Auto-merging nitfol\n"
@@ -42077,7 +42077,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:215
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git pull                         <1>\n"
 "Auto-merging nitfol\n"
@@ -42203,7 +42203,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:289
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git tag start\n"
 "$ git switch -c branch1\n"
@@ -42246,7 +42246,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:317
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git reset -N HEAD^                        <1>\n"
 "$ git add -p                                <2>\n"
@@ -42473,7 +42473,7 @@ msgstr "Move branches ou restaura arquivos de árvores de trabalho."
 
 #. type: Plain text
 #: en/git-restore.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git restore' [<options>] [--source=<tree>] [--staged] [--worktree] <pathspec>...\n"
 "'git restore' (-p|--patch) [<options>] [--source=<tree>] [--staged] [--worktree] [<pathspec>...]\n"
@@ -42750,7 +42750,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-revert.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git revert' [--[no-]edit] [-n] [-m parent-number] [-s] [-S[<keyid>]] <commit>...\n"
 "'git revert' (--continue | --skip | --abort | --quit)\n"
@@ -42854,7 +42854,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-list.txt:65
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git rev-list' [ --max-count=<number> ]\n"
 "\t     [ --skip=<number> ]\n"
@@ -42957,13 +42957,13 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-list.txt:102
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Another special notation is \"'<commit1>'...'<commit2>'\" which is useful for merges.  The resulting set of commits is the symmetric difference between the two operands.  The following two commands are equivalent:"
 msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-list.txt:106
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git rev-list A B --not $(git merge-base --all A B)\n"
 "\t$ git rev-list A...B\n"
@@ -42989,7 +42989,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-parse.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git rev-parse' [<options>] <args>...\n"
 msgstr ""
 
@@ -43473,7 +43473,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-parse.txt:253
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Resolve \"$GIT_DIR/<path>\" and takes other path relocation variables such as $GIT_OBJECT_DIRECTORY, $GIT_INDEX_FILE... into account. For example, if $GIT_OBJECT_DIRECTORY is set to /foo/bar then \"git rev-parse --git-path objects/abc\" returns /foo/bar/abc."
 msgstr ""
 
@@ -43581,7 +43581,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:290
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<args>..."
 msgstr ""
 
@@ -43713,7 +43713,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:364
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "OPTS_SPEC=\"\\\n"
 "some-command [<options>] <args>...\n"
@@ -43771,7 +43771,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:389
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "usage: some-command [<options>] <args>...\n"
 msgstr ""
 
@@ -43783,7 +43783,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:397
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "    -h, --help            show the help\n"
 "    --foo                 some nifty option --foo\n"
@@ -43794,7 +43794,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:400
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "An option group Header\n"
 "    -C[...]               option C with an optional argument\n"
@@ -43899,7 +43899,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rm.txt:12
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git rm' [-f | --force] [-n] [-r] [--cached] [--ignore-unmatch] [--quiet] [--] <file>...\n"
 msgstr ""
 
@@ -44127,7 +44127,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-email.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git send-email' [<options>] <file|directory|rev-list options>...\n"
 "'git send-email' --dump-aliases\n"
@@ -44195,7 +44195,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:53
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--bcc=<address>,..."
 msgstr ""
 
@@ -44213,7 +44213,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:59
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--cc=<address>,..."
 msgstr ""
 
@@ -44297,7 +44297,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-email.txt:110
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "  [PATCH 0/2] Here is what I did...\n"
 "    [PATCH 1/2] Clean up and tests\n"
@@ -44328,7 +44328,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:119
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--to=<address>,..."
 msgstr ""
 
@@ -44460,7 +44460,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-send-email.txt:188
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "$ git send-email --smtp-auth=\"PLAIN LOGIN GSSAPI\" ...\n"
 msgstr ""
 
@@ -45156,7 +45156,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-pack.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git send-pack' [--all] [--dry-run] [--force] [--receive-pack=<git-receive-pack>]\n"
 "\t\t[--verbose] [--thin] [--atomic]\n"
@@ -45529,7 +45529,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-shortlog.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "'git shortlog' [<options>] [<revision range>] [[--] <path>...]\n"
 "git log --pretty=short | 'git shortlog' [<options>]\n"
@@ -45657,7 +45657,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show-branch.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git show-branch' [-a|--all] [-r|--remotes] [--topo-order | --date-order]\n"
 "\t\t[--current] [--color[=<when>] | --no-color] [--sparse]\n"
@@ -46018,7 +46018,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show-ref.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git show-ref' [-q|--quiet] [--verify] [--head] [-d|--dereference]\n"
 "\t     [-s|--hash[=<n>]] [--abbrev[=<n>]] [--tags]\n"
@@ -46166,7 +46166,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-show-ref.txt:111
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git show-ref --head --dereference\n"
 "832e76a9899f560a90ffd62ae2ce83bbeff58f54 HEAD\n"
@@ -46187,7 +46187,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-show-ref.txt:121
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git show-ref --heads --hash\n"
 "2e3ba0114a1f52b47df29743d6915d056be13278\n"
@@ -46308,7 +46308,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'git show' [<options>] [<object>...]\n"
 msgstr ""
 
@@ -46356,7 +46356,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-show.txt:37
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "<object>..."
 msgstr ""
 
@@ -46614,7 +46614,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stage.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git stage' args...\n"
 msgstr ""
 
@@ -46638,7 +46638,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stash.txt:22
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git stash' list [<options>]\n"
 "'git stash' show [<options>] [<stash>]\n"
@@ -46661,7 +46661,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stash.txt:38
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "The modifications stashed away by this command can be listed with `git stash list`, inspected with `git stash show`, and restored (potentially on top of a different commit) with `git stash apply`.  Calling `git stash` without any arguments is equivalent to `git stash push`.  A stash is by default listed as \"WIP on 'branchname' ...\", but you can give a more descriptive message on the command line when you create one."
 msgstr ""
 
@@ -46673,7 +46673,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-stash.txt:49
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "push [-p|--patch] [-k|--[no-]keep-index] [-u|--include-untracked] [-a|--all] [-q|--quiet] [-m|--message <message>] [--] [<pathspec>...]"
 msgstr ""
 
@@ -46745,7 +46745,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:104
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "stash@{0}: WIP on submit: 6ebd0e2... Update git-stash documentation\n"
 "stash@{1}: On master: 9cc0589... Add git-stash\n"
@@ -46918,7 +46918,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:227
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git pull\n"
 " ...\n"
@@ -46936,7 +46936,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:246
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git switch -c my_wip\n"
@@ -46957,7 +46957,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:257
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git stash\n"
@@ -46981,7 +46981,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:275
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git add --patch foo            # add just first part to the index\n"
@@ -47035,7 +47035,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-status.txt:13
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git status' [<options>...] [--] [<pathspec>...]\n"
 msgstr ""
 
@@ -47512,7 +47512,7 @@ msgstr ""
 
 #. type: delimited block .
 #: en/git-status.txt:345
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "Field       Meaning\n"
 "--------------------------------------------------------\n"
@@ -47833,7 +47833,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-submodule.txt:23
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git submodule' [--quiet] [--cached]\n"
 "'git submodule' [--quiet] add [<options>] [--] <repository> [<path>]\n"
@@ -47904,7 +47904,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:74
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "status [--cached] [--recursive] [--] [<path>...]"
 msgstr ""
 
@@ -47928,7 +47928,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:91
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "init [--] [<path>...]"
 msgstr ""
 
@@ -47958,7 +47958,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:114
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "deinit [-f|--force] (--all|[--] <path>...)"
 msgstr ""
 
@@ -47988,7 +47988,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:132
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "update [--init] [--remote] [-N|--no-fetch] [--[no-]recommend-shallow] [-f|--force] [--checkout|--rebase|--merge] [--reference <repository>] [--depth <depth>] [--recursive] [--jobs <n>] [--] [<path>...]"
 msgstr ""
 
@@ -48112,7 +48112,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:182
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "summary [--cached|--files] [(-n|--summary-limit) <n>] [commit] [--] [<path>...]"
 msgstr ""
 
@@ -48154,7 +48154,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:224
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "sync [--recursive] [--] [<path>...]"
 msgstr ""
 
@@ -48680,7 +48680,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:127
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Fetch unfetched revisions from the Subversion remote we are tracking.  The name of the [svn-remote \"...\"] section in the $GIT_DIR/config file may be specified as an optional command-line argument."
 msgstr ""
 
@@ -49126,7 +49126,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:366
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "is supported, non-numeric args are not: HEAD, NEXT, BASE, PREV, etc ..."
 msgstr ""
 
@@ -50027,7 +50027,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-svn.txt:876
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "# Clone a repo (like git clone):\n"
 "\tgit svn clone http://svn.example.com/project/trunk\n"
@@ -50080,7 +50080,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-svn.txt:924
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "# Do the initial import on a server\n"
 "\tssh server \"cd /pub && git svn clone http://svn.example.com/project [options...]\"\n"
@@ -50830,7 +50830,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-tag.txt:20
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git tag' [-a | -s | -u <keyid>] [-f] [-m <msg> | -F <file>] [-e]\n"
 "\t<tagname> [<commit> | <object>]\n"
@@ -50976,7 +50976,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-tag.txt:103
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "List tags. With optional `<pattern>...`, e.g. `git tag --list 'v-*'`, list only the tags that match the pattern(s)."
 msgstr ""
 
@@ -51266,13 +51266,13 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:319
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "\tgit://git..../proj.git master\n"
 msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:321
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "to get the following updates...\n"
 msgstr ""
 
@@ -51284,7 +51284,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:327
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "$ git pull git://git..../proj.git master\n"
 msgstr ""
 
@@ -51404,7 +51404,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git.txt:55
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Other options are available to control how the manual page is displayed. See linkgit:git-help[1] for more information, because `git --help ...` is converted internally into `git help ...`."
 msgstr ""
 
@@ -51448,7 +51448,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git.txt:82
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Note that omitting the `=` in `git -c foo.bar ...` is allowed and sets `foo.bar` to the boolean true value (just like `[foo]bar` would in a config file). Including the equals but with an empty value (like `git -c foo.bar= ...`) sets `foo.bar` to the empty string which `git config --type=bool` will convert to `false`."
 msgstr ""
 
@@ -51652,7 +51652,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:169
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--list-cmds=group[,group...]"
 msgstr ""
 
@@ -52155,7 +52155,7 @@ msgstr "`GIT_COMMON_DIR`"
 
 #. type: Plain text
 #: en/git.txt:481
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If this variable is set to a path, non-worktree files that are normally in $GIT_DIR will be taken from this path instead. Worktree-specific files such as HEAD or index are taken from $GIT_DIR. See linkgit:gitrepository-layout[5] and linkgit:git-worktree[1] for details. This variable has lower precedence than other path variables such as GIT_INDEX_FILE, GIT_OBJECT_DIRECTORY..."
 msgstr ""
 
@@ -52626,10 +52626,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:685
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2`"
-msgstr "`GIT_TRACE`"
+msgstr "`GIT_TRACE2`"
 
 #. type: Plain text
 #: en/git.txt:689
@@ -52657,10 +52656,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:720
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE_SETUP`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2_EVENT`"
-msgstr "`GIT_TRACE_SETUP`"
+msgstr "`GIT_TRACE2_EVENT`"
 
 #. type: Plain text
 #: en/git.txt:725
@@ -52670,10 +52668,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:726
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE_PERFORMANCE`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2_PERF`"
-msgstr "`GIT_TRACE_PERFORMANCE`"
+msgstr "`GIT_TRACE2_PERF`"
 
 #. type: Plain text
 #: en/git.txt:732
@@ -53112,7 +53109,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-update-index.txt:29
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git update-index'\n"
 "\t     [--add] [--remove | --force-remove] [--replace]\n"
@@ -53672,7 +53669,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-update-index.txt:348
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The command looks at `core.ignorestat` configuration variable.  When this is true, paths updated with `git update-index paths...` and paths updated with other Git commands that update both index and working tree (e.g. 'git apply --index', 'git checkout-index -u', and 'git read-tree -u') are automatically marked as \"assume unchanged\".  Note that \"assume unchanged\" bit is *not* set if `git update-index --refresh` finds the working tree file matches the index (use `git update-index --really-refresh` if you want to mark them as \"assume unchanged\")."
 msgstr ""
 
@@ -54541,7 +54538,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-commit.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-commit' <commit>...\n"
 msgstr ""
 
@@ -54583,7 +54580,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-pack.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-pack' [-v|--verbose] [-s|--stat-only] [--] <pack>.idx ...\n"
 msgstr ""
 
@@ -54595,7 +54592,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-verify-pack.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<pack>.idx ..."
 msgstr ""
 
@@ -54673,7 +54670,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-tag.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-tag' [--format=<format>] <tag>...\n"
 msgstr ""
 
@@ -54691,7 +54688,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-verify-tag.txt:27
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<tag>..."
 msgstr ""
 
@@ -54715,7 +54712,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-web--browse.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git web{litdd}browse' [<options>] <url|file>...\n"
 msgstr ""
 
@@ -54989,7 +54986,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-whatchanged.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git whatchanged' <option>...\n"
 msgstr ""
 
@@ -55519,7 +55516,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-worktree.txt:372
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git worktree add -b emergency-fix ../temp master\n"
 "$ pushd ../temp\n"
@@ -56722,7 +56719,7 @@ msgstr "cor"
 
 #. type: Labeled list
 #: en/pretty-formats.txt:115
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'%C(...)'"
 msgstr ""
 
@@ -56734,7 +56731,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/pretty-formats.txt:129
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "\"CONFIGURATION FILE\" section of linkgit:git-config[1].  By default, colors are shown only when enabled for log output (by `color.diff`, `color.ui`, or `--color`, and respecting the `auto` settings of the former if we are going to a terminal). `%C(auto,...)` is accepted as a historical synonym for the default (e.g., `%C(auto,red)`). Specifying `%C(always,...)` will show the colors even when color is not otherwise enabled (though consider just using `--color=always` to enable color for the whole output, including this format and anything else git might color).  `auto` alone (i.e. `%C(auto)`) will turn on auto coloring on the next placeholders until the color is switched again."
 msgstr ""
 
@@ -57827,7 +57824,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/pull-fetch-param.txt:45
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "Whether that update is allowed without `--force` depends on the ref namespace it's being fetched to, the type of object being fetched, and whether the update is considered to be a fast-forward. Generally, the same rules apply for fetching as when pushing, see the `<refspec>...` section of linkgit:git-push[1] for what those are. Exceptions to those rules particular to 'git fetch' are noted below."
 msgstr ""
 
@@ -58298,13 +58295,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/revisions.txt:280
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "The '...' (three-dot) Symmetric Difference Notation"
 msgstr ""
 
 #. type: Plain text
 #: en/revisions.txt:286
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "A similar notation 'r1\\...r2' is called symmetric difference of 'r1' and 'r2' and is defined as 'r1 r2 --not $(git merge-base --all r1 r2)'.  It is the set of commits that are reachable from either one of 'r1' (left side) or 'r2' (right side) but not from both."
 msgstr ""
 
@@ -58394,7 +58391,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/revisions.txt:331
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'<rev1>\\...<rev2>'"
 msgstr ""
 
@@ -58448,7 +58445,7 @@ msgstr ""
 
 #. type: delimited block .
 #: en/revisions.txt:377
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "   Args   Expanded arguments    Selected commits\n"
 "   D                            G H D\n"
@@ -58938,7 +58935,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:256
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "For example, `--cherry-pick --right-only A...B` omits those commits from `B` which are in `A` or are patch-equivalent to a commit in `A`. In other words, this lists the `+` commits from `git cherry A B`.  More precisely, `--cherry-pick --right-only --no-merges` gives the exact list."
 msgstr ""
 
@@ -58950,7 +58947,7 @@ msgstr "--cherry"
 
 #. type: Plain text
 #: en/rev-list-options.txt:263
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "A synonym for `--right-only --cherry-mark --no-merges`; useful to limit the output to the commits on our side and mark those that have been applied to the other side of a forked history with `git log --cherry upstream...mybranch`, similar to `git cherry upstream mybranch`."
 msgstr ""
 
@@ -58962,7 +58959,7 @@ msgstr "--walk-reflogs"
 
 #. type: Plain text
 #: en/rev-list-options.txt:271
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Instead of walking the commit ancestry chain, walk reflog entries from the most recent one to older ones.  When this option is used you cannot specify commits to exclude (that is, '{caret}commit', 'commit1..commit2', and 'commit1\\...commit2' notations cannot be used)."
 msgstr ""
 
@@ -59955,7 +59952,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:875
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "`--date=format:...` feeds the format `...` to your system `strftime`, except for %z and %Z, which are handled internally.  Use `--date=format:%c` to show the date in your system locale's preferred format.  See the `strftime` manual for a complete list of format placeholders. When using `-local`, the correct syntax is `--date=format-local:...`."
 msgstr ""
 
@@ -59991,7 +59988,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:892
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Print also the parents of the commit (in the form \"commit parent...\").  Also enables parent rewriting, see 'History Simplification' above."
 msgstr ""
 
@@ -60003,7 +60000,7 @@ msgstr "--children"
 
 #. type: Plain text
 #: en/rev-list-options.txt:896
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Print also the children of the commit (in the form \"commit child...\").  Also enables parent rewriting, see 'History Simplification' above."
 msgstr ""
 
@@ -60056,13 +60053,13 @@ msgstr ""
 
 #. type: delimited block -
 #: en/rev-list-options.txt:922
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "\t$ git rev-list --left-right --boundary --pretty=oneline A...B\n"
 msgstr ""
 
 #. type: delimited block -
 #: en/rev-list-options.txt:929
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "\t>bbbbbbb... 3rd on b\n"
 "\t>bbbbbbb... 2nd on b\n"

--- a/po/documentation.pt_PT.po
+++ b/po/documentation.pt_PT.po
@@ -2432,7 +2432,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/config.txt:256
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The value for many variables that specify various sizes can be suffixed with `k`, `M`,... to mean \"scale the number by 1024\", \"by 1024x1024\", etc."
 msgstr ""
 
@@ -2822,7 +2822,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-format.txt:16
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "git-diff-tree [-r] <tree-ish-1> <tree-ish-2> [<pattern>...]"
 msgstr ""
 
@@ -2834,7 +2834,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-format.txt:19
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "git-diff-files [<pattern>...]"
 msgstr ""
 
@@ -3514,7 +3514,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/diff-generate-patch.txt:179
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Unlike the traditional 'unified' diff format, which shows two files A and B with a single column that has `-` (minus -- appears in A but removed in B), `+` (plus -- missing in A but added to B), or `\" \"` (space -- unchanged) prefix, this format compares two or more files file1, file2,... with one file X, and shows how X differs from each of fileN.  One column for each of fileN is prepended to the output line to note how X's line is different from it."
 msgstr ""
 
@@ -3837,7 +3837,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:137
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Generate a diffstat. By default, as much space as necessary will be used for the filename part, and the rest for the graph part. Maximum width defaults to terminal width, or 80 columns if not connected to a terminal, and can be overridden by `<width>`. The width of the filename part can be limited by giving another width `<name-width>` after a comma. The width of the graph part can be limited by using `--stat-graph-width=<width>` (affects all commands generating a stat graph) or by setting `diff.statGraphWidth=<width>` (does not affect `git format-patch`).  By giving a third parameter `<count>`, you can limit the output to the first `<count>` lines, followed by `...` if there are more."
 msgstr ""
 
@@ -3885,13 +3885,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:161
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "-X[<param1,param2,...>]"
 msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:162
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--dirstat[=<param1,param2,...>]"
 msgstr ""
 
@@ -3981,13 +3981,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:209
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--dirstat-by-file[=<param1,param2>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:211
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Synonym for --dirstat=files,param1,param2..."
 msgstr ""
 
@@ -4648,13 +4648,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:527
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--diff-filter=[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:538
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Select only files that are Added (`A`), Copied (`C`), Deleted (`D`), Modified (`M`), Renamed (`R`), have their type (i.e. regular file, symlink, submodule, ...) changed (`T`), are Unmerged (`U`), are Unknown (`X`), or have had their pairing Broken (`B`).  Any combination of the filter characters (including none) can be used.  When `*` (All-or-none) is added to the combination, all paths are selected if there is any file that matches other criteria in the comparison; if there is no file that matches other criteria, nothing is selected."
 msgstr ""
 
@@ -4714,7 +4714,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/diff-options.txt:573
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "+    return !regexec(regexp, two->ptr, 1, &regmatch, 0);\n"
 "...\n"
@@ -5637,7 +5637,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-add.txt:15
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "'git add' [--verbose | -v] [--dry-run | -n] [--force | -f] [--interactive | -i] [--patch | -p]\n"
 "\t  [--edit | -e] [--[no-]all | --[no-]ignore-removal | [--update | -u]]\n"
@@ -5695,7 +5695,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-add.txt:52 en/git-grep.txt:308 en/git-status.txt:148
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid "<pathspec>..."
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-add.txt:145
-#, priority:300
+#, ignore-ellipsis, priority:300
 msgid "This option is primarily to help users who are used to older versions of Git, whose \"git add <pathspec>...\" was a synonym for \"git add --no-all <pathspec>...\", i.e. ignored removed files."
 msgstr ""
 
@@ -6337,7 +6337,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-am.txt:20
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git am' [--signoff] [--keep] [--[no-]keep-cr] [--[no-]utf8]\n"
 "\t [--[no-]3way] [--interactive] [--committer-date-is-author-date]\n"
@@ -6357,7 +6357,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-am.txt:29
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "(<mbox>|<Maildir>)..."
 msgstr ""
 
@@ -6893,7 +6893,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-apply.txt:20
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git apply' [--stat] [--numstat] [--summary] [--check] [--index | --intent-to-add] [--3way]\n"
 "\t  [--apply] [--no-add] [--build-fake-ancestor=<file>] [-R | --reverse]\n"
@@ -6919,7 +6919,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-apply.txt:37
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<patch>..."
 msgstr ""
 
@@ -7333,7 +7333,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-archimport.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git archimport' [-h] [-v] [-o] [-a] [-f] [-T] [-D depth] [-t tempdir]\n"
 "               <archive/branch>[:<git-branch>] ...\n"
@@ -7497,7 +7497,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-archive.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git archive' [--format=<fmt>] [--list] [--prefix=<prefix>/] [<extra>]\n"
 "\t      [-o <file> | --output=<file>] [--worktree-attributes]\n"
@@ -7885,7 +7885,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bisect.txt:31
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 " git bisect start [--term-{old,good}=<term> --term-{new,bad}=<term>]\n"
 "\t\t  [--no-checkout] [<bad> [<good>...]] [--] [<paths>...]\n"
@@ -8080,7 +8080,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-bisect.txt:158
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git bisect new [<rev>...]\n"
 msgstr ""
 
@@ -8110,7 +8110,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bisect.txt:175
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If you would like to use your own terms instead of \"bad\"/\"good\" or \"new\"/\"old\", you can choose any names you like (except existing bisect subcommands like `reset`, `start`, ...) by starting the bisection using"
 msgstr ""
 
@@ -8550,7 +8550,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-bisect.txt:463
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git bisect start HEAD <known-good-commit> [ <boundary-commit> ... ] --no-checkout\n"
 "$ git bisect run sh -c '\n"
@@ -9018,7 +9018,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:26
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git branch' [--color[=<when>] | --no-color] [--show-current]\n"
 "\t[-v [--abbrev=<length> | --no-abbrev]]\n"
@@ -9063,7 +9063,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:61
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "The command's second form creates a new branch head named <branchname> which points to the current `HEAD`, or <start-point> if given. As a special case, for <start-point>, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -9261,7 +9261,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:176
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "List branches.  With optional `<pattern>...`, e.g. `git branch --list 'maint-*'`, list only the branches that match the pattern(s)."
 msgstr ""
 
@@ -9507,7 +9507,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:291
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "Sort based on the key given. Prefix `-` to sort in descending order of the value. You may use the --sort=<key> option multiple times, in which case the last key becomes the primary key. The keys supported are the same as those in `git for-each-ref`. Sort order defaults to the value configured for the `branch.sort` variable if exists, or to sorting based on the full refname (including `refs/...` prefix). This lists detached HEAD (if present) first, then local branches and finally remote-tracking branches. See linkgit:git-config[1]."
 msgstr ""
 
@@ -9549,7 +9549,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-branch.txt:317
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git clone git://git.kernel.org/pub/scm/.../linux-2.6 my2.6\n"
 "$ cd my2.6\n"
@@ -9571,7 +9571,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-branch.txt:329
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git clone git://git.kernel.org/.../git.git my.git\n"
 "$ cd my.git\n"
@@ -9685,7 +9685,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bundle.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git bundle' create <file> <git-rev-list-args>\n"
 "'git bundle' verify <file>\n"
@@ -9761,7 +9761,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-bundle.txt:71
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<refname>...]"
 msgstr ""
 
@@ -10537,7 +10537,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-attr.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git check-attr' [-a | --all | <attr>...] [--] <pathname>...\n"
 "'git check-attr' --stdin [-z] [-a | --all | <attr>...]\n"
@@ -10778,7 +10778,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-ignore.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git check-ignore' [<options>] <pathname>...\n"
 "'git check-ignore' [<options>] --stdin\n"
@@ -10954,7 +10954,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-mailmap.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git check-mailmap' [<options>] <contact>...\n"
 msgstr ""
 
@@ -10990,7 +10990,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout-index.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git checkout-index' [-u] [-q] [-a] [-f] [-n] [--prefix=<string>]\n"
 "\t\t   [--stage=<number>|all]\n"
@@ -11265,7 +11265,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:18
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git checkout' [-q] [-f] [-m] [<branch>]\n"
 "'git checkout' [-q] [-f] [-m] --detach [<branch>]\n"
@@ -11376,7 +11376,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-checkout.txt:82
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git checkout' [<tree-ish>] [--] <pathspec>..."
 msgstr ""
 
@@ -11394,7 +11394,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-checkout.txt:98
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git checkout' (-p|--patch) [<tree-ish>] [--] [<pathspec>...]"
 msgstr ""
 
@@ -11736,7 +11736,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:326 en/git-switch.txt:58
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "As a special case, you may use `A...B` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -11766,7 +11766,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:337
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "As a special case, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -12337,7 +12337,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git cherry-pick' [--edit] [-n] [-m parent-number] [-s] [-x] [--ff]\n"
 "\t\t  [-S[<keyid>]] <commit>...\n"
@@ -12394,13 +12394,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-cherry-pick.txt:43 en/git-merge.txt:116 en/git-revert.txt:36 en/git-verify-commit.txt:27
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "<commit>..."
 msgstr ""
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:52
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Commits to cherry-pick.  For a more complete list of ways to spell commits, see linkgit:gitrevisions[7].  Sets of commits can be passed but no traversal is done by default, as if the `--no-walk` option was specified, see linkgit:git-rev-list[1]. Note that specifying a range will feed all <commit>... arguments to a single revision walk (see a later example that uses 'maint master..next')."
 msgstr ""
 
@@ -12430,7 +12430,7 @@ msgstr "-x"
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:78
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When recording the commit, append a line that says \"(cherry picked from commit ...)\" to the original commit message in order to indicate which commit this change was cherry-picked from.  This is done only for cherry picks without conflicts.  Do not use this option if you are cherry-picking from your private branch because the information is useless to the recipient.  If on the other hand you are cherry-picking between two publicly visible branches (e.g. backporting a fix to a maintenance branch for an older release from a development branch), adding this information can be useful."
 msgstr ""
 
@@ -12788,7 +12788,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:58
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git checkout -b topic origin/master\n"
 "# work and create some commits\n"
@@ -12824,7 +12824,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git log --graph --oneline --decorate --boundary origin/master...topic\n"
 "* 7654321 (origin/master) upstream tip commit\n"
@@ -12847,7 +12847,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:96
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git cherry origin/master topic\n"
 "- cccc000... commit C\n"
@@ -12875,7 +12875,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:126
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git log --graph --oneline --decorate --boundary origin/master...topic\n"
 "* 7654321 (origin/master) upstream tip commit\n"
@@ -12901,7 +12901,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:136
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git cherry origin/master topic base\n"
 "- cccc000... commit C\n"
@@ -12953,7 +12953,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-clean.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git clean' [-d] [-f] [-i] [-n] [-q] [-e <pattern>] [-x | -X] [--] <path>...\n"
 msgstr ""
 
@@ -12971,7 +12971,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-clean.txt:25
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If any optional `<path>...` arguments are given, only those paths are affected."
 msgstr ""
 
@@ -13582,7 +13582,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-clone.txt:306
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "$ git clone git://git.kernel.org/pub/scm/.../linux.git my-linux\n"
 "$ cd my-linux\n"
@@ -13612,7 +13612,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-clone.txt:325
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "$ git clone --reference /git/linux.git \\\n"
 "\tgit://git.kernel.org/pub/scm/.../linux.git \\\n"
@@ -13805,7 +13805,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-commit-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git commit-tree' <tree> [(-p <parent>)...]\n"
 "'git commit-tree' [(-p <parent>)...] [-S[<keyid>]] [(-m <message>)...]\n"
@@ -14006,7 +14006,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-commit.txt:17
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git commit' [-a | --interactive | --patch] [-s] [-v] [-u<mode>] [--amend]\n"
 "\t   [--dry-run] [(-c | -C | --fixup | --squash) <commit>]\n"
@@ -14426,7 +14426,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-commit.txt:248
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "\t$ git reset --soft HEAD^\n"
 "\t$ ... do something else to come up with the right tree ...\n"
@@ -14591,7 +14591,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-commit.txt:346 en/git-rm.txt:29
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "<file>..."
 msgstr ""
 
@@ -15568,7 +15568,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-config.txt:428
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "However, if you really only want to replace the line for the default proxy, i.e. the one without a \"for ...\" postfix, do something like this:"
 msgstr ""
 
@@ -16926,7 +16926,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-cvsserver.txt:26
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git-cvsserver' [<options>] [pserver|server] [<directory> ...]\n"
 msgstr ""
 
@@ -17624,7 +17624,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-daemon.txt:25
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git daemon' [--verbose] [--syslog] [--export-all]\n"
 "\t     [--timeout=<n>] [--init-timeout=<n>] [--max-connections=<n>]\n"
@@ -18190,7 +18190,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-describe.txt:14
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "'git describe' [--all] [--tags] [--contains] [--abbrev=<n>] [<commit-ish>...]\n"
 "'git describe' [--all] [--tags] [--contains] [--abbrev=<n>] --dirty[=<mark>]\n"
@@ -18217,7 +18217,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-describe.txt:37
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "<commit-ish>..."
 msgstr ""
 
@@ -18313,7 +18313,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-describe.txt:95
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Always output the long format (the tag, the number of commits and the abbreviated commit name) even when it matches a tag.  This is useful when you want to see parts of the commit object name in \"describe\" output, even when the commit in question happens to be a tagged version.  Instead of just emitting the tag name, it will describe such a commit as v1.2-0-gdeadbee (0th commit since tag v1.2 that points at object deadbee....)."
 msgstr ""
 
@@ -18491,7 +18491,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-files.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git diff-files' [-q] [-0|-1|-2|-3|-c|--cc] [<common diff options>] [<path>...]\n"
 msgstr ""
 
@@ -18563,7 +18563,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-index.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git diff-index' [-m] [--cached] [<common diff options>] <tree-ish> [<path>...]\n"
 msgstr ""
 
@@ -18702,7 +18702,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-index.txt:102
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "  torvalds@ppc970:~/v2.6/linux> git diff-index --abbrev HEAD\n"
 "  :100644 100664 7476bb... 000000...      kernel/sched.c\n"
@@ -18740,7 +18740,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-difftool.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git difftool' [<options>] [<commit> [<commit>]] [--] [<path>...]\n"
 msgstr ""
 
@@ -19052,7 +19052,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git diff-tree' [--stdin] [-m] [-s] [-v] [--no-commit-id] [--pretty]\n"
 "\t      [-t] [-r] [-c | --cc] [--combined-all-paths] [--root]\n"
@@ -19085,7 +19085,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff-tree.txt:32 en/git-diff.txt:114 en/git-submodule.txt:422
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "<path>..."
 msgstr ""
 
@@ -19211,7 +19211,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:17
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git diff' [<options>] [<commit>] [--] [<path>...]\n"
 "'git diff' [<options>] --cached [<commit>] [--] [<path>...]\n"
@@ -19228,7 +19228,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:24
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] [--] [<path>...]"
 msgstr ""
 
@@ -19252,7 +19252,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:41
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] --cached [<commit>] [--] [<path>...]"
 msgstr ""
 
@@ -19264,7 +19264,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:51
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit> [--] [<path>...]"
 msgstr ""
 
@@ -19276,7 +19276,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:59
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit> <commit> [--] [<path>...]"
 msgstr ""
 
@@ -19288,7 +19288,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:64
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit>..<commit> [--] [<path>...]"
 msgstr ""
 
@@ -19300,13 +19300,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:70
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit>\\...<commit> [--] [<path>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:77
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "This form is to view the changes on the branch containing and up to the second <commit>, starting at a common ancestor of both <commit>.  \"git diff A\\...B\" is equivalent to \"git diff $(git merge-base A B) B\".  You can omit any one of <commit>, which has the same effect as using HEAD instead."
 msgstr ""
 
@@ -19318,7 +19318,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:89
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "For a more complete list of ways to spell <commit>, see \"SPECIFYING REVISIONS\" section in linkgit:gitrevisions[7].  However, \"diff\" is about comparing two _endpoints_, not ranges, and the range notations (\"<commit>..<commit>\" and \"<commit>\\...<commit>\") do not mean a range as defined in the \"SPECIFYING RANGES\" section in linkgit:gitrevisions[7]."
 msgstr ""
 
@@ -19426,7 +19426,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-diff.txt:160
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git diff topic master    <1>\n"
 "$ git diff topic..master   <2>\n"
@@ -19746,7 +19746,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:143
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<git-rev-list-args>...]"
 msgstr ""
 
@@ -19827,7 +19827,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-fast-export.txt:215
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git init anon-repo\n"
 "$ cd anon-repo\n"
@@ -22137,7 +22137,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch-pack.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git fetch-pack' [--all] [--quiet|-q] [--keep|-k] [--thin] [--include-tag]\n"
 "\t[--upload-pack=<git-upload-pack>]\n"
@@ -22291,7 +22291,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fetch-pack.txt:117 en/git-ls-remote.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<refs>..."
 msgstr ""
 
@@ -22321,7 +22321,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch.txt:16
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git fetch' [<options>] [<repository> [<refspec>...]]\n"
 "'git fetch' [<options>] <group>\n"
@@ -22662,7 +22662,7 @@ msgstr "--summary"
 
 #. type: Plain text
 #: en/git-fetch.txt:226
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "For a successfully fetched ref, the summary shows the old and new values of the ref in a form suitable for using as an argument to `git log` (this is `<old>..<new>` in most cases, and `<old>...<new>` for forced non-fast-forward updates)."
 msgstr ""
 
@@ -22784,7 +22784,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:18
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git filter-branch' [--setup <command>] [--subdirectory-filter <directory>]\n"
 "\t[--env-filter <command>] [--tree-filter <command>]\n"
@@ -22923,7 +22923,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:117
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for rewriting the index.  It is similar to the tree filter but does not check out the tree, which makes it much faster.  Frequently used with `git rm --cached --ignore-unmatch ...`, see EXAMPLES below.  For hairy cases, see linkgit:git-update-index[1]."
 msgstr ""
 
@@ -22935,7 +22935,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:125
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for rewriting the commit's parent list.  It will receive the parent string on stdin and shall output the new parent string on stdout.  The parent string is in the format described in linkgit:git-commit-tree[1]: empty for the initial commit, \"-p parent\" for a normal commit and \"-p parent1 -p parent2 -p parent3 ...\" for a merge commit."
 msgstr ""
 
@@ -22959,7 +22959,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:138
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for performing the commit.  If this filter is specified, it will be called instead of the 'git commit-tree' command, with arguments of the form \"<TREE_ID> [(-p <PARENT_COMMIT_ID>)...]\" and the log message on stdin.  The commit id is expected on stdout."
 msgstr ""
 
@@ -23061,7 +23061,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-filter-branch.txt:207
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<rev-list options>..."
 msgstr ""
 
@@ -23322,7 +23322,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-filter-branch.txt:388
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git filter-branch ... C..H\n"
 msgstr ""
 
@@ -23334,7 +23334,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-filter-branch.txt:395
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "git filter-branch ... C..H --not D\n"
 "git filter-branch ... D..H --not C\n"
@@ -23573,7 +23573,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git for-each-ref' [--count=<count>] [--shell|--perl|--python|--tcl]\n"
 "\t\t   [(--sort=<key>)...] [--format=<format>] [<pattern>...]\n"
@@ -23590,7 +23590,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-for-each-ref.txt:29 en/git-show-ref.txt:88
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<pattern>..."
 msgstr ""
 
@@ -23878,7 +23878,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:197
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Left-, middle-, or right-align the content between %(align:...) and %(end). The \"align:\" is followed by `width=<width>` and `position=<position>` in any order separated by a comma, where the `<position>` is either left, right or middle, default being left and `<width>` is the total length of the content with alignment. For brevity, the \"width=\" and/or \"position=\" prefixes may be omitted, and bare <width> and <position> used instead.  For instance, `%(align:<width>,<position>)`. If the contents length is more than the width then no alignment is performed. If used with `--quote` everything in between %(align:...) and %(end) is quoted, but if nested then only the topmost level performs quoting."
 msgstr ""
 
@@ -23890,7 +23890,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:210
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Used as %(if)...%(then)...%(end) or %(if)...%(then)...%(else)...%(end).  If there is an atom with value or string literal after the %(if) then everything after the %(then) is printed, else if the %(else) atom is used, then everything after %(else) is printed. We ignore space when evaluating the string before %(then), this is useful when we use the %(HEAD) atom which prints either \"*\" or \" \" and we want to apply the 'if' condition only on the 'HEAD' ref.  Append \":equals=<string>\" or \":notequals=<string>\" to compare the value between the %(if:...) and %(then) atoms with the given string."
 msgstr ""
 
@@ -24110,7 +24110,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:361
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "An example to show the usage of %(if)...%(then)...%(else)...%(end).  This prefixes the current branch with a star."
 msgstr ""
 
@@ -24122,7 +24122,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:369
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "An example to show the usage of %(if)...%(then)...%(end).  This prints the authorname, if present."
 msgstr ""
 
@@ -24768,7 +24768,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:372
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "Do the same for ia64 so we can have sleek & trim looking\n"
 "...\n"
@@ -24776,7 +24776,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:380
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Typically it will be placed in a MUA's drafts folder, edited to add timely commentary that should not go in the changelog after the three dashes, and then sent as a message whose body, in our example, starts with \"arch/arm config files were...\".  On the receiving end, readers can save interesting patches in a UNIX mailbox and apply them with linkgit:git-am[1]."
 msgstr ""
 
@@ -24788,7 +24788,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:390
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "...\n"
 "> So we should do such-and-such.\n"
@@ -24810,7 +24810,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:398
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "arch/arm config files were slimmed down using a python script\n"
 "...\n"
@@ -24984,7 +24984,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:499
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Configure your mail server composition as plain text: Edit...Account Settings...Composition & Addressing, uncheck \"Compose Messages in HTML\"."
 msgstr ""
 
@@ -25121,7 +25121,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:573
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Use Message -> Insert file... and insert the patch."
 msgstr ""
 
@@ -25296,7 +25296,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fsck-objects.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git fsck-objects' ...\n"
 msgstr ""
 
@@ -25684,7 +25684,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-gc.txt:55
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Once housekeeping is triggered by exceeding the limits of configuration options such as `gc.auto` and `gc.autoPackLimit`, all other housekeeping tasks (e.g. rerere, working trees, reflog...) will be performed as well."
 msgstr ""
 
@@ -25858,7 +25858,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-grep.txt:32
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git grep' [-a | --text] [-I] [--textconv] [-i | --ignore-case] [-w | --word-regexp]\n"
 "\t   [-v | --invert-match] [-h|-H] [--full-name]\n"
@@ -26466,7 +26466,7 @@ msgstr "--not"
 
 #. type: Labeled list
 #: en/git-grep.txt:284
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "( ... )"
 msgstr ""
 
@@ -26496,7 +26496,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-grep.txt:300
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<tree>..."
 msgstr ""
 
@@ -26814,7 +26814,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-hash-object.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git hash-object' [-t <type>] [-w] [--path=<file>|--no-filters] [--stdin [--literally]] [--] <file>...\n"
 "'git hash-object' [-t <type>] [-w] --stdin-paths [--no-filters]\n"
@@ -26944,7 +26944,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-help.txt:38
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Note that `git --help ...` is identical to `git help ...` because the former is internally converted into the latter."
 msgstr ""
 
@@ -27394,7 +27394,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:102
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tAuthType Basic\n"
 "\tAuthName \"Git Access\"\n"
@@ -27412,7 +27412,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:115
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "<LocationMatch \"^/git/.*/git-receive-pack$\">\n"
 "\tAuthType Basic\n"
@@ -27436,7 +27436,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:136
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "<Location /git/private>\n"
 "\tAuthType Basic\n"
@@ -27586,7 +27586,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:231
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "auth.require = (\n"
 "\t\"/\" => (\n"
@@ -27789,7 +27789,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-http-push.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git http-push' [--all] [--dry-run] [--force] [--verbose] <url> <ref> [<ref>...]\n"
 msgstr ""
 
@@ -27858,7 +27858,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-http-push.txt:54 en/git-send-pack.txt:98
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<ref>..."
 msgstr ""
 
@@ -28723,7 +28723,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-interpret-trailers.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git interpret-trailers' [<options>] [(--trailer <token>[(=|:)<value>])...] [<file>...]\n"
 "'git interpret-trailers' [<options>] [--parse] [<file>...]\n"
@@ -29393,7 +29393,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-log.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'git log' [<options>] [<revision range>] [[--] <path>...]\n"
 msgstr ""
 
@@ -29489,7 +29489,7 @@ msgstr "--full-diff"
 
 #. type: Plain text
 #: en/git-log.txt:63
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Without this flag, `git log -p <path>...` shows commits that touch the specified paths, and diffs about the same specified paths.  With this, the full diff is shown for commits that touch the specified paths; this means that \"<path>...\" limits only commits, and doesn't limit diff for those commits."
 msgstr ""
 
@@ -29543,7 +29543,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-log.txt:93 en/git-shortlog.txt:72
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "[--] <path>..."
 msgstr ""
 
@@ -29819,7 +29819,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-files.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-files' [-z] [-t] [-v] [-f]\n"
 "\t\t(--[cached|deleted|others|ignored|stage|unmerged|killed|modified])*\n"
@@ -30300,7 +30300,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-remote.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-remote' [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
 "\t      [-q | --quiet] [--exit-code] [--get-url] [--sort=<key>]\n"
@@ -30405,7 +30405,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-remote.txt:91
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When unspecified, all references, after filtering done with --heads and --tags, are shown.  When <refs>... are specified, only references matching the given patterns are displayed."
 msgstr ""
 
@@ -30450,7 +30450,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-tree' [-d] [-r] [-t] [-l] [-z]\n"
 "\t    [--name-only] [--name-status] [--full-name] [--full-tree] [--abbrev[=<n>]]\n"
@@ -30531,7 +30531,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-ls-tree.txt:76
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<path>...]"
 msgstr ""
 
@@ -30741,7 +30741,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mailsplit.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git mailsplit' [-b] [-f<nn>] [-d<prec>] [--keep-cr] [--mboxrd]\n"
 "\t\t-o<directory> [--] [(<mbox>|<Maildir>)...]\n"
@@ -30863,7 +30863,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git merge-base' [-a|--all] <commit> <commit>...\n"
 "'git merge-base' [-a|--all] --octopus <commit>...\n"
@@ -31060,7 +31060,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:139
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tA=$(git rev-parse --verify A)\n"
 "\tif test \"$A\" = \"$(git merge-base A B)\"\n"
@@ -31077,7 +31077,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:146
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tif git merge-base --is-ancestor A B\n"
 "\tthen\n"
@@ -31564,7 +31564,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mergetool.txt:12
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git mergetool' [--tool=<tool>] [-y | --[no-]prompt] [<file>...]\n"
 msgstr ""
 
@@ -31726,7 +31726,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge.txt:17
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git merge' [-n] [--stat] [--no-commit] [--squash] [--[no-]edit]\n"
 "\t[-s <strategy>] [-X <strategy-option>] [-S[<keyid>]]\n"
@@ -32319,7 +32319,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mv.txt:13
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git mv' <options>... <args>...\n"
 msgstr ""
 
@@ -32331,7 +32331,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mv.txt:20
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 " git mv [-v] [-f] [-n] [-k] <source> <destination>\n"
 " git mv [-v] [-f] [-n] [-k] <source> ... <destination directory>\n"
@@ -32399,7 +32399,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-name-rev.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git name-rev' [--tags] [--refs=<pattern>]\n"
 "\t       ( --all | --stdin | <commit-ish>... )\n"
@@ -32517,7 +32517,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-notes.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git notes' [list [<object>]]\n"
 "'git notes' add [-f] [--allow-empty] [-F <file> | -m <msg> | (-c | -C) <object>] [<object>]\n"
@@ -32853,7 +32853,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-notes.txt:229
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Commit notes are blobs containing extra information about an object (usually information to supplement a commit's message).  These blobs are taken from notes refs.  A notes ref is usually a branch which contains \"files\" whose paths are the object names for the objects they describe, with some directory separators included for performance reasons footnote:[Permitted pathnames have the form 'ab'`/`'cd'`/`'ef'`/`'...'`/`'abcdef...': a sequence of directory names of two hexadecimal digits each followed by a filename with the rest of the object ID.]."
 msgstr ""
 
@@ -32919,7 +32919,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-notes.txt:288
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git notes add -m 'Tested-by: Johannes Sixt <j6t@kdbg.org>' 72a144e2\n"
 "$ git show -s 72a144e\n"
@@ -33138,7 +33138,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-p4.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git p4 clone' [<sync options>] [<clone options>] <p4 depot path>...\n"
 "'git p4 sync' [<sync options>] [<p4 depot path>...]\n"
@@ -33971,7 +33971,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-p4.txt:445
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The full syntax for a p4 view is documented in 'p4 help views'.  'git p4' knows only a subset of the view syntax.  It understands multi-line mappings, overlays with '+', exclusions with '-' and double-quotes around whitespace.  Of the possible wildcards, 'git p4' only handles '...', and only when it is at the end of the path.  'git p4' will complain if it encounters an unhandled wildcard."
 msgstr ""
 
@@ -34013,7 +34013,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-p4.txt:475
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "//depot/main/...\n"
 "//depot/branch1/...\n"
@@ -34027,7 +34027,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-p4.txt:480
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "//depot/main/... //depot/branch1/...\n"
 msgstr ""
 
@@ -35144,7 +35144,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-pack-redundant.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git pack-redundant' [ --verbose ] [ --alt-odb ] < --all | .pack filename ... >\n"
 msgstr ""
 
@@ -35444,7 +35444,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-prune.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git prune' [-n] [-v] [--progress] [--expire <time>] [--] [<head>...]\n"
 msgstr ""
 
@@ -35498,7 +35498,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-prune.txt:54
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<head>..."
 msgstr ""
 
@@ -35552,7 +35552,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-pull.txt:13
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "'git pull' [<options>] [<repository> [<refspec>...]]\n"
 msgstr ""
 
@@ -35900,7 +35900,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:18
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git push' [--all | --mirror | --tags] [--follow-tags] [--atomic] [-n | --dry-run] [--receive-pack=<git-receive-pack>]\n"
 "\t   [--repo=<repository>] [-f | --force] [-d | --delete] [--prune] [-v | --verbose]\n"
@@ -35930,7 +35930,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:39
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "When the command line does not specify what to push with `<refspec>...` arguments or `--all`, `--mirror`, `--tags` options, the command finds the default `<refspec>` by consulting `remote.*.push` configuration, and if it is not found, honors `push.default` configuration to decide what to push (See linkgit:git-config[1] for the meaning of `push.default`)."
 msgstr ""
 
@@ -35954,7 +35954,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:56
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "<refspec>..."
 msgstr ""
 
@@ -36314,7 +36314,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:343
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "Note that `--force` applies to all the refs that are pushed, hence using it with `push.default` set to `matching` or with multiple push destinations configured with `remote.*.push` may overwrite refs other than the current branch (including local refs that are strictly behind their remote counterpart).  To force a push to only one branch, use a `+` in front of the refspec to push (e.g `git push origin +master` to force a push to the `master` branch). See the `<refspec>...` section above for details."
 msgstr ""
 
@@ -36446,7 +36446,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:445
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "For a successfully pushed ref, the summary shows the old and new values of the ref in a form suitable for using as an argument to `git log` (this is `<old>..<new>` in most cases, and `<old>...<new>` for forced non-fast-forward updates)."
 msgstr ""
 
@@ -36707,7 +36707,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:616
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "See the section describing `<refspec>...` above for a discussion of the matching semantics."
 msgstr ""
 
@@ -37408,7 +37408,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-read-tree.txt:357
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git fetch git://.... linus\n"
 "$ LT=`git rev-parse FETCH_HEAD`\n"
@@ -37462,7 +37462,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-read-tree.txt:405
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "'git read-tree' and other merge-based commands ('git merge', 'git checkout'...) can help maintaining the skip-worktree bitmap and working directory update. `$GIT_DIR/info/sparse-checkout` is used to define the skip-worktree reference bitmap. When 'git read-tree' needs to update the working directory, it resets the skip-worktree bit in the index based on this file, which uses the same syntax as .gitignore files.  If an entry matches a pattern in this file, skip-worktree will not be set on that entry. Otherwise, skip-worktree will be set."
 msgstr ""
 
@@ -37842,7 +37842,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:219
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "As a special case, you may use \"A\\...B\" as a shortcut for the merge base of A and B if there is exactly one merge base. You can leave out at most one of A and B, in which case it defaults to HEAD."
 msgstr ""
 
@@ -38106,7 +38106,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:430
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "It is currently only possible to recreate the merge commits using the `recursive` merge strategy; Different merge strategies can be used only via explicit `exec git merge -s <strategy> [...]` commands."
 msgstr ""
 
@@ -38160,7 +38160,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:457
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "\tgit rebase -i --exec \"cmd1 && cmd2 && ...\"\n"
 msgstr ""
 
@@ -38172,7 +38172,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:461
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "\tgit rebase -i --exec \"cmd1\" --exec \"cmd2\" --exec ...\n"
 msgstr ""
 
@@ -38208,7 +38208,7 @@ msgstr "--no-autosquash"
 
 #. type: Plain text
 #: en/git-rebase.txt:495
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When the commit log message begins with \"squash! ...\" (or \"fixup! ...\"), and there is already a commit in the todo list that matches the same `...`, automatically modify the todo list of rebase -i so that the commit marked for squashing comes right after the commit to be modified, and change the action of the moved commit from `pick` to `squash` (or `fixup`).  A commit matches the `...` if the commit subject matches, or if the `...` refers to the commit's hash. As a fall-back, partial matches of the commit subject work, too.  The recommended way to create fixup/squash commits is by using the `--fixup`/`--squash` options of linkgit:git-commit[1]."
 msgstr ""
 
@@ -38535,7 +38535,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:636
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "pick deadbee The oneline of this commit\n"
 "pick fa1afe1 The oneline of the next commit\n"
@@ -38639,7 +38639,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:710
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "pick deadbee Implement feature XXX\n"
 "fixup f1a5c00 Fix to feature XXX\n"
@@ -38658,7 +38658,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:720
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The \"exec\" command launches the command in a shell (the one specified in `$SHELL`, or the default shell if `$SHELL` is not set), so you can use shell features (like \"cd\", \">\", \";\" ...). The command is run from the root of the working tree."
 msgstr ""
 
@@ -38802,7 +38802,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:815
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "    o---o---o---o---o---o---o---o  master\n"
 "\t \\\t\t\t \\\n"
@@ -39600,7 +39600,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reflog.txt:27
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git reflog' ['show'] [log-options] [<ref>]\n"
 "'git reflog expire' [--expire=<time>] [--expire-unreachable=<time>]\n"
@@ -39787,7 +39787,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-remote-ext.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git remote add <nick> \"ext::<command>[ <arguments>...]\"\n"
 msgstr ""
 
@@ -39925,7 +39925,7 @@ msgstr "GIT_EXT_SERVICE"
 
 #. type: Plain text
 #: en/git-remote-ext.txt:70
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Set to long name (git-upload-pack, etc...) of service helper needs to invoke."
 msgstr ""
 
@@ -39937,7 +39937,7 @@ msgstr "GIT_EXT_SERVICE_NOPREFIX"
 
 #. type: Plain text
 #: en/git-remote-ext.txt:74
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Set to long name (upload-pack, etc...) of service helper needs to invoke."
 msgstr ""
 
@@ -40117,7 +40117,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-remote.txt:25
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git remote' [-v | --verbose]\n"
 "'git remote add' [-t <branch>] [-m <master>] [-f] [--[no-]tags] [--mirror=<fetch|push>] <name> <url>\n"
@@ -40436,7 +40436,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-remote.txt:235
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "$ git remote\n"
 "origin\n"
@@ -40680,7 +40680,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-replace.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git replace' [-f] <object> <replacement>\n"
 "'git replace' [-f] --edit <object>\n"
@@ -40800,13 +40800,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-replace.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--graft <commit> [<parent>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/git-replace.txt:93
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Create a graft commit. A new commit is created with the same content as <commit> except that its parents will be [<parent>...] instead of <commit>'s parents. A replacement ref is then created to replace <commit> with the newly created commit. Use `--convert-graft-file` to convert a `$GIT_DIR/info/grafts` file and use replace refs instead."
 msgstr ""
 
@@ -41228,7 +41228,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rerere.txt:121
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git switch topic\n"
 "\t$ git merge master\n"
@@ -41260,7 +41260,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rerere.txt:145
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git switch topic\n"
 "\t$ git merge master\n"
@@ -41365,7 +41365,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reset.txt:14
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git reset' [-q] [<tree-ish>] [--] <paths>...\n"
 "'git reset' (--patch | -p) [<tree-ish>] [--] [<paths>...]\n"
@@ -41380,7 +41380,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-reset.txt:22
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git reset' [-q] [<tree-ish>] [--] <paths>..."
 msgstr ""
 
@@ -41392,7 +41392,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reset.txt:30
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "This means that `git reset <paths>` is the opposite of `git add <paths>`. This command is equivalent to `git restore [--source=<tree-ish>] --staged <paths>...`."
 msgstr ""
 
@@ -41404,7 +41404,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-reset.txt:38
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git reset' (--patch | -p) [<tree-ish>] [--] [<paths>...]"
 msgstr ""
 
@@ -41559,7 +41559,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:138
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git commit ...\n"
 "$ git reset --soft HEAD^      <1>\n"
@@ -41632,7 +41632,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:170
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git commit ...\n"
 "$ git reset --hard HEAD~3   <1>\n"
@@ -41652,7 +41652,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:190
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git pull                         <1>\n"
 "Auto-merging nitfol\n"
@@ -41697,7 +41697,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:215
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git pull                         <1>\n"
 "Auto-merging nitfol\n"
@@ -41823,7 +41823,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:289
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git tag start\n"
 "$ git switch -c branch1\n"
@@ -41866,7 +41866,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:317
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git reset -N HEAD^                        <1>\n"
 "$ git add -p                                <2>\n"
@@ -42092,7 +42092,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-restore.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git restore' [<options>] [--source=<tree>] [--staged] [--worktree] <pathspec>...\n"
 "'git restore' (-p|--patch) [<options>] [--source=<tree>] [--staged] [--worktree] [<pathspec>...]\n"
@@ -42344,7 +42344,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-revert.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git revert' [--[no-]edit] [-n] [-m parent-number] [-s] [-S[<keyid>]] <commit>...\n"
 "'git revert' (--continue | --skip | --abort | --quit)\n"
@@ -42448,7 +42448,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-list.txt:65
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git rev-list' [ --max-count=<number> ]\n"
 "\t     [ --skip=<number> ]\n"
@@ -42551,13 +42551,13 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-list.txt:102
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Another special notation is \"'<commit1>'...'<commit2>'\" which is useful for merges.  The resulting set of commits is the symmetric difference between the two operands.  The following two commands are equivalent:"
 msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-list.txt:106
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git rev-list A B --not $(git merge-base --all A B)\n"
 "\t$ git rev-list A...B\n"
@@ -42583,7 +42583,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-parse.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git rev-parse' [<options>] <args>...\n"
 msgstr ""
 
@@ -43067,7 +43067,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-parse.txt:253
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Resolve \"$GIT_DIR/<path>\" and takes other path relocation variables such as $GIT_OBJECT_DIRECTORY, $GIT_INDEX_FILE... into account. For example, if $GIT_OBJECT_DIRECTORY is set to /foo/bar then \"git rev-parse --git-path objects/abc\" returns /foo/bar/abc."
 msgstr ""
 
@@ -43175,7 +43175,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:290
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<args>..."
 msgstr ""
 
@@ -43307,7 +43307,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:364
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "OPTS_SPEC=\"\\\n"
 "some-command [<options>] <args>...\n"
@@ -43365,7 +43365,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:389
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "usage: some-command [<options>] <args>...\n"
 msgstr ""
 
@@ -43377,7 +43377,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:397
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "    -h, --help            show the help\n"
 "    --foo                 some nifty option --foo\n"
@@ -43388,7 +43388,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:400
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "An option group Header\n"
 "    -C[...]               option C with an optional argument\n"
@@ -43493,7 +43493,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rm.txt:12
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git rm' [-f | --force] [-n] [-r] [--cached] [--ignore-unmatch] [--quiet] [--] <file>...\n"
 msgstr ""
 
@@ -43721,7 +43721,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-email.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git send-email' [<options>] <file|directory|rev-list options>...\n"
 "'git send-email' --dump-aliases\n"
@@ -43789,7 +43789,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:53
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--bcc=<address>,..."
 msgstr ""
 
@@ -43807,7 +43807,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:59
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--cc=<address>,..."
 msgstr ""
 
@@ -43891,7 +43891,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-email.txt:110
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "  [PATCH 0/2] Here is what I did...\n"
 "    [PATCH 1/2] Clean up and tests\n"
@@ -43922,7 +43922,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:119
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--to=<address>,..."
 msgstr ""
 
@@ -44054,7 +44054,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-send-email.txt:188
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "$ git send-email --smtp-auth=\"PLAIN LOGIN GSSAPI\" ...\n"
 msgstr ""
 
@@ -44750,7 +44750,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-pack.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git send-pack' [--all] [--dry-run] [--force] [--receive-pack=<git-receive-pack>]\n"
 "\t\t[--verbose] [--thin] [--atomic]\n"
@@ -45123,7 +45123,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-shortlog.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "'git shortlog' [<options>] [<revision range>] [[--] <path>...]\n"
 "git log --pretty=short | 'git shortlog' [<options>]\n"
@@ -45251,7 +45251,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show-branch.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git show-branch' [-a|--all] [-r|--remotes] [--topo-order | --date-order]\n"
 "\t\t[--current] [--color[=<when>] | --no-color] [--sparse]\n"
@@ -45612,7 +45612,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show-ref.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git show-ref' [-q|--quiet] [--verify] [--head] [-d|--dereference]\n"
 "\t     [-s|--hash[=<n>]] [--abbrev[=<n>]] [--tags]\n"
@@ -45760,7 +45760,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-show-ref.txt:111
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git show-ref --head --dereference\n"
 "832e76a9899f560a90ffd62ae2ce83bbeff58f54 HEAD\n"
@@ -45781,7 +45781,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-show-ref.txt:121
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git show-ref --heads --hash\n"
 "2e3ba0114a1f52b47df29743d6915d056be13278\n"
@@ -45902,7 +45902,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'git show' [<options>] [<object>...]\n"
 msgstr ""
 
@@ -45950,7 +45950,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-show.txt:37
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "<object>..."
 msgstr ""
 
@@ -46208,7 +46208,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stage.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git stage' args...\n"
 msgstr ""
 
@@ -46232,7 +46232,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stash.txt:22
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git stash' list [<options>]\n"
 "'git stash' show [<options>] [<stash>]\n"
@@ -46255,7 +46255,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stash.txt:38
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "The modifications stashed away by this command can be listed with `git stash list`, inspected with `git stash show`, and restored (potentially on top of a different commit) with `git stash apply`.  Calling `git stash` without any arguments is equivalent to `git stash push`.  A stash is by default listed as \"WIP on 'branchname' ...\", but you can give a more descriptive message on the command line when you create one."
 msgstr ""
 
@@ -46267,7 +46267,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-stash.txt:49
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "push [-p|--patch] [-k|--[no-]keep-index] [-u|--include-untracked] [-a|--all] [-q|--quiet] [-m|--message <message>] [--] [<pathspec>...]"
 msgstr ""
 
@@ -46339,7 +46339,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:104
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "stash@{0}: WIP on submit: 6ebd0e2... Update git-stash documentation\n"
 "stash@{1}: On master: 9cc0589... Add git-stash\n"
@@ -46512,7 +46512,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:227
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git pull\n"
 " ...\n"
@@ -46530,7 +46530,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:246
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git switch -c my_wip\n"
@@ -46551,7 +46551,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:257
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git stash\n"
@@ -46575,7 +46575,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:275
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git add --patch foo            # add just first part to the index\n"
@@ -46629,7 +46629,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-status.txt:13
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git status' [<options>...] [--] [<pathspec>...]\n"
 msgstr ""
 
@@ -47106,7 +47106,7 @@ msgstr ""
 
 #. type: delimited block .
 #: en/git-status.txt:345
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "Field       Meaning\n"
 "--------------------------------------------------------\n"
@@ -47427,7 +47427,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-submodule.txt:23
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git submodule' [--quiet] [--cached]\n"
 "'git submodule' [--quiet] add [<options>] [--] <repository> [<path>]\n"
@@ -47498,7 +47498,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:74
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "status [--cached] [--recursive] [--] [<path>...]"
 msgstr ""
 
@@ -47522,7 +47522,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:91
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "init [--] [<path>...]"
 msgstr ""
 
@@ -47552,7 +47552,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:114
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "deinit [-f|--force] (--all|[--] <path>...)"
 msgstr ""
 
@@ -47582,7 +47582,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:132
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "update [--init] [--remote] [-N|--no-fetch] [--[no-]recommend-shallow] [-f|--force] [--checkout|--rebase|--merge] [--reference <repository>] [--depth <depth>] [--recursive] [--jobs <n>] [--] [<path>...]"
 msgstr ""
 
@@ -47706,7 +47706,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:182
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "summary [--cached|--files] [(-n|--summary-limit) <n>] [commit] [--] [<path>...]"
 msgstr ""
 
@@ -47748,7 +47748,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:224
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "sync [--recursive] [--] [<path>...]"
 msgstr ""
 
@@ -48273,7 +48273,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:127
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Fetch unfetched revisions from the Subversion remote we are tracking.  The name of the [svn-remote \"...\"] section in the $GIT_DIR/config file may be specified as an optional command-line argument."
 msgstr ""
 
@@ -48719,7 +48719,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:366
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "is supported, non-numeric args are not: HEAD, NEXT, BASE, PREV, etc ..."
 msgstr ""
 
@@ -49620,7 +49620,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-svn.txt:876
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "# Clone a repo (like git clone):\n"
 "\tgit svn clone http://svn.example.com/project/trunk\n"
@@ -49673,7 +49673,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-svn.txt:924
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "# Do the initial import on a server\n"
 "\tssh server \"cd /pub && git svn clone http://svn.example.com/project [options...]\"\n"
@@ -50383,7 +50383,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-tag.txt:20
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git tag' [-a | -s | -u <keyid>] [-f] [-m <msg> | -F <file>] [-e]\n"
 "\t<tagname> [<commit> | <object>]\n"
@@ -50529,7 +50529,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-tag.txt:103
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "List tags. With optional `<pattern>...`, e.g. `git tag --list 'v-*'`, list only the tags that match the pattern(s)."
 msgstr ""
 
@@ -50819,13 +50819,13 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:319
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "\tgit://git..../proj.git master\n"
 msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:321
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "to get the following updates...\n"
 msgstr ""
 
@@ -50837,7 +50837,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:327
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "$ git pull git://git..../proj.git master\n"
 msgstr ""
 
@@ -50957,7 +50957,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git.txt:55
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Other options are available to control how the manual page is displayed. See linkgit:git-help[1] for more information, because `git --help ...` is converted internally into `git help ...`."
 msgstr ""
 
@@ -51001,7 +51001,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git.txt:82
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Note that omitting the `=` in `git -c foo.bar ...` is allowed and sets `foo.bar` to the boolean true value (just like `[foo]bar` would in a config file). Including the equals but with an empty value (like `git -c foo.bar= ...`) sets `foo.bar` to the empty string which `git config --type=bool` will convert to `false`."
 msgstr ""
 
@@ -51205,7 +51205,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:169
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--list-cmds=group[,group...]"
 msgstr ""
 
@@ -51708,7 +51708,7 @@ msgstr "`GIT_COMMON_DIR`"
 
 #. type: Plain text
 #: en/git.txt:481
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If this variable is set to a path, non-worktree files that are normally in $GIT_DIR will be taken from this path instead. Worktree-specific files such as HEAD or index are taken from $GIT_DIR. See linkgit:gitrepository-layout[5] and linkgit:git-worktree[1] for details. This variable has lower precedence than other path variables such as GIT_INDEX_FILE, GIT_OBJECT_DIRECTORY..."
 msgstr ""
 
@@ -52179,9 +52179,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:685
-#, fuzzy, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2`"
-msgstr "`GIT_TRACE`"
+msgstr "`GIT_TRACE2`"
 
 #. type: Plain text
 #: en/git.txt:689
@@ -52209,9 +52209,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:720
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2_EVENT`"
-msgstr ""
+msgstr "`GIT_TRACE2_EVENT`"
 
 #. type: Plain text
 #: en/git.txt:725
@@ -52221,9 +52221,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:726
-#, fuzzy, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2_PERF`"
-msgstr "`GIT_TRACE_CURL`"
+msgstr "`GIT_TRACE2_PERF`"
 
 #. type: Plain text
 #: en/git.txt:732
@@ -52662,7 +52662,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-update-index.txt:29
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git update-index'\n"
 "\t     [--add] [--remove | --force-remove] [--replace]\n"
@@ -53222,7 +53222,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-update-index.txt:348
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The command looks at `core.ignorestat` configuration variable.  When this is true, paths updated with `git update-index paths...` and paths updated with other Git commands that update both index and working tree (e.g. 'git apply --index', 'git checkout-index -u', and 'git read-tree -u') are automatically marked as \"assume unchanged\".  Note that \"assume unchanged\" bit is *not* set if `git update-index --refresh` finds the working tree file matches the index (use `git update-index --really-refresh` if you want to mark them as \"assume unchanged\")."
 msgstr ""
 
@@ -54090,7 +54090,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-commit.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-commit' <commit>...\n"
 msgstr ""
 
@@ -54132,7 +54132,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-pack.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-pack' [-v|--verbose] [-s|--stat-only] [--] <pack>.idx ...\n"
 msgstr ""
 
@@ -54144,7 +54144,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-verify-pack.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<pack>.idx ..."
 msgstr ""
 
@@ -54222,7 +54222,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-tag.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-tag' [--format=<format>] <tag>...\n"
 msgstr ""
 
@@ -54240,7 +54240,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-verify-tag.txt:27
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<tag>..."
 msgstr ""
 
@@ -54264,7 +54264,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-web--browse.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git web{litdd}browse' [<options>] <url|file>...\n"
 msgstr ""
 
@@ -54538,7 +54538,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-whatchanged.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git whatchanged' <option>...\n"
 msgstr ""
 
@@ -55068,7 +55068,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-worktree.txt:372
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git worktree add -b emergency-fix ../temp master\n"
 "$ pushd ../temp\n"
@@ -56267,7 +56267,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/pretty-formats.txt:115
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'%C(...)'"
 msgstr ""
 
@@ -56279,7 +56279,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/pretty-formats.txt:129
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "\"CONFIGURATION FILE\" section of linkgit:git-config[1].  By default, colors are shown only when enabled for log output (by `color.diff`, `color.ui`, or `--color`, and respecting the `auto` settings of the former if we are going to a terminal). `%C(auto,...)` is accepted as a historical synonym for the default (e.g., `%C(auto,red)`). Specifying `%C(always,...)` will show the colors even when color is not otherwise enabled (though consider just using `--color=always` to enable color for the whole output, including this format and anything else git might color).  `auto` alone (i.e. `%C(auto)`) will turn on auto coloring on the next placeholders until the color is switched again."
 msgstr ""
 
@@ -57357,7 +57357,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/pull-fetch-param.txt:45
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "Whether that update is allowed without `--force` depends on the ref namespace it's being fetched to, the type of object being fetched, and whether the update is considered to be a fast-forward. Generally, the same rules apply for fetching as when pushing, see the `<refspec>...` section of linkgit:git-push[1] for what those are. Exceptions to those rules particular to 'git fetch' are noted below."
 msgstr ""
 
@@ -57828,13 +57828,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/revisions.txt:280
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "The '...' (three-dot) Symmetric Difference Notation"
 msgstr ""
 
 #. type: Plain text
 #: en/revisions.txt:286
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "A similar notation 'r1\\...r2' is called symmetric difference of 'r1' and 'r2' and is defined as 'r1 r2 --not $(git merge-base --all r1 r2)'.  It is the set of commits that are reachable from either one of 'r1' (left side) or 'r2' (right side) but not from both."
 msgstr ""
 
@@ -57924,7 +57924,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/revisions.txt:331
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'<rev1>\\...<rev2>'"
 msgstr ""
 
@@ -57978,7 +57978,7 @@ msgstr ""
 
 #. type: delimited block .
 #: en/revisions.txt:377
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "   Args   Expanded arguments    Selected commits\n"
 "   D                            G H D\n"
@@ -58468,7 +58468,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:256
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "For example, `--cherry-pick --right-only A...B` omits those commits from `B` which are in `A` or are patch-equivalent to a commit in `A`. In other words, this lists the `+` commits from `git cherry A B`.  More precisely, `--cherry-pick --right-only --no-merges` gives the exact list."
 msgstr ""
 
@@ -58480,7 +58480,7 @@ msgstr "--cherry"
 
 #. type: Plain text
 #: en/rev-list-options.txt:263
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "A synonym for `--right-only --cherry-mark --no-merges`; useful to limit the output to the commits on our side and mark those that have been applied to the other side of a forked history with `git log --cherry upstream...mybranch`, similar to `git cherry upstream mybranch`."
 msgstr ""
 
@@ -58492,7 +58492,7 @@ msgstr "--walk-reflogs"
 
 #. type: Plain text
 #: en/rev-list-options.txt:271
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Instead of walking the commit ancestry chain, walk reflog entries from the most recent one to older ones.  When this option is used you cannot specify commits to exclude (that is, '{caret}commit', 'commit1..commit2', and 'commit1\\...commit2' notations cannot be used)."
 msgstr ""
 
@@ -59485,7 +59485,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:875
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "`--date=format:...` feeds the format `...` to your system `strftime`, except for %z and %Z, which are handled internally.  Use `--date=format:%c` to show the date in your system locale's preferred format.  See the `strftime` manual for a complete list of format placeholders. When using `-local`, the correct syntax is `--date=format-local:...`."
 msgstr ""
 
@@ -59521,7 +59521,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:892
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Print also the parents of the commit (in the form \"commit parent...\").  Also enables parent rewriting, see 'History Simplification' above."
 msgstr ""
 
@@ -59533,7 +59533,7 @@ msgstr "--children"
 
 #. type: Plain text
 #: en/rev-list-options.txt:896
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Print also the children of the commit (in the form \"commit child...\").  Also enables parent rewriting, see 'History Simplification' above."
 msgstr ""
 
@@ -59586,13 +59586,13 @@ msgstr ""
 
 #. type: delimited block -
 #: en/rev-list-options.txt:922
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "\t$ git rev-list --left-right --boundary --pretty=oneline A...B\n"
 msgstr ""
 
 #. type: delimited block -
 #: en/rev-list-options.txt:929
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "\t>bbbbbbb... 3rd on b\n"
 "\t>bbbbbbb... 2nd on b\n"

--- a/po/documentation.ru.po
+++ b/po/documentation.ru.po
@@ -13,8 +13,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<="
-"4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 3.9-dev\n"
 
 #. type: Labeled list
@@ -2436,7 +2435,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/config.txt:256
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The value for many variables that specify various sizes can be suffixed with `k`, `M`,... to mean \"scale the number by 1024\", \"by 1024x1024\", etc."
 msgstr ""
 
@@ -2826,7 +2825,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-format.txt:16
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "git-diff-tree [-r] <tree-ish-1> <tree-ish-2> [<pattern>...]"
 msgstr ""
 
@@ -2838,7 +2837,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-format.txt:19
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "git-diff-files [<pattern>...]"
 msgstr ""
 
@@ -3518,7 +3517,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/diff-generate-patch.txt:179
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Unlike the traditional 'unified' diff format, which shows two files A and B with a single column that has `-` (minus -- appears in A but removed in B), `+` (plus -- missing in A but added to B), or `\" \"` (space -- unchanged) prefix, this format compares two or more files file1, file2,... with one file X, and shows how X differs from each of fileN.  One column for each of fileN is prepended to the output line to note how X's line is different from it."
 msgstr ""
 
@@ -3841,7 +3840,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:137
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Generate a diffstat. By default, as much space as necessary will be used for the filename part, and the rest for the graph part. Maximum width defaults to terminal width, or 80 columns if not connected to a terminal, and can be overridden by `<width>`. The width of the filename part can be limited by giving another width `<name-width>` after a comma. The width of the graph part can be limited by using `--stat-graph-width=<width>` (affects all commands generating a stat graph) or by setting `diff.statGraphWidth=<width>` (does not affect `git format-patch`).  By giving a third parameter `<count>`, you can limit the output to the first `<count>` lines, followed by `...` if there are more."
 msgstr ""
 
@@ -3889,13 +3888,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:161
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "-X[<param1,param2,...>]"
 msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:162
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--dirstat[=<param1,param2,...>]"
 msgstr ""
 
@@ -3985,13 +3984,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:209
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--dirstat-by-file[=<param1,param2>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:211
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Synonym for --dirstat=files,param1,param2..."
 msgstr ""
 
@@ -4652,13 +4651,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:527
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--diff-filter=[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:538
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Select only files that are Added (`A`), Copied (`C`), Deleted (`D`), Modified (`M`), Renamed (`R`), have their type (i.e. regular file, symlink, submodule, ...) changed (`T`), are Unmerged (`U`), are Unknown (`X`), or have had their pairing Broken (`B`).  Any combination of the filter characters (including none) can be used.  When `*` (All-or-none) is added to the combination, all paths are selected if there is any file that matches other criteria in the comparison; if there is no file that matches other criteria, nothing is selected."
 msgstr ""
 
@@ -4718,7 +4717,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/diff-options.txt:573
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "+    return !regexec(regexp, two->ptr, 1, &regmatch, 0);\n"
 "...\n"
@@ -5641,7 +5640,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-add.txt:15
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "'git add' [--verbose | -v] [--dry-run | -n] [--force | -f] [--interactive | -i] [--patch | -p]\n"
 "\t  [--edit | -e] [--[no-]all | --[no-]ignore-removal | [--update | -u]]\n"
@@ -5699,7 +5698,7 @@ msgstr "ПАРАМЕТРЫ"
 
 #. type: Labeled list
 #: en/git-add.txt:52 en/git-grep.txt:308 en/git-status.txt:148
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid "<pathspec>..."
 msgstr ""
 
@@ -5843,7 +5842,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-add.txt:145
-#, priority:300
+#, ignore-ellipsis, priority:300
 msgid "This option is primarily to help users who are used to older versions of Git, whose \"git add <pathspec>...\" was a synonym for \"git add --no-all <pathspec>...\", i.e. ignored removed files."
 msgstr ""
 
@@ -6163,9 +6162,7 @@ msgstr ""
 #: en/git-add.txt:332
 #, priority:300
 msgid "After deciding the fate for all hunks, if there is any hunk that was chosen, the index is updated with the selected hunks."
-msgstr ""
-"После решения судьбы всех фрагментов патча выбранные фрагменты добавляются в "
-"индекс."
+msgstr "После решения судьбы всех фрагментов патча выбранные фрагменты добавляются в индекс."
 
 #. type: Plain text
 #: en/git-add.txt:335
@@ -6195,15 +6192,7 @@ msgstr "РЕДАКТИРОВАНИЕ ПАТЧЕЙ"
 #: en/git-add.txt:353
 #, priority:300
 msgid "Invoking `git add -e` or selecting `e` from the interactive hunk selector will open a patch in your editor; after the editor exits, the result is applied to the index. You are free to make arbitrary changes to the patch, but note that some changes may have confusing results, or even result in a patch that cannot be applied.  If you want to abort the operation entirely (i.e., stage nothing new in the index), simply delete all lines of the patch. The list below describes some common things you may see in a patch, and which editing operations make sense on them."
-msgstr ""
-"Вызов `git add -e` или выбор `e` при интерактивном выборе фрагментов откроет "
-"патч в вашем редакторе; после закрытия редактора результат добавляется в "
-"индекс. Вы вольны вносить в патч любые изменения, но помните, что некоторые "
-"изменения могут привести к неожиданным результатам или даже к невозможности "
-"применения патча. Если вы хотите прервать операцию (т.е. не добавлять в "
-"индекс ничего нового), просто удалите все строки из патча. Приведенный ниже "
-"список описывает общие вещи, которые вы можете увидеть в патче, и как их "
-"можно редактировать."
+msgstr "Вызов `git add -e` или выбор `e` при интерактивном выборе фрагментов откроет патч в вашем редакторе; после закрытия редактора результат добавляется в индекс. Вы вольны вносить в патч любые изменения, но помните, что некоторые изменения могут привести к неожиданным результатам или даже к невозможности применения патча. Если вы хотите прервать операцию (т.е. не добавлять в индекс ничего нового), просто удалите все строки из патча. Приведенный ниже список описывает общие вещи, которые вы можете увидеть в патче, и как их можно редактировать."
 
 #. type: Labeled list
 #: en/git-add.txt:355
@@ -6215,10 +6204,7 @@ msgstr "добавляемое содержимое"
 #: en/git-add.txt:359
 #, priority:300
 msgid "Added content is represented by lines beginning with \"{plus}\". You can prevent staging any addition lines by deleting them."
-msgstr ""
-"Добавляемое содержимое представляется в виде строк со знаком \"{plus}\" в "
-"начале каждой строки. Вы можете предотвратить добавление строк посредством "
-"их удаления."
+msgstr "Добавляемое содержимое представляется в виде строк со знаком \"{plus}\" в начале каждой строки. Вы можете предотвратить добавление строк посредством их удаления."
 
 #. type: Labeled list
 #: en/git-add.txt:360
@@ -6230,10 +6216,7 @@ msgstr "удаляемое содержимое"
 #: en/git-add.txt:364
 #, priority:300
 msgid "Removed content is represented by lines beginning with \"-\". You can prevent staging their removal by converting the \"-\" to a \" \" (space)."
-msgstr ""
-"Удаляемое содержимое представляется в виде строк, начинающихся со знака \"-\""
-". Вы можете предотвратить внесение их в индекс, заменив \"-\" на \" \" "
-"(пробел)."
+msgstr "Удаляемое содержимое представляется в виде строк, начинающихся со знака \"-\". Вы можете предотвратить внесение их в индекс, заменив \"-\" на \" \" (пробел)."
 
 #. type: Labeled list
 #: en/git-add.txt:365
@@ -6245,13 +6228,7 @@ msgstr "изменяемое содержимое"
 #: en/git-add.txt:372
 #, priority:300
 msgid "Modified content is represented by \"-\" lines (removing the old content)  followed by \"{plus}\" lines (adding the replacement content). You can prevent staging the modification by converting \"-\" lines to \" \", and removing \"{plus}\" lines. Beware that modifying only half of the pair is likely to introduce confusing changes to the index."
-msgstr ""
-"Изменяемое содержимое представляется в виде строк со знаком \"-\" (удаляемые "
-"старые строки) и следующих за ними строк со знаком \"{plus}\" (заменяющие "
-"строки). Вы можете предотвратить добавление данного фрагмента в индекс, "
-"заменив знак \"-\" на \" \" в первых строках и удалив вторые строки. "
-"Помните, что изменение только половины пары (\"-\" и \"{plus}\"), может "
-"привести к непонятным изменениям в индексе."
+msgstr "Изменяемое содержимое представляется в виде строк со знаком \"-\" (удаляемые старые строки) и следующих за ними строк со знаком \"{plus}\" (заменяющие строки). Вы можете предотвратить добавление данного фрагмента в индекс, заменив знак \"-\" на \" \" в первых строках и удалив вторые строки. Помните, что изменение только половины пары (\"-\" и \"{plus}\"), может привести к непонятным изменениям в индексе."
 
 #. type: Plain text
 #: en/git-add.txt:380
@@ -6363,7 +6340,7 @@ msgstr "Применение серии патчей из почтового с�
 
 #. type: Plain text
 #: en/git-am.txt:20
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git am' [--signoff] [--keep] [--[no-]keep-cr] [--[no-]utf8]\n"
 "\t [--[no-]3way] [--interactive] [--committer-date-is-author-date]\n"
@@ -6391,7 +6368,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-am.txt:29
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "(<mbox>|<Maildir>)..."
 msgstr ""
 
@@ -6927,7 +6904,7 @@ msgstr "Применение патча к файлам и/или индексу
 
 #. type: Plain text
 #: en/git-apply.txt:20
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git apply' [--stat] [--numstat] [--summary] [--check] [--index | --intent-to-add] [--3way]\n"
 "\t  [--apply] [--no-add] [--build-fake-ancestor=<file>] [-R | --reverse]\n"
@@ -6953,7 +6930,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-apply.txt:37
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<patch>..."
 msgstr ""
 
@@ -7367,7 +7344,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-archimport.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git archimport' [-h] [-v] [-o] [-a] [-f] [-T] [-D depth] [-t tempdir]\n"
 "               <archive/branch>[:<git-branch>] ...\n"
@@ -7531,7 +7508,7 @@ msgstr "Создание архива файлов из указанного д�
 
 #. type: Plain text
 #: en/git-archive.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git archive' [--format=<fmt>] [--list] [--prefix=<prefix>/] [<extra>]\n"
 "\t      [-o <file> | --output=<file>] [--worktree-attributes]\n"
@@ -7919,7 +7896,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bisect.txt:31
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 " git bisect start [--term-{old,good}=<term> --term-{new,bad}=<term>]\n"
 "\t\t  [--no-checkout] [<bad> [<good>...]] [--] [<paths>...]\n"
@@ -8114,7 +8091,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-bisect.txt:158
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git bisect new [<rev>...]\n"
 msgstr ""
 
@@ -8144,7 +8121,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bisect.txt:175
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If you would like to use your own terms instead of \"bad\"/\"good\" or \"new\"/\"old\", you can choose any names you like (except existing bisect subcommands like `reset`, `start`, ...) by starting the bisection using"
 msgstr ""
 
@@ -8584,7 +8561,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-bisect.txt:463
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git bisect start HEAD <known-good-commit> [ <boundary-commit> ... ] --no-checkout\n"
 "$ git bisect run sh -c '\n"
@@ -9052,7 +9029,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:26
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git branch' [--color[=<when>] | --no-color] [--show-current]\n"
 "\t[-v [--abbrev=<length> | --no-abbrev]]\n"
@@ -9097,7 +9074,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:61
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "The command's second form creates a new branch head named <branchname> which points to the current `HEAD`, or <start-point> if given. As a special case, for <start-point>, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -9295,7 +9272,7 @@ msgstr "показать список и отслеживаемых и лока�
 
 #. type: Plain text
 #: en/git-branch.txt:176
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "List branches.  With optional `<pattern>...`, e.g. `git branch --list 'maint-*'`, list only the branches that match the pattern(s)."
 msgstr ""
 
@@ -9541,7 +9518,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:291
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "Sort based on the key given. Prefix `-` to sort in descending order of the value. You may use the --sort=<key> option multiple times, in which case the last key becomes the primary key. The keys supported are the same as those in `git for-each-ref`. Sort order defaults to the value configured for the `branch.sort` variable if exists, or to sorting based on the full refname (including `refs/...` prefix). This lists detached HEAD (if present) first, then local branches and finally remote-tracking branches. See linkgit:git-config[1]."
 msgstr ""
 
@@ -9583,7 +9560,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-branch.txt:317
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git clone git://git.kernel.org/pub/scm/.../linux-2.6 my2.6\n"
 "$ cd my2.6\n"
@@ -9605,7 +9582,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-branch.txt:329
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git clone git://git.kernel.org/.../git.git my.git\n"
 "$ cd my.git\n"
@@ -9719,7 +9696,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bundle.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git bundle' create <file> <git-rev-list-args>\n"
 "'git bundle' verify <file>\n"
@@ -9795,7 +9772,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-bundle.txt:71
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<refname>...]"
 msgstr ""
 
@@ -10571,7 +10548,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-attr.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git check-attr' [-a | --all | <attr>...] [--] <pathname>...\n"
 "'git check-attr' --stdin [-z] [-a | --all | <attr>...]\n"
@@ -10812,7 +10789,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-ignore.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git check-ignore' [<options>] <pathname>...\n"
 "'git check-ignore' [<options>] --stdin\n"
@@ -10988,7 +10965,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-mailmap.txt:13
-#, fuzzy, no-wrap, priority:100
+#, fuzzy, ignore-ellipsis, no-wrap, priority:100
 msgid "'git check-mailmap' [<options>] <contact>...\n"
 msgstr "git check-mailmap [<опции>] <контакт>…"
 
@@ -11024,7 +11001,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout-index.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git checkout-index' [-u] [-q] [-a] [-f] [-n] [--prefix=<string>]\n"
 "\t\t   [--stage=<number>|all]\n"
@@ -11299,7 +11276,7 @@ msgstr "Переключение веток или восстановление 
 
 #. type: Plain text
 #: en/git-checkout.txt:18
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git checkout' [-q] [-f] [-m] [<branch>]\n"
 "'git checkout' [-q] [-f] [-m] --detach [<branch>]\n"
@@ -11410,7 +11387,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-checkout.txt:82
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git checkout' [<tree-ish>] [--] <pathspec>..."
 msgstr ""
 
@@ -11428,7 +11405,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-checkout.txt:98
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git checkout' (-p|--patch) [<tree-ish>] [--] [<pathspec>...]"
 msgstr ""
 
@@ -11770,7 +11747,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:326 en/git-switch.txt:58
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "As a special case, you may use `A...B` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -11800,7 +11777,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:337
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "As a special case, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -12371,7 +12348,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git cherry-pick' [--edit] [-n] [-m parent-number] [-s] [-x] [--ff]\n"
 "\t\t  [-S[<keyid>]] <commit>...\n"
@@ -12428,13 +12405,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-cherry-pick.txt:43 en/git-merge.txt:116 en/git-revert.txt:36 en/git-verify-commit.txt:27
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "<commit>..."
 msgstr ""
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:52
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Commits to cherry-pick.  For a more complete list of ways to spell commits, see linkgit:gitrevisions[7].  Sets of commits can be passed but no traversal is done by default, as if the `--no-walk` option was specified, see linkgit:git-rev-list[1]. Note that specifying a range will feed all <commit>... arguments to a single revision walk (see a later example that uses 'maint master..next')."
 msgstr ""
 
@@ -12464,7 +12441,7 @@ msgstr "-x"
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:78
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When recording the commit, append a line that says \"(cherry picked from commit ...)\" to the original commit message in order to indicate which commit this change was cherry-picked from.  This is done only for cherry picks without conflicts.  Do not use this option if you are cherry-picking from your private branch because the information is useless to the recipient.  If on the other hand you are cherry-picking between two publicly visible branches (e.g. backporting a fix to a maintenance branch for an older release from a development branch), adding this information can be useful."
 msgstr ""
 
@@ -12822,7 +12799,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:58
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git checkout -b topic origin/master\n"
 "# work and create some commits\n"
@@ -12858,7 +12835,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git log --graph --oneline --decorate --boundary origin/master...topic\n"
 "* 7654321 (origin/master) upstream tip commit\n"
@@ -12881,7 +12858,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:96
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git cherry origin/master topic\n"
 "- cccc000... commit C\n"
@@ -12909,7 +12886,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:126
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git log --graph --oneline --decorate --boundary origin/master...topic\n"
 "* 7654321 (origin/master) upstream tip commit\n"
@@ -12935,7 +12912,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:136
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git cherry origin/master topic base\n"
 "- cccc000... commit C\n"
@@ -12987,7 +12964,7 @@ msgstr "Удаление неотслеживаемых файлов из раб
 
 #. type: Plain text
 #: en/git-clean.txt:12
-#, fuzzy, no-wrap, priority:100
+#, fuzzy, ignore-ellipsis, no-wrap, priority:100
 msgid "'git clean' [-d] [-f] [-i] [-n] [-q] [-e <pattern>] [-x | -X] [--] <path>...\n"
 msgstr "git clean [-d] [-f] [-i] [-n] [-q] [-e <шаблон>] [-x | -X] [--] <пути>…"
 
@@ -13005,7 +12982,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-clean.txt:25
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If any optional `<path>...` arguments are given, only those paths are affected."
 msgstr ""
 
@@ -13616,7 +13593,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-clone.txt:306
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "$ git clone git://git.kernel.org/pub/scm/.../linux.git my-linux\n"
 "$ cd my-linux\n"
@@ -13646,7 +13623,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-clone.txt:325
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "$ git clone --reference /git/linux.git \\\n"
 "\tgit://git.kernel.org/pub/scm/.../linux.git \\\n"
@@ -13839,7 +13816,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-commit-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git commit-tree' <tree> [(-p <parent>)...]\n"
 "'git commit-tree' [(-p <parent>)...] [-S[<keyid>]] [(-m <message>)...]\n"
@@ -14040,7 +14017,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-commit.txt:17
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git commit' [-a | --interactive | --patch] [-s] [-v] [-u<mode>] [--amend]\n"
 "\t   [--dry-run] [(-c | -C | --fixup | --squash) <commit>]\n"
@@ -14460,7 +14437,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-commit.txt:248
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "\t$ git reset --soft HEAD^\n"
 "\t$ ... do something else to come up with the right tree ...\n"
@@ -14625,7 +14602,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-commit.txt:346 en/git-rm.txt:29
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "<file>..."
 msgstr ""
 
@@ -15602,7 +15579,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-config.txt:428
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "However, if you really only want to replace the line for the default proxy, i.e. the one without a \"for ...\" postfix, do something like this:"
 msgstr ""
 
@@ -16960,7 +16937,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-cvsserver.txt:26
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git-cvsserver' [<options>] [pserver|server] [<directory> ...]\n"
 msgstr ""
 
@@ -17658,7 +17635,7 @@ msgstr "Очень простой сервер для Git репозиторие
 
 #. type: Plain text
 #: en/git-daemon.txt:25
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git daemon' [--verbose] [--syslog] [--export-all]\n"
 "\t     [--timeout=<n>] [--init-timeout=<n>] [--max-connections=<n>]\n"
@@ -18224,7 +18201,7 @@ msgstr "Присвоение объекту удобочитаемое имя н
 
 #. type: Plain text
 #: en/git-describe.txt:14
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "'git describe' [--all] [--tags] [--contains] [--abbrev=<n>] [<commit-ish>...]\n"
 "'git describe' [--all] [--tags] [--contains] [--abbrev=<n>] --dirty[=<mark>]\n"
@@ -18251,7 +18228,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-describe.txt:37
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "<commit-ish>..."
 msgstr ""
 
@@ -18347,7 +18324,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-describe.txt:95
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Always output the long format (the tag, the number of commits and the abbreviated commit name) even when it matches a tag.  This is useful when you want to see parts of the commit object name in \"describe\" output, even when the commit in question happens to be a tagged version.  Instead of just emitting the tag name, it will describe such a commit as v1.2-0-gdeadbee (0th commit since tag v1.2 that points at object deadbee....)."
 msgstr ""
 
@@ -18525,7 +18502,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-files.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git diff-files' [-q] [-0|-1|-2|-3|-c|--cc] [<common diff options>] [<path>...]\n"
 msgstr ""
 
@@ -18597,7 +18574,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-index.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git diff-index' [-m] [--cached] [<common diff options>] <tree-ish> [<path>...]\n"
 msgstr ""
 
@@ -18736,7 +18713,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-index.txt:102
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "  torvalds@ppc970:~/v2.6/linux> git diff-index --abbrev HEAD\n"
 "  :100644 100664 7476bb... 000000...      kernel/sched.c\n"
@@ -18774,7 +18751,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-difftool.txt:12
-#, fuzzy, no-wrap, priority:100
+#, fuzzy, ignore-ellipsis, no-wrap, priority:100
 msgid "'git difftool' [<options>] [<commit> [<commit>]] [--] [<path>...]\n"
 msgstr "git difftool [<опции>] [<коммит> [<коммит>]] [--] [<путь>…]"
 
@@ -19086,7 +19063,7 @@ msgstr "Сравнение содержимого и режима двоичны
 
 #. type: Plain text
 #: en/git-diff-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git diff-tree' [--stdin] [-m] [-s] [-v] [--no-commit-id] [--pretty]\n"
 "\t      [-t] [-r] [-c | --cc] [--combined-all-paths] [--root]\n"
@@ -19119,7 +19096,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff-tree.txt:32 en/git-diff.txt:114 en/git-submodule.txt:422
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "<path>..."
 msgstr ""
 
@@ -19245,7 +19222,7 @@ msgstr "Вывод разницы между коммитами, коммито�
 
 #. type: Plain text
 #: en/git-diff.txt:17
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git diff' [<options>] [<commit>] [--] [<path>...]\n"
 "'git diff' [<options>] --cached [<commit>] [--] [<path>...]\n"
@@ -19262,7 +19239,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:24
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] [--] [<path>...]"
 msgstr ""
 
@@ -19286,7 +19263,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:41
-#, fuzzy, no-wrap, priority:280
+#, fuzzy, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] --cached [<commit>] [--] [<path>...]"
 msgstr "git difftool [<опции>] [<коммит> [<коммит>]] [--] [<путь>…]"
 
@@ -19298,7 +19275,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:51
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit> [--] [<path>...]"
 msgstr ""
 
@@ -19310,7 +19287,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:59
-#, fuzzy, no-wrap, priority:280
+#, fuzzy, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit> <commit> [--] [<path>...]"
 msgstr "git difftool [<опции>] [<коммит> [<коммит>]] [--] [<путь>…]"
 
@@ -19322,7 +19299,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:64
-#, fuzzy, no-wrap, priority:280
+#, fuzzy, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit>..<commit> [--] [<path>...]"
 msgstr "git difftool [<опции>] [<коммит> [<коммит>]] [--] [<путь>…]"
 
@@ -19334,13 +19311,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:70
-#, fuzzy, no-wrap, priority:280
+#, fuzzy, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit>\\...<commit> [--] [<path>...]"
 msgstr "git difftool [<опции>] [<коммит> [<коммит>]] [--] [<путь>…]"
 
 #. type: Plain text
 #: en/git-diff.txt:77
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "This form is to view the changes on the branch containing and up to the second <commit>, starting at a common ancestor of both <commit>.  \"git diff A\\...B\" is equivalent to \"git diff $(git merge-base A B) B\".  You can omit any one of <commit>, which has the same effect as using HEAD instead."
 msgstr ""
 
@@ -19352,7 +19329,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:89
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "For a more complete list of ways to spell <commit>, see \"SPECIFYING REVISIONS\" section in linkgit:gitrevisions[7].  However, \"diff\" is about comparing two _endpoints_, not ranges, and the range notations (\"<commit>..<commit>\" and \"<commit>\\...<commit>\") do not mean a range as defined in the \"SPECIFYING RANGES\" section in linkgit:gitrevisions[7]."
 msgstr ""
 
@@ -19460,7 +19437,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-diff.txt:160
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git diff topic master    <1>\n"
 "$ git diff topic..master   <2>\n"
@@ -19780,7 +19757,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:143
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<git-rev-list-args>...]"
 msgstr ""
 
@@ -19861,7 +19838,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-fast-export.txt:215
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git init anon-repo\n"
 "$ cd anon-repo\n"
@@ -22171,7 +22148,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch-pack.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git fetch-pack' [--all] [--quiet|-q] [--keep|-k] [--thin] [--include-tag]\n"
 "\t[--upload-pack=<git-upload-pack>]\n"
@@ -22325,7 +22302,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fetch-pack.txt:117 en/git-ls-remote.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<refs>..."
 msgstr ""
 
@@ -22355,7 +22332,7 @@ msgstr "Загрузка объектов и ссылок из другого р
 
 #. type: Plain text
 #: en/git-fetch.txt:16
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git fetch' [<options>] [<repository> [<refspec>...]]\n"
 "'git fetch' [<options>] <group>\n"
@@ -22696,7 +22673,7 @@ msgstr "--summary"
 
 #. type: Plain text
 #: en/git-fetch.txt:226
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "For a successfully fetched ref, the summary shows the old and new values of the ref in a form suitable for using as an argument to `git log` (this is `<old>..<new>` in most cases, and `<old>...<new>` for forced non-fast-forward updates)."
 msgstr ""
 
@@ -22818,7 +22795,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:18
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git filter-branch' [--setup <command>] [--subdirectory-filter <directory>]\n"
 "\t[--env-filter <command>] [--tree-filter <command>]\n"
@@ -22957,7 +22934,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:117
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for rewriting the index.  It is similar to the tree filter but does not check out the tree, which makes it much faster.  Frequently used with `git rm --cached --ignore-unmatch ...`, see EXAMPLES below.  For hairy cases, see linkgit:git-update-index[1]."
 msgstr ""
 
@@ -22969,7 +22946,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:125
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for rewriting the commit's parent list.  It will receive the parent string on stdin and shall output the new parent string on stdout.  The parent string is in the format described in linkgit:git-commit-tree[1]: empty for the initial commit, \"-p parent\" for a normal commit and \"-p parent1 -p parent2 -p parent3 ...\" for a merge commit."
 msgstr ""
 
@@ -22993,7 +22970,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:138
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for performing the commit.  If this filter is specified, it will be called instead of the 'git commit-tree' command, with arguments of the form \"<TREE_ID> [(-p <PARENT_COMMIT_ID>)...]\" and the log message on stdin.  The commit id is expected on stdout."
 msgstr ""
 
@@ -23095,7 +23072,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-filter-branch.txt:207
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<rev-list options>..."
 msgstr ""
 
@@ -23356,7 +23333,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-filter-branch.txt:388
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git filter-branch ... C..H\n"
 msgstr ""
 
@@ -23368,7 +23345,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-filter-branch.txt:395
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "git filter-branch ... C..H --not D\n"
 "git filter-branch ... D..H --not C\n"
@@ -23607,7 +23584,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git for-each-ref' [--count=<count>] [--shell|--perl|--python|--tcl]\n"
 "\t\t   [(--sort=<key>)...] [--format=<format>] [<pattern>...]\n"
@@ -23624,7 +23601,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-for-each-ref.txt:29 en/git-show-ref.txt:88
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<pattern>..."
 msgstr ""
 
@@ -23912,7 +23889,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:197
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Left-, middle-, or right-align the content between %(align:...) and %(end). The \"align:\" is followed by `width=<width>` and `position=<position>` in any order separated by a comma, where the `<position>` is either left, right or middle, default being left and `<width>` is the total length of the content with alignment. For brevity, the \"width=\" and/or \"position=\" prefixes may be omitted, and bare <width> and <position> used instead.  For instance, `%(align:<width>,<position>)`. If the contents length is more than the width then no alignment is performed. If used with `--quote` everything in between %(align:...) and %(end) is quoted, but if nested then only the topmost level performs quoting."
 msgstr ""
 
@@ -23924,7 +23901,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:210
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Used as %(if)...%(then)...%(end) or %(if)...%(then)...%(else)...%(end).  If there is an atom with value or string literal after the %(if) then everything after the %(then) is printed, else if the %(else) atom is used, then everything after %(else) is printed. We ignore space when evaluating the string before %(then), this is useful when we use the %(HEAD) atom which prints either \"*\" or \" \" and we want to apply the 'if' condition only on the 'HEAD' ref.  Append \":equals=<string>\" or \":notequals=<string>\" to compare the value between the %(if:...) and %(then) atoms with the given string."
 msgstr ""
 
@@ -24145,7 +24122,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:361
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "An example to show the usage of %(if)...%(then)...%(else)...%(end).  This prefixes the current branch with a star."
 msgstr ""
 
@@ -24157,7 +24134,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:369
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "An example to show the usage of %(if)...%(then)...%(end).  This prints the authorname, if present."
 msgstr ""
 
@@ -24803,7 +24780,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:372
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "Do the same for ia64 so we can have sleek & trim looking\n"
 "...\n"
@@ -24811,7 +24788,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:380
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Typically it will be placed in a MUA's drafts folder, edited to add timely commentary that should not go in the changelog after the three dashes, and then sent as a message whose body, in our example, starts with \"arch/arm config files were...\".  On the receiving end, readers can save interesting patches in a UNIX mailbox and apply them with linkgit:git-am[1]."
 msgstr ""
 
@@ -24823,7 +24800,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:390
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "...\n"
 "> So we should do such-and-such.\n"
@@ -24845,7 +24822,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:398
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "arch/arm config files were slimmed down using a python script\n"
 "...\n"
@@ -25019,7 +24996,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:499
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Configure your mail server composition as plain text: Edit...Account Settings...Composition & Addressing, uncheck \"Compose Messages in HTML\"."
 msgstr ""
 
@@ -25156,7 +25133,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:573
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Use Message -> Insert file... and insert the patch."
 msgstr ""
 
@@ -25331,7 +25308,7 @@ msgstr "Проверка связности и валидности объект
 
 #. type: Plain text
 #: en/git-fsck-objects.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git fsck-objects' ...\n"
 msgstr ""
 
@@ -25719,7 +25696,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-gc.txt:55
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Once housekeeping is triggered by exceeding the limits of configuration options such as `gc.auto` and `gc.autoPackLimit`, all other housekeeping tasks (e.g. rerere, working trees, reflog...) will be performed as well."
 msgstr ""
 
@@ -25893,7 +25870,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-grep.txt:32
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git grep' [-a | --text] [-I] [--textconv] [-i | --ignore-case] [-w | --word-regexp]\n"
 "\t   [-v | --invert-match] [-h|-H] [--full-name]\n"
@@ -26501,7 +26478,7 @@ msgstr "--not"
 
 #. type: Labeled list
 #: en/git-grep.txt:284
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "( ... )"
 msgstr ""
 
@@ -26531,7 +26508,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-grep.txt:300
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<tree>..."
 msgstr ""
 
@@ -26849,7 +26826,7 @@ msgstr "Вычисление идентификатора объекта и во
 
 #. type: Plain text
 #: en/git-hash-object.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git hash-object' [-t <type>] [-w] [--path=<file>|--no-filters] [--stdin [--literally]] [--] <file>...\n"
 "'git hash-object' [-t <type>] [-w] --stdin-paths [--no-filters]\n"
@@ -26979,7 +26956,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-help.txt:38
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Note that `git --help ...` is identical to `git help ...` because the former is internally converted into the latter."
 msgstr ""
 
@@ -27429,7 +27406,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:102
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tAuthType Basic\n"
 "\tAuthName \"Git Access\"\n"
@@ -27447,7 +27424,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:115
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "<LocationMatch \"^/git/.*/git-receive-pack$\">\n"
 "\tAuthType Basic\n"
@@ -27471,7 +27448,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:136
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "<Location /git/private>\n"
 "\tAuthType Basic\n"
@@ -27621,7 +27598,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:231
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "auth.require = (\n"
 "\t\"/\" => (\n"
@@ -27824,7 +27801,7 @@ msgstr "Отправка объектов в другой репозиторий
 
 #. type: Plain text
 #: en/git-http-push.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git http-push' [--all] [--dry-run] [--force] [--verbose] <url> <ref> [<ref>...]\n"
 msgstr ""
 
@@ -27893,7 +27870,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-http-push.txt:54 en/git-send-pack.txt:98
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<ref>..."
 msgstr ""
 
@@ -28758,7 +28735,7 @@ msgstr "Добавление или разбор структурированн�
 
 #. type: Plain text
 #: en/git-interpret-trailers.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git interpret-trailers' [<options>] [(--trailer <token>[(=|:)<value>])...] [<file>...]\n"
 "'git interpret-trailers' [<options>] [--parse] [<file>...]\n"
@@ -29428,7 +29405,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-log.txt:13
-#, fuzzy, no-wrap, priority:260
+#, fuzzy, ignore-ellipsis, no-wrap, priority:260
 msgid "'git log' [<options>] [<revision range>] [[--] <path>...]\n"
 msgstr "git log [<опции>] [<диапазон-редакций>] [[--] <путь>…]"
 
@@ -29524,7 +29501,7 @@ msgstr "--full-diff"
 
 #. type: Plain text
 #: en/git-log.txt:63
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Without this flag, `git log -p <path>...` shows commits that touch the specified paths, and diffs about the same specified paths.  With this, the full diff is shown for commits that touch the specified paths; this means that \"<path>...\" limits only commits, and doesn't limit diff for those commits."
 msgstr ""
 
@@ -29578,7 +29555,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-log.txt:93 en/git-shortlog.txt:72
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "[--] <path>..."
 msgstr ""
 
@@ -29854,7 +29831,7 @@ msgstr "Вывод информации о файлах в индексе и в 
 
 #. type: Plain text
 #: en/git-ls-files.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-files' [-z] [-t] [-v] [-f]\n"
 "\t\t(--[cached|deleted|others|ignored|stage|unmerged|killed|modified])*\n"
@@ -30335,7 +30312,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-remote.txt:15
-#, fuzzy, no-wrap, priority:100
+#, fuzzy, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-remote' [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
 "\t      [-q | --quiet] [--exit-code] [--get-url] [--sort=<key>]\n"
@@ -30443,7 +30420,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-remote.txt:91
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When unspecified, all references, after filtering done with --heads and --tags, are shown.  When <refs>... are specified, only references matching the given patterns are displayed."
 msgstr ""
 
@@ -30488,7 +30465,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-tree' [-d] [-r] [-t] [-l] [-z]\n"
 "\t    [--name-only] [--name-status] [--full-name] [--full-tree] [--abbrev[=<n>]]\n"
@@ -30569,7 +30546,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-ls-tree.txt:76
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<path>...]"
 msgstr ""
 
@@ -30779,7 +30756,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mailsplit.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git mailsplit' [-b] [-f<nn>] [-d<prec>] [--keep-cr] [--mboxrd]\n"
 "\t\t-o<directory> [--] [(<mbox>|<Maildir>)...]\n"
@@ -30901,7 +30878,7 @@ msgstr "Поиск подходящих общих предков для воз�
 
 #. type: Plain text
 #: en/git-merge-base.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git merge-base' [-a|--all] <commit> <commit>...\n"
 "'git merge-base' [-a|--all] --octopus <commit>...\n"
@@ -31098,7 +31075,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:139
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tA=$(git rev-parse --verify A)\n"
 "\tif test \"$A\" = \"$(git merge-base A B)\"\n"
@@ -31115,7 +31092,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:146
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tif git merge-base --is-ancestor A B\n"
 "\tthen\n"
@@ -31602,7 +31579,7 @@ msgstr "Запуск инструментов разрешения конфли�
 
 #. type: Plain text
 #: en/git-mergetool.txt:12
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git mergetool' [--tool=<tool>] [-y | --[no-]prompt] [<file>...]\n"
 msgstr ""
 
@@ -31764,7 +31741,7 @@ msgstr "Объединение одной или нескольких истор
 
 #. type: Plain text
 #: en/git-merge.txt:17
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git merge' [-n] [--stat] [--no-commit] [--squash] [--[no-]edit]\n"
 "\t[-s <strategy>] [-X <strategy-option>] [-S[<keyid>]]\n"
@@ -32357,7 +32334,7 @@ msgstr "Перемещение или переименование файла, �
 
 #. type: Plain text
 #: en/git-mv.txt:13
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git mv' <options>... <args>...\n"
 msgstr ""
 
@@ -32369,7 +32346,7 @@ msgstr "Перемещение или переименование файла, �
 
 #. type: Plain text
 #: en/git-mv.txt:20
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 " git mv [-v] [-f] [-n] [-k] <source> <destination>\n"
 " git mv [-v] [-f] [-n] [-k] <source> ... <destination directory>\n"
@@ -32437,7 +32414,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-name-rev.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git name-rev' [--tags] [--refs=<pattern>]\n"
 "\t       ( --all | --stdin | <commit-ish>... )\n"
@@ -32555,7 +32532,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-notes.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git notes' [list [<object>]]\n"
 "'git notes' add [-f] [--allow-empty] [-F <file> | -m <msg> | (-c | -C) <object>] [<object>]\n"
@@ -32891,7 +32868,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-notes.txt:229
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Commit notes are blobs containing extra information about an object (usually information to supplement a commit's message).  These blobs are taken from notes refs.  A notes ref is usually a branch which contains \"files\" whose paths are the object names for the objects they describe, with some directory separators included for performance reasons footnote:[Permitted pathnames have the form 'ab'`/`'cd'`/`'ef'`/`'...'`/`'abcdef...': a sequence of directory names of two hexadecimal digits each followed by a filename with the rest of the object ID.]."
 msgstr ""
 
@@ -32957,7 +32934,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-notes.txt:288
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git notes add -m 'Tested-by: Johannes Sixt <j6t@kdbg.org>' 72a144e2\n"
 "$ git show -s 72a144e\n"
@@ -33176,7 +33153,7 @@ msgstr "Импорт и отправка в репозитории Perforce"
 
 #. type: Plain text
 #: en/git-p4.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git p4 clone' [<sync options>] [<clone options>] <p4 depot path>...\n"
 "'git p4 sync' [<sync options>] [<p4 depot path>...]\n"
@@ -34009,7 +33986,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-p4.txt:445
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The full syntax for a p4 view is documented in 'p4 help views'.  'git p4' knows only a subset of the view syntax.  It understands multi-line mappings, overlays with '+', exclusions with '-' and double-quotes around whitespace.  Of the possible wildcards, 'git p4' only handles '...', and only when it is at the end of the path.  'git p4' will complain if it encounters an unhandled wildcard."
 msgstr ""
 
@@ -34051,7 +34028,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-p4.txt:475
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "//depot/main/...\n"
 "//depot/branch1/...\n"
@@ -34065,7 +34042,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-p4.txt:480
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "//depot/main/... //depot/branch1/...\n"
 msgstr ""
 
@@ -35182,7 +35159,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-pack-redundant.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git pack-redundant' [ --verbose ] [ --alt-odb ] < --all | .pack filename ... >\n"
 msgstr ""
 
@@ -35482,7 +35459,7 @@ msgstr "Очистка всех недостижимых объектов из �
 
 #. type: Plain text
 #: en/git-prune.txt:13
-#, fuzzy, no-wrap, priority:100
+#, fuzzy, ignore-ellipsis, no-wrap, priority:100
 msgid "'git prune' [-n] [-v] [--progress] [--expire <time>] [--] [<head>...]\n"
 msgstr "git prune [-n] [-v] [--progress] [--expire <время>] [--] [<редакция>…]"
 
@@ -35536,7 +35513,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-prune.txt:54
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<head>..."
 msgstr ""
 
@@ -35590,7 +35567,7 @@ msgstr "Извлечение изменений и объединение с д�
 
 #. type: Plain text
 #: en/git-pull.txt:13
-#, fuzzy, no-wrap, priority:220
+#, fuzzy, ignore-ellipsis, no-wrap, priority:220
 msgid "'git pull' [<options>] [<repository> [<refspec>...]]\n"
 msgstr "git pull [<опции>] [<репозиторий> [<спецификатор-ссылки>…]]"
 
@@ -35938,7 +35915,7 @@ msgstr "Обновление внешних ссылок и связанных �
 
 #. type: Plain text
 #: en/git-push.txt:18
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git push' [--all | --mirror | --tags] [--follow-tags] [--atomic] [-n | --dry-run] [--receive-pack=<git-receive-pack>]\n"
 "\t   [--repo=<repository>] [-f | --force] [-d | --delete] [--prune] [-v | --verbose]\n"
@@ -35968,7 +35945,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:39
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "When the command line does not specify what to push with `<refspec>...` arguments or `--all`, `--mirror`, `--tags` options, the command finds the default `<refspec>` by consulting `remote.*.push` configuration, and if it is not found, honors `push.default` configuration to decide what to push (See linkgit:git-config[1] for the meaning of `push.default`)."
 msgstr ""
 
@@ -35992,7 +35969,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:56
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "<refspec>..."
 msgstr ""
 
@@ -36352,7 +36329,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:343
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "Note that `--force` applies to all the refs that are pushed, hence using it with `push.default` set to `matching` or with multiple push destinations configured with `remote.*.push` may overwrite refs other than the current branch (including local refs that are strictly behind their remote counterpart).  To force a push to only one branch, use a `+` in front of the refspec to push (e.g `git push origin +master` to force a push to the `master` branch). See the `<refspec>...` section above for details."
 msgstr ""
 
@@ -36484,7 +36461,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:445
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "For a successfully pushed ref, the summary shows the old and new values of the ref in a form suitable for using as an argument to `git log` (this is `<old>..<new>` in most cases, and `<old>...<new>` for forced non-fast-forward updates)."
 msgstr ""
 
@@ -36745,7 +36722,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:616
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "See the section describing `<refspec>...` above for a discussion of the matching semantics."
 msgstr ""
 
@@ -37446,7 +37423,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-read-tree.txt:357
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git fetch git://.... linus\n"
 "$ LT=`git rev-parse FETCH_HEAD`\n"
@@ -37500,7 +37477,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-read-tree.txt:405
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "'git read-tree' and other merge-based commands ('git merge', 'git checkout'...) can help maintaining the skip-worktree bitmap and working directory update. `$GIT_DIR/info/sparse-checkout` is used to define the skip-worktree reference bitmap. When 'git read-tree' needs to update the working directory, it resets the skip-worktree bit in the index based on this file, which uses the same syntax as .gitignore files.  If an entry matches a pattern in this file, skip-worktree will not be set on that entry. Otherwise, skip-worktree will be set."
 msgstr ""
 
@@ -37880,7 +37857,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:219
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "As a special case, you may use \"A\\...B\" as a shortcut for the merge base of A and B if there is exactly one merge base. You can leave out at most one of A and B, in which case it defaults to HEAD."
 msgstr ""
 
@@ -38144,7 +38121,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:430
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "It is currently only possible to recreate the merge commits using the `recursive` merge strategy; Different merge strategies can be used only via explicit `exec git merge -s <strategy> [...]` commands."
 msgstr ""
 
@@ -38198,7 +38175,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:457
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "\tgit rebase -i --exec \"cmd1 && cmd2 && ...\"\n"
 msgstr ""
 
@@ -38210,7 +38187,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:461
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "\tgit rebase -i --exec \"cmd1\" --exec \"cmd2\" --exec ...\n"
 msgstr ""
 
@@ -38246,7 +38223,7 @@ msgstr "--no-autosquash"
 
 #. type: Plain text
 #: en/git-rebase.txt:495
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When the commit log message begins with \"squash! ...\" (or \"fixup! ...\"), and there is already a commit in the todo list that matches the same `...`, automatically modify the todo list of rebase -i so that the commit marked for squashing comes right after the commit to be modified, and change the action of the moved commit from `pick` to `squash` (or `fixup`).  A commit matches the `...` if the commit subject matches, or if the `...` refers to the commit's hash. As a fall-back, partial matches of the commit subject work, too.  The recommended way to create fixup/squash commits is by using the `--fixup`/`--squash` options of linkgit:git-commit[1]."
 msgstr ""
 
@@ -38573,7 +38550,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:636
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "pick deadbee The oneline of this commit\n"
 "pick fa1afe1 The oneline of the next commit\n"
@@ -38677,7 +38654,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:710
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "pick deadbee Implement feature XXX\n"
 "fixup f1a5c00 Fix to feature XXX\n"
@@ -38696,7 +38673,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:720
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The \"exec\" command launches the command in a shell (the one specified in `$SHELL`, or the default shell if `$SHELL` is not set), so you can use shell features (like \"cd\", \">\", \";\" ...). The command is run from the root of the working tree."
 msgstr ""
 
@@ -38840,7 +38817,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:815
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "    o---o---o---o---o---o---o---o  master\n"
 "\t \\\t\t\t \\\n"
@@ -39638,7 +39615,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reflog.txt:27
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git reflog' ['show'] [log-options] [<ref>]\n"
 "'git reflog expire' [--expire=<time>] [--expire-unreachable=<time>]\n"
@@ -39825,7 +39802,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-remote-ext.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git remote add <nick> \"ext::<command>[ <arguments>...]\"\n"
 msgstr ""
 
@@ -39963,7 +39940,7 @@ msgstr "GIT_EXT_SERVICE"
 
 #. type: Plain text
 #: en/git-remote-ext.txt:70
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Set to long name (git-upload-pack, etc...) of service helper needs to invoke."
 msgstr ""
 
@@ -39975,7 +39952,7 @@ msgstr "GIT_EXT_SERVICE_NOPREFIX"
 
 #. type: Plain text
 #: en/git-remote-ext.txt:74
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Set to long name (upload-pack, etc...) of service helper needs to invoke."
 msgstr ""
 
@@ -40155,7 +40132,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-remote.txt:25
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git remote' [-v | --verbose]\n"
 "'git remote add' [-t <branch>] [-m <master>] [-f] [--[no-]tags] [--mirror=<fetch|push>] <name> <url>\n"
@@ -40474,7 +40451,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-remote.txt:235
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "$ git remote\n"
 "origin\n"
@@ -40718,7 +40695,7 @@ msgstr "Создание, вывод списка, удаление ссылок
 
 #. type: Plain text
 #: en/git-replace.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git replace' [-f] <object> <replacement>\n"
 "'git replace' [-f] --edit <object>\n"
@@ -40838,13 +40815,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-replace.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--graft <commit> [<parent>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/git-replace.txt:93
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Create a graft commit. A new commit is created with the same content as <commit> except that its parents will be [<parent>...] instead of <commit>'s parents. A replacement ref is then created to replace <commit> with the newly created commit. Use `--convert-graft-file` to convert a `$GIT_DIR/info/grafts` file and use replace refs instead."
 msgstr ""
 
@@ -41266,7 +41243,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rerere.txt:121
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git switch topic\n"
 "\t$ git merge master\n"
@@ -41298,7 +41275,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rerere.txt:145
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git switch topic\n"
 "\t$ git merge master\n"
@@ -41403,7 +41380,7 @@ msgstr "Сброс текущего состояния HEAD на указанн�
 
 #. type: Plain text
 #: en/git-reset.txt:14
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git reset' [-q] [<tree-ish>] [--] <paths>...\n"
 "'git reset' (--patch | -p) [<tree-ish>] [--] [<paths>...]\n"
@@ -41418,7 +41395,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-reset.txt:22
-#, fuzzy, no-wrap, priority:280
+#, fuzzy, ignore-ellipsis, no-wrap, priority:280
 msgid "'git reset' [-q] [<tree-ish>] [--] <paths>..."
 msgstr "git reset [-q] [<указатель-дерева>] [--] <пути>…"
 
@@ -41430,7 +41407,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reset.txt:30
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "This means that `git reset <paths>` is the opposite of `git add <paths>`. This command is equivalent to `git restore [--source=<tree-ish>] --staged <paths>...`."
 msgstr ""
 
@@ -41442,7 +41419,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-reset.txt:38
-#, fuzzy, no-wrap, priority:280
+#, fuzzy, ignore-ellipsis, no-wrap, priority:280
 msgid "'git reset' (--patch | -p) [<tree-ish>] [--] [<paths>...]"
 msgstr "git reset --patch [<указатель-дерева>] [--] [<пути>…]"
 
@@ -41597,7 +41574,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:138
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git commit ...\n"
 "$ git reset --soft HEAD^      <1>\n"
@@ -41670,7 +41647,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:170
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git commit ...\n"
 "$ git reset --hard HEAD~3   <1>\n"
@@ -41690,7 +41667,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:190
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git pull                         <1>\n"
 "Auto-merging nitfol\n"
@@ -41735,7 +41712,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:215
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git pull                         <1>\n"
 "Auto-merging nitfol\n"
@@ -41861,7 +41838,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:289
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git tag start\n"
 "$ git switch -c branch1\n"
@@ -41904,7 +41881,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:317
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git reset -N HEAD^                        <1>\n"
 "$ git add -p                                <2>\n"
@@ -42130,7 +42107,7 @@ msgstr "Переключение веток или восстановление 
 
 #. type: Plain text
 #: en/git-restore.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git restore' [<options>] [--source=<tree>] [--staged] [--worktree] <pathspec>...\n"
 "'git restore' (-p|--patch) [<options>] [--source=<tree>] [--staged] [--worktree] [<pathspec>...]\n"
@@ -42383,7 +42360,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-revert.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git revert' [--[no-]edit] [-n] [-m parent-number] [-s] [-S[<keyid>]] <commit>...\n"
 "'git revert' (--continue | --skip | --abort | --quit)\n"
@@ -42487,7 +42464,7 @@ msgstr "Вывод списка объектов коммита в обратн�
 
 #. type: Plain text
 #: en/git-rev-list.txt:65
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git rev-list' [ --max-count=<number> ]\n"
 "\t     [ --skip=<number> ]\n"
@@ -42590,13 +42567,13 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-list.txt:102
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Another special notation is \"'<commit1>'...'<commit2>'\" which is useful for merges.  The resulting set of commits is the symmetric difference between the two operands.  The following two commands are equivalent:"
 msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-list.txt:106
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git rev-list A B --not $(git merge-base --all A B)\n"
 "\t$ git rev-list A...B\n"
@@ -42622,7 +42599,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-parse.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git rev-parse' [<options>] <args>...\n"
 msgstr ""
 
@@ -43106,7 +43083,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-parse.txt:253
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Resolve \"$GIT_DIR/<path>\" and takes other path relocation variables such as $GIT_OBJECT_DIRECTORY, $GIT_INDEX_FILE... into account. For example, if $GIT_OBJECT_DIRECTORY is set to /foo/bar then \"git rev-parse --git-path objects/abc\" returns /foo/bar/abc."
 msgstr ""
 
@@ -43214,7 +43191,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:290
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<args>..."
 msgstr ""
 
@@ -43346,7 +43323,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:364
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "OPTS_SPEC=\"\\\n"
 "some-command [<options>] <args>...\n"
@@ -43404,7 +43381,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:389
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "usage: some-command [<options>] <args>...\n"
 msgstr ""
 
@@ -43416,7 +43393,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:397
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "    -h, --help            show the help\n"
 "    --foo                 some nifty option --foo\n"
@@ -43427,7 +43404,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:400
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "An option group Header\n"
 "    -C[...]               option C with an optional argument\n"
@@ -43532,7 +43509,7 @@ msgstr "Удаление файлов из рабочего каталога и 
 
 #. type: Plain text
 #: en/git-rm.txt:12
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git rm' [-f | --force] [-n] [-r] [--cached] [--ignore-unmatch] [--quiet] [--] <file>...\n"
 msgstr ""
 
@@ -43760,7 +43737,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-email.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git send-email' [<options>] <file|directory|rev-list options>...\n"
 "'git send-email' --dump-aliases\n"
@@ -43828,7 +43805,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:53
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--bcc=<address>,..."
 msgstr ""
 
@@ -43846,7 +43823,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:59
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--cc=<address>,..."
 msgstr ""
 
@@ -43930,7 +43907,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-email.txt:110
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "  [PATCH 0/2] Here is what I did...\n"
 "    [PATCH 1/2] Clean up and tests\n"
@@ -43961,7 +43938,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:119
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--to=<address>,..."
 msgstr ""
 
@@ -44093,7 +44070,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-send-email.txt:188
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "$ git send-email --smtp-auth=\"PLAIN LOGIN GSSAPI\" ...\n"
 msgstr ""
 
@@ -44789,7 +44766,7 @@ msgstr "Отправка объектов в другой репозиторий
 
 #. type: Plain text
 #: en/git-send-pack.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git send-pack' [--all] [--dry-run] [--force] [--receive-pack=<git-receive-pack>]\n"
 "\t\t[--verbose] [--thin] [--atomic]\n"
@@ -45162,7 +45139,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-shortlog.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "'git shortlog' [<options>] [<revision range>] [[--] <path>...]\n"
 "git log --pretty=short | 'git shortlog' [<options>]\n"
@@ -45290,7 +45267,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show-branch.txt:17
-#, fuzzy, no-wrap, priority:100
+#, fuzzy, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git show-branch' [-a|--all] [-r|--remotes] [--topo-order | --date-order]\n"
 "\t\t[--current] [--color[=<when>] | --no-color] [--sparse]\n"
@@ -45655,7 +45632,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show-ref.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git show-ref' [-q|--quiet] [--verify] [--head] [-d|--dereference]\n"
 "\t     [-s|--hash[=<n>]] [--abbrev[=<n>]] [--tags]\n"
@@ -45803,7 +45780,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-show-ref.txt:111
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git show-ref --head --dereference\n"
 "832e76a9899f560a90ffd62ae2ce83bbeff58f54 HEAD\n"
@@ -45824,7 +45801,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-show-ref.txt:121
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git show-ref --heads --hash\n"
 "2e3ba0114a1f52b47df29743d6915d056be13278\n"
@@ -45945,7 +45922,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show.txt:13
-#, fuzzy, no-wrap, priority:260
+#, fuzzy, ignore-ellipsis, no-wrap, priority:260
 msgid "'git show' [<options>] [<object>...]\n"
 msgstr "git show [<опции>] <объект>…"
 
@@ -45993,7 +45970,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-show.txt:37
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "<object>..."
 msgstr ""
 
@@ -46251,7 +46228,7 @@ msgstr "Добавление содержимого файлов в индекс
 
 #. type: Plain text
 #: en/git-stage.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git stage' args...\n"
 msgstr ""
 
@@ -46275,7 +46252,7 @@ msgstr "Спрятать изменения в изменённом рабоче
 
 #. type: Plain text
 #: en/git-stash.txt:22
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git stash' list [<options>]\n"
 "'git stash' show [<options>] [<stash>]\n"
@@ -46298,7 +46275,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stash.txt:38
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "The modifications stashed away by this command can be listed with `git stash list`, inspected with `git stash show`, and restored (potentially on top of a different commit) with `git stash apply`.  Calling `git stash` without any arguments is equivalent to `git stash push`.  A stash is by default listed as \"WIP on 'branchname' ...\", but you can give a more descriptive message on the command line when you create one."
 msgstr ""
 
@@ -46310,7 +46287,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-stash.txt:49
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "push [-p|--patch] [-k|--[no-]keep-index] [-u|--include-untracked] [-a|--all] [-q|--quiet] [-m|--message <message>] [--] [<pathspec>...]"
 msgstr ""
 
@@ -46382,7 +46359,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:104
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "stash@{0}: WIP on submit: 6ebd0e2... Update git-stash documentation\n"
 "stash@{1}: On master: 9cc0589... Add git-stash\n"
@@ -46555,7 +46532,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:227
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git pull\n"
 " ...\n"
@@ -46573,7 +46550,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:246
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git switch -c my_wip\n"
@@ -46594,7 +46571,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:257
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git stash\n"
@@ -46618,7 +46595,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:275
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git add --patch foo            # add just first part to the index\n"
@@ -46672,7 +46649,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-status.txt:13
-#, fuzzy, no-wrap, priority:280
+#, fuzzy, ignore-ellipsis, no-wrap, priority:280
 msgid "'git status' [<options>...] [--] [<pathspec>...]\n"
 msgstr "git status [<опции>] [--] <спецификатор-пути>…"
 
@@ -47149,7 +47126,7 @@ msgstr ""
 
 #. type: delimited block .
 #: en/git-status.txt:345
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "Field       Meaning\n"
 "--------------------------------------------------------\n"
@@ -47471,7 +47448,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-submodule.txt:23
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git submodule' [--quiet] [--cached]\n"
 "'git submodule' [--quiet] add [<options>] [--] <repository> [<path>]\n"
@@ -47542,7 +47519,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:74
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "status [--cached] [--recursive] [--] [<path>...]"
 msgstr ""
 
@@ -47566,7 +47543,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:91
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "init [--] [<path>...]"
 msgstr ""
 
@@ -47596,7 +47573,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:114
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "deinit [-f|--force] (--all|[--] <path>...)"
 msgstr ""
 
@@ -47626,7 +47603,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:132
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "update [--init] [--remote] [-N|--no-fetch] [--[no-]recommend-shallow] [-f|--force] [--checkout|--rebase|--merge] [--reference <repository>] [--depth <depth>] [--recursive] [--jobs <n>] [--] [<path>...]"
 msgstr ""
 
@@ -47750,7 +47727,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:182
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "summary [--cached|--files] [(-n|--summary-limit) <n>] [commit] [--] [<path>...]"
 msgstr ""
 
@@ -47792,7 +47769,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:224
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "sync [--recursive] [--] [<path>...]"
 msgstr ""
 
@@ -48318,7 +48295,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:127
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Fetch unfetched revisions from the Subversion remote we are tracking.  The name of the [svn-remote \"...\"] section in the $GIT_DIR/config file may be specified as an optional command-line argument."
 msgstr ""
 
@@ -48764,7 +48741,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:366
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "is supported, non-numeric args are not: HEAD, NEXT, BASE, PREV, etc ..."
 msgstr ""
 
@@ -49665,7 +49642,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-svn.txt:876
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "# Clone a repo (like git clone):\n"
 "\tgit svn clone http://svn.example.com/project/trunk\n"
@@ -49718,7 +49695,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-svn.txt:924
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "# Do the initial import on a server\n"
 "\tssh server \"cd /pub && git svn clone http://svn.example.com/project [options...]\"\n"
@@ -50429,7 +50406,7 @@ msgstr "Создание, вывод списка, удаление или пр�
 
 #. type: Plain text
 #: en/git-tag.txt:20
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git tag' [-a | -s | -u <keyid>] [-f] [-m <msg> | -F <file>] [-e]\n"
 "\t<tagname> [<commit> | <object>]\n"
@@ -50575,7 +50552,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-tag.txt:103
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "List tags. With optional `<pattern>...`, e.g. `git tag --list 'v-*'`, list only the tags that match the pattern(s)."
 msgstr ""
 
@@ -50865,13 +50842,13 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:319
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "\tgit://git..../proj.git master\n"
 msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:321
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "to get the following updates...\n"
 msgstr ""
 
@@ -50883,7 +50860,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:327
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "$ git pull git://git..../proj.git master\n"
 msgstr ""
 
@@ -51008,7 +50985,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git.txt:55
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Other options are available to control how the manual page is displayed. See linkgit:git-help[1] for more information, because `git --help ...` is converted internally into `git help ...`."
 msgstr ""
 
@@ -51052,7 +51029,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git.txt:82
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Note that omitting the `=` in `git -c foo.bar ...` is allowed and sets `foo.bar` to the boolean true value (just like `[foo]bar` would in a config file). Including the equals but with an empty value (like `git -c foo.bar= ...`) sets `foo.bar` to the empty string which `git config --type=bool` will convert to `false`."
 msgstr ""
 
@@ -51256,7 +51233,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:169
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--list-cmds=group[,group...]"
 msgstr ""
 
@@ -51759,7 +51736,7 @@ msgstr "`GIT_COMMON_DIR`"
 
 #. type: Plain text
 #: en/git.txt:481
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If this variable is set to a path, non-worktree files that are normally in $GIT_DIR will be taken from this path instead. Worktree-specific files such as HEAD or index are taken from $GIT_DIR. See linkgit:gitrepository-layout[5] and linkgit:git-worktree[1] for details. This variable has lower precedence than other path variables such as GIT_INDEX_FILE, GIT_OBJECT_DIRECTORY..."
 msgstr ""
 
@@ -52230,10 +52207,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:685
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2`"
-msgstr "`GIT_TRACE`"
+msgstr "`GIT_TRACE2`"
 
 #. type: Plain text
 #: en/git.txt:689
@@ -52261,10 +52237,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:720
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE_SETUP`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2_EVENT`"
-msgstr "`GIT_TRACE_SETUP`"
+msgstr "`GIT_TRACE2_EVENT`"
 
 #. type: Plain text
 #: en/git.txt:725
@@ -52274,10 +52249,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:726
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE_PERFORMANCE`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2_PERF`"
-msgstr "`GIT_TRACE_PERFORMANCE`"
+msgstr "`GIT_TRACE2_PERF`"
 
 #. type: Plain text
 #: en/git.txt:732
@@ -52716,7 +52690,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-update-index.txt:29
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git update-index'\n"
 "\t     [--add] [--remove | --force-remove] [--replace]\n"
@@ -53276,7 +53250,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-update-index.txt:348
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The command looks at `core.ignorestat` configuration variable.  When this is true, paths updated with `git update-index paths...` and paths updated with other Git commands that update both index and working tree (e.g. 'git apply --index', 'git checkout-index -u', and 'git read-tree -u') are automatically marked as \"assume unchanged\".  Note that \"assume unchanged\" bit is *not* set if `git update-index --refresh` finds the working tree file matches the index (use `git update-index --really-refresh` if you want to mark them as \"assume unchanged\")."
 msgstr ""
 
@@ -54145,7 +54119,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-commit.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-commit' <commit>...\n"
 msgstr ""
 
@@ -54187,7 +54161,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-pack.txt:13
-#, fuzzy, no-wrap, priority:100
+#, fuzzy, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-pack' [-v|--verbose] [-s|--stat-only] [--] <pack>.idx ...\n"
 msgstr "git verify-pack [-v | --verbose] [-s | --stat-only] <пакет>…"
 
@@ -54199,7 +54173,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-verify-pack.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<pack>.idx ..."
 msgstr ""
 
@@ -54277,7 +54251,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-tag.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-tag' [--format=<format>] <tag>...\n"
 msgstr ""
 
@@ -54295,7 +54269,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-verify-tag.txt:27
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<tag>..."
 msgstr ""
 
@@ -54319,7 +54293,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-web--browse.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git web{litdd}browse' [<options>] <url|file>...\n"
 msgstr ""
 
@@ -54593,7 +54567,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-whatchanged.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git whatchanged' <option>...\n"
 msgstr ""
 
@@ -55123,7 +55097,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-worktree.txt:372
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git worktree add -b emergency-fix ../temp master\n"
 "$ pushd ../temp\n"
@@ -56324,7 +56298,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/pretty-formats.txt:115
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'%C(...)'"
 msgstr ""
 
@@ -56336,7 +56310,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/pretty-formats.txt:129
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "\"CONFIGURATION FILE\" section of linkgit:git-config[1].  By default, colors are shown only when enabled for log output (by `color.diff`, `color.ui`, or `--color`, and respecting the `auto` settings of the former if we are going to a terminal). `%C(auto,...)` is accepted as a historical synonym for the default (e.g., `%C(auto,red)`). Specifying `%C(always,...)` will show the colors even when color is not otherwise enabled (though consider just using `--color=always` to enable color for the whole output, including this format and anything else git might color).  `auto` alone (i.e. `%C(auto)`) will turn on auto coloring on the next placeholders until the color is switched again."
 msgstr ""
 
@@ -57427,7 +57401,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/pull-fetch-param.txt:45
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "Whether that update is allowed without `--force` depends on the ref namespace it's being fetched to, the type of object being fetched, and whether the update is considered to be a fast-forward. Generally, the same rules apply for fetching as when pushing, see the `<refspec>...` section of linkgit:git-push[1] for what those are. Exceptions to those rules particular to 'git fetch' are noted below."
 msgstr ""
 
@@ -57898,13 +57872,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/revisions.txt:280
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "The '...' (three-dot) Symmetric Difference Notation"
 msgstr ""
 
 #. type: Plain text
 #: en/revisions.txt:286
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "A similar notation 'r1\\...r2' is called symmetric difference of 'r1' and 'r2' and is defined as 'r1 r2 --not $(git merge-base --all r1 r2)'.  It is the set of commits that are reachable from either one of 'r1' (left side) or 'r2' (right side) but not from both."
 msgstr ""
 
@@ -57994,7 +57968,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/revisions.txt:331
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'<rev1>\\...<rev2>'"
 msgstr ""
 
@@ -58048,7 +58022,7 @@ msgstr ""
 
 #. type: delimited block .
 #: en/revisions.txt:377
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "   Args   Expanded arguments    Selected commits\n"
 "   D                            G H D\n"
@@ -58538,7 +58512,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:256
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "For example, `--cherry-pick --right-only A...B` omits those commits from `B` which are in `A` or are patch-equivalent to a commit in `A`. In other words, this lists the `+` commits from `git cherry A B`.  More precisely, `--cherry-pick --right-only --no-merges` gives the exact list."
 msgstr ""
 
@@ -58550,7 +58524,7 @@ msgstr "--cherry"
 
 #. type: Plain text
 #: en/rev-list-options.txt:263
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "A synonym for `--right-only --cherry-mark --no-merges`; useful to limit the output to the commits on our side and mark those that have been applied to the other side of a forked history with `git log --cherry upstream...mybranch`, similar to `git cherry upstream mybranch`."
 msgstr ""
 
@@ -58562,7 +58536,7 @@ msgstr "--walk-reflogs"
 
 #. type: Plain text
 #: en/rev-list-options.txt:271
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Instead of walking the commit ancestry chain, walk reflog entries from the most recent one to older ones.  When this option is used you cannot specify commits to exclude (that is, '{caret}commit', 'commit1..commit2', and 'commit1\\...commit2' notations cannot be used)."
 msgstr ""
 
@@ -59555,7 +59529,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:875
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "`--date=format:...` feeds the format `...` to your system `strftime`, except for %z and %Z, which are handled internally.  Use `--date=format:%c` to show the date in your system locale's preferred format.  See the `strftime` manual for a complete list of format placeholders. When using `-local`, the correct syntax is `--date=format-local:...`."
 msgstr ""
 
@@ -59591,7 +59565,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:892
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Print also the parents of the commit (in the form \"commit parent...\").  Also enables parent rewriting, see 'History Simplification' above."
 msgstr ""
 
@@ -59603,7 +59577,7 @@ msgstr "--children"
 
 #. type: Plain text
 #: en/rev-list-options.txt:896
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Print also the children of the commit (in the form \"commit child...\").  Also enables parent rewriting, see 'History Simplification' above."
 msgstr ""
 
@@ -59656,13 +59630,13 @@ msgstr ""
 
 #. type: delimited block -
 #: en/rev-list-options.txt:922
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "\t$ git rev-list --left-right --boundary --pretty=oneline A...B\n"
 msgstr ""
 
 #. type: delimited block -
 #: en/rev-list-options.txt:929
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "\t>bbbbbbb... 3rd on b\n"
 "\t>bbbbbbb... 2nd on b\n"

--- a/po/documentation.tr.po
+++ b/po/documentation.tr.po
@@ -2435,7 +2435,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/config.txt:256
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The value for many variables that specify various sizes can be suffixed with `k`, `M`,... to mean \"scale the number by 1024\", \"by 1024x1024\", etc."
 msgstr ""
 
@@ -2826,7 +2826,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-format.txt:16
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "git-diff-tree [-r] <tree-ish-1> <tree-ish-2> [<pattern>...]"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-format.txt:19
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "git-diff-files [<pattern>...]"
 msgstr ""
 
@@ -3518,7 +3518,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/diff-generate-patch.txt:179
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Unlike the traditional 'unified' diff format, which shows two files A and B with a single column that has `-` (minus -- appears in A but removed in B), `+` (plus -- missing in A but added to B), or `\" \"` (space -- unchanged) prefix, this format compares two or more files file1, file2,... with one file X, and shows how X differs from each of fileN.  One column for each of fileN is prepended to the output line to note how X's line is different from it."
 msgstr ""
 
@@ -3842,7 +3842,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:137
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Generate a diffstat. By default, as much space as necessary will be used for the filename part, and the rest for the graph part. Maximum width defaults to terminal width, or 80 columns if not connected to a terminal, and can be overridden by `<width>`. The width of the filename part can be limited by giving another width `<name-width>` after a comma. The width of the graph part can be limited by using `--stat-graph-width=<width>` (affects all commands generating a stat graph) or by setting `diff.statGraphWidth=<width>` (does not affect `git format-patch`).  By giving a third parameter `<count>`, you can limit the output to the first `<count>` lines, followed by `...` if there are more."
 msgstr ""
 
@@ -3890,13 +3890,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:161
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "-X[<param1,param2,...>]"
 msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:162
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--dirstat[=<param1,param2,...>]"
 msgstr ""
 
@@ -3986,13 +3986,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:209
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--dirstat-by-file[=<param1,param2>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:211
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Synonym for --dirstat=files,param1,param2..."
 msgstr ""
 
@@ -4653,13 +4653,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:527
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--diff-filter=[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:538
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Select only files that are Added (`A`), Copied (`C`), Deleted (`D`), Modified (`M`), Renamed (`R`), have their type (i.e. regular file, symlink, submodule, ...) changed (`T`), are Unmerged (`U`), are Unknown (`X`), or have had their pairing Broken (`B`).  Any combination of the filter characters (including none) can be used.  When `*` (All-or-none) is added to the combination, all paths are selected if there is any file that matches other criteria in the comparison; if there is no file that matches other criteria, nothing is selected."
 msgstr ""
 
@@ -4719,7 +4719,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/diff-options.txt:573
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "+    return !regexec(regexp, two->ptr, 1, &regmatch, 0);\n"
 "...\n"
@@ -5644,7 +5644,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-add.txt:15
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "'git add' [--verbose | -v] [--dry-run | -n] [--force | -f] [--interactive | -i] [--patch | -p]\n"
 "\t  [--edit | -e] [--[no-]all | --[no-]ignore-removal | [--update | -u]]\n"
@@ -5702,7 +5702,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-add.txt:52 en/git-grep.txt:308 en/git-status.txt:148
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid "<pathspec>..."
 msgstr ""
 
@@ -5846,7 +5846,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-add.txt:145
-#, priority:300
+#, ignore-ellipsis, priority:300
 msgid "This option is primarily to help users who are used to older versions of Git, whose \"git add <pathspec>...\" was a synonym for \"git add --no-all <pathspec>...\", i.e. ignored removed files."
 msgstr ""
 
@@ -6344,7 +6344,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-am.txt:20
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git am' [--signoff] [--keep] [--[no-]keep-cr] [--[no-]utf8]\n"
 "\t [--[no-]3way] [--interactive] [--committer-date-is-author-date]\n"
@@ -6364,7 +6364,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-am.txt:29
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "(<mbox>|<Maildir>)..."
 msgstr ""
 
@@ -6900,7 +6900,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-apply.txt:20
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git apply' [--stat] [--numstat] [--summary] [--check] [--index | --intent-to-add] [--3way]\n"
 "\t  [--apply] [--no-add] [--build-fake-ancestor=<file>] [-R | --reverse]\n"
@@ -6926,7 +6926,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-apply.txt:37
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<patch>..."
 msgstr ""
 
@@ -7340,7 +7340,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-archimport.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git archimport' [-h] [-v] [-o] [-a] [-f] [-T] [-D depth] [-t tempdir]\n"
 "               <archive/branch>[:<git-branch>] ...\n"
@@ -7504,7 +7504,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-archive.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git archive' [--format=<fmt>] [--list] [--prefix=<prefix>/] [<extra>]\n"
 "\t      [-o <file> | --output=<file>] [--worktree-attributes]\n"
@@ -7892,7 +7892,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bisect.txt:31
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 " git bisect start [--term-{old,good}=<term> --term-{new,bad}=<term>]\n"
 "\t\t  [--no-checkout] [<bad> [<good>...]] [--] [<paths>...]\n"
@@ -8087,7 +8087,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-bisect.txt:158
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git bisect new [<rev>...]\n"
 msgstr ""
 
@@ -8117,7 +8117,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bisect.txt:175
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If you would like to use your own terms instead of \"bad\"/\"good\" or \"new\"/\"old\", you can choose any names you like (except existing bisect subcommands like `reset`, `start`, ...) by starting the bisection using"
 msgstr ""
 
@@ -8557,7 +8557,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-bisect.txt:463
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git bisect start HEAD <known-good-commit> [ <boundary-commit> ... ] --no-checkout\n"
 "$ git bisect run sh -c '\n"
@@ -9025,7 +9025,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:26
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git branch' [--color[=<when>] | --no-color] [--show-current]\n"
 "\t[-v [--abbrev=<length> | --no-abbrev]]\n"
@@ -9070,7 +9070,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:61
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "The command's second form creates a new branch head named <branchname> which points to the current `HEAD`, or <start-point> if given. As a special case, for <start-point>, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -9268,7 +9268,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:176
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "List branches.  With optional `<pattern>...`, e.g. `git branch --list 'maint-*'`, list only the branches that match the pattern(s)."
 msgstr ""
 
@@ -9515,7 +9515,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:291
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "Sort based on the key given. Prefix `-` to sort in descending order of the value. You may use the --sort=<key> option multiple times, in which case the last key becomes the primary key. The keys supported are the same as those in `git for-each-ref`. Sort order defaults to the value configured for the `branch.sort` variable if exists, or to sorting based on the full refname (including `refs/...` prefix). This lists detached HEAD (if present) first, then local branches and finally remote-tracking branches. See linkgit:git-config[1]."
 msgstr ""
 
@@ -9557,7 +9557,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-branch.txt:317
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git clone git://git.kernel.org/pub/scm/.../linux-2.6 my2.6\n"
 "$ cd my2.6\n"
@@ -9579,7 +9579,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-branch.txt:329
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git clone git://git.kernel.org/.../git.git my.git\n"
 "$ cd my.git\n"
@@ -9693,7 +9693,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bundle.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git bundle' create <file> <git-rev-list-args>\n"
 "'git bundle' verify <file>\n"
@@ -9769,7 +9769,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-bundle.txt:71
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<refname>...]"
 msgstr ""
 
@@ -10545,7 +10545,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-attr.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git check-attr' [-a | --all | <attr>...] [--] <pathname>...\n"
 "'git check-attr' --stdin [-z] [-a | --all | <attr>...]\n"
@@ -10786,7 +10786,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-ignore.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git check-ignore' [<options>] <pathname>...\n"
 "'git check-ignore' [<options>] --stdin\n"
@@ -10962,7 +10962,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-mailmap.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git check-mailmap' [<options>] <contact>...\n"
 msgstr ""
 
@@ -10998,7 +10998,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout-index.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git checkout-index' [-u] [-q] [-a] [-f] [-n] [--prefix=<string>]\n"
 "\t\t   [--stage=<number>|all]\n"
@@ -11273,7 +11273,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:18
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git checkout' [-q] [-f] [-m] [<branch>]\n"
 "'git checkout' [-q] [-f] [-m] --detach [<branch>]\n"
@@ -11384,7 +11384,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-checkout.txt:82
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git checkout' [<tree-ish>] [--] <pathspec>..."
 msgstr ""
 
@@ -11402,7 +11402,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-checkout.txt:98
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git checkout' (-p|--patch) [<tree-ish>] [--] [<pathspec>...]"
 msgstr ""
 
@@ -11744,7 +11744,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:326 en/git-switch.txt:58
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "As a special case, you may use `A...B` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -11774,7 +11774,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:337
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "As a special case, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -12345,7 +12345,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git cherry-pick' [--edit] [-n] [-m parent-number] [-s] [-x] [--ff]\n"
 "\t\t  [-S[<keyid>]] <commit>...\n"
@@ -12402,13 +12402,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-cherry-pick.txt:43 en/git-merge.txt:116 en/git-revert.txt:36 en/git-verify-commit.txt:27
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "<commit>..."
 msgstr ""
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:52
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Commits to cherry-pick.  For a more complete list of ways to spell commits, see linkgit:gitrevisions[7].  Sets of commits can be passed but no traversal is done by default, as if the `--no-walk` option was specified, see linkgit:git-rev-list[1]. Note that specifying a range will feed all <commit>... arguments to a single revision walk (see a later example that uses 'maint master..next')."
 msgstr ""
 
@@ -12438,7 +12438,7 @@ msgstr "-x"
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:78
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When recording the commit, append a line that says \"(cherry picked from commit ...)\" to the original commit message in order to indicate which commit this change was cherry-picked from.  This is done only for cherry picks without conflicts.  Do not use this option if you are cherry-picking from your private branch because the information is useless to the recipient.  If on the other hand you are cherry-picking between two publicly visible branches (e.g. backporting a fix to a maintenance branch for an older release from a development branch), adding this information can be useful."
 msgstr ""
 
@@ -12796,7 +12796,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:58
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git checkout -b topic origin/master\n"
 "# work and create some commits\n"
@@ -12832,7 +12832,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git log --graph --oneline --decorate --boundary origin/master...topic\n"
 "* 7654321 (origin/master) upstream tip commit\n"
@@ -12855,7 +12855,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:96
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git cherry origin/master topic\n"
 "- cccc000... commit C\n"
@@ -12883,7 +12883,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:126
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git log --graph --oneline --decorate --boundary origin/master...topic\n"
 "* 7654321 (origin/master) upstream tip commit\n"
@@ -12909,7 +12909,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:136
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git cherry origin/master topic base\n"
 "- cccc000... commit C\n"
@@ -12961,7 +12961,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-clean.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git clean' [-d] [-f] [-i] [-n] [-q] [-e <pattern>] [-x | -X] [--] <path>...\n"
 msgstr ""
 
@@ -12979,7 +12979,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-clean.txt:25
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If any optional `<path>...` arguments are given, only those paths are affected."
 msgstr ""
 
@@ -13591,7 +13591,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-clone.txt:306
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "$ git clone git://git.kernel.org/pub/scm/.../linux.git my-linux\n"
 "$ cd my-linux\n"
@@ -13621,7 +13621,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-clone.txt:325
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "$ git clone --reference /git/linux.git \\\n"
 "\tgit://git.kernel.org/pub/scm/.../linux.git \\\n"
@@ -13814,7 +13814,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-commit-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git commit-tree' <tree> [(-p <parent>)...]\n"
 "'git commit-tree' [(-p <parent>)...] [-S[<keyid>]] [(-m <message>)...]\n"
@@ -14015,7 +14015,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-commit.txt:17
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git commit' [-a | --interactive | --patch] [-s] [-v] [-u<mode>] [--amend]\n"
 "\t   [--dry-run] [(-c | -C | --fixup | --squash) <commit>]\n"
@@ -14435,7 +14435,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-commit.txt:248
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "\t$ git reset --soft HEAD^\n"
 "\t$ ... do something else to come up with the right tree ...\n"
@@ -14600,7 +14600,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-commit.txt:346 en/git-rm.txt:29
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "<file>..."
 msgstr ""
 
@@ -15577,7 +15577,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-config.txt:428
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "However, if you really only want to replace the line for the default proxy, i.e. the one without a \"for ...\" postfix, do something like this:"
 msgstr ""
 
@@ -16935,7 +16935,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-cvsserver.txt:26
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git-cvsserver' [<options>] [pserver|server] [<directory> ...]\n"
 msgstr ""
 
@@ -17633,7 +17633,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-daemon.txt:25
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git daemon' [--verbose] [--syslog] [--export-all]\n"
 "\t     [--timeout=<n>] [--init-timeout=<n>] [--max-connections=<n>]\n"
@@ -18200,7 +18200,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-describe.txt:14
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "'git describe' [--all] [--tags] [--contains] [--abbrev=<n>] [<commit-ish>...]\n"
 "'git describe' [--all] [--tags] [--contains] [--abbrev=<n>] --dirty[=<mark>]\n"
@@ -18227,7 +18227,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-describe.txt:37
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "<commit-ish>..."
 msgstr ""
 
@@ -18323,7 +18323,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-describe.txt:95
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Always output the long format (the tag, the number of commits and the abbreviated commit name) even when it matches a tag.  This is useful when you want to see parts of the commit object name in \"describe\" output, even when the commit in question happens to be a tagged version.  Instead of just emitting the tag name, it will describe such a commit as v1.2-0-gdeadbee (0th commit since tag v1.2 that points at object deadbee....)."
 msgstr ""
 
@@ -18501,7 +18501,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-files.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git diff-files' [-q] [-0|-1|-2|-3|-c|--cc] [<common diff options>] [<path>...]\n"
 msgstr ""
 
@@ -18573,7 +18573,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-index.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git diff-index' [-m] [--cached] [<common diff options>] <tree-ish> [<path>...]\n"
 msgstr ""
 
@@ -18712,7 +18712,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-index.txt:102
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "  torvalds@ppc970:~/v2.6/linux> git diff-index --abbrev HEAD\n"
 "  :100644 100664 7476bb... 000000...      kernel/sched.c\n"
@@ -18750,7 +18750,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-difftool.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git difftool' [<options>] [<commit> [<commit>]] [--] [<path>...]\n"
 msgstr ""
 
@@ -19062,7 +19062,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git diff-tree' [--stdin] [-m] [-s] [-v] [--no-commit-id] [--pretty]\n"
 "\t      [-t] [-r] [-c | --cc] [--combined-all-paths] [--root]\n"
@@ -19095,7 +19095,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff-tree.txt:32 en/git-diff.txt:114 en/git-submodule.txt:422
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "<path>..."
 msgstr ""
 
@@ -19221,7 +19221,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:17
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git diff' [<options>] [<commit>] [--] [<path>...]\n"
 "'git diff' [<options>] --cached [<commit>] [--] [<path>...]\n"
@@ -19238,7 +19238,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:24
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] [--] [<path>...]"
 msgstr ""
 
@@ -19262,7 +19262,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:41
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] --cached [<commit>] [--] [<path>...]"
 msgstr ""
 
@@ -19274,7 +19274,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:51
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit> [--] [<path>...]"
 msgstr ""
 
@@ -19286,7 +19286,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:59
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit> <commit> [--] [<path>...]"
 msgstr ""
 
@@ -19298,7 +19298,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:64
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit>..<commit> [--] [<path>...]"
 msgstr ""
 
@@ -19310,13 +19310,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:70
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit>\\...<commit> [--] [<path>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:77
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "This form is to view the changes on the branch containing and up to the second <commit>, starting at a common ancestor of both <commit>.  \"git diff A\\...B\" is equivalent to \"git diff $(git merge-base A B) B\".  You can omit any one of <commit>, which has the same effect as using HEAD instead."
 msgstr ""
 
@@ -19328,7 +19328,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:89
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "For a more complete list of ways to spell <commit>, see \"SPECIFYING REVISIONS\" section in linkgit:gitrevisions[7].  However, \"diff\" is about comparing two _endpoints_, not ranges, and the range notations (\"<commit>..<commit>\" and \"<commit>\\...<commit>\") do not mean a range as defined in the \"SPECIFYING RANGES\" section in linkgit:gitrevisions[7]."
 msgstr ""
 
@@ -19436,7 +19436,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-diff.txt:160
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git diff topic master    <1>\n"
 "$ git diff topic..master   <2>\n"
@@ -19756,7 +19756,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:143
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<git-rev-list-args>...]"
 msgstr ""
 
@@ -19837,7 +19837,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-fast-export.txt:215
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git init anon-repo\n"
 "$ cd anon-repo\n"
@@ -22147,7 +22147,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch-pack.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git fetch-pack' [--all] [--quiet|-q] [--keep|-k] [--thin] [--include-tag]\n"
 "\t[--upload-pack=<git-upload-pack>]\n"
@@ -22301,7 +22301,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fetch-pack.txt:117 en/git-ls-remote.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<refs>..."
 msgstr ""
 
@@ -22331,7 +22331,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch.txt:16
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git fetch' [<options>] [<repository> [<refspec>...]]\n"
 "'git fetch' [<options>] <group>\n"
@@ -22672,7 +22672,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch.txt:226
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "For a successfully fetched ref, the summary shows the old and new values of the ref in a form suitable for using as an argument to `git log` (this is `<old>..<new>` in most cases, and `<old>...<new>` for forced non-fast-forward updates)."
 msgstr ""
 
@@ -22794,7 +22794,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:18
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git filter-branch' [--setup <command>] [--subdirectory-filter <directory>]\n"
 "\t[--env-filter <command>] [--tree-filter <command>]\n"
@@ -22934,7 +22934,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:117
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for rewriting the index.  It is similar to the tree filter but does not check out the tree, which makes it much faster.  Frequently used with `git rm --cached --ignore-unmatch ...`, see EXAMPLES below.  For hairy cases, see linkgit:git-update-index[1]."
 msgstr ""
 
@@ -22946,7 +22946,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:125
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for rewriting the commit's parent list.  It will receive the parent string on stdin and shall output the new parent string on stdout.  The parent string is in the format described in linkgit:git-commit-tree[1]: empty for the initial commit, \"-p parent\" for a normal commit and \"-p parent1 -p parent2 -p parent3 ...\" for a merge commit."
 msgstr ""
 
@@ -22970,7 +22970,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:138
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for performing the commit.  If this filter is specified, it will be called instead of the 'git commit-tree' command, with arguments of the form \"<TREE_ID> [(-p <PARENT_COMMIT_ID>)...]\" and the log message on stdin.  The commit id is expected on stdout."
 msgstr ""
 
@@ -23072,7 +23072,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-filter-branch.txt:207
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<rev-list options>..."
 msgstr ""
 
@@ -23333,7 +23333,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-filter-branch.txt:388
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git filter-branch ... C..H\n"
 msgstr ""
 
@@ -23345,7 +23345,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-filter-branch.txt:395
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "git filter-branch ... C..H --not D\n"
 "git filter-branch ... D..H --not C\n"
@@ -23584,7 +23584,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git for-each-ref' [--count=<count>] [--shell|--perl|--python|--tcl]\n"
 "\t\t   [(--sort=<key>)...] [--format=<format>] [<pattern>...]\n"
@@ -23601,7 +23601,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-for-each-ref.txt:29 en/git-show-ref.txt:88
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<pattern>..."
 msgstr ""
 
@@ -23894,7 +23894,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:197
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Left-, middle-, or right-align the content between %(align:...) and %(end). The \"align:\" is followed by `width=<width>` and `position=<position>` in any order separated by a comma, where the `<position>` is either left, right or middle, default being left and `<width>` is the total length of the content with alignment. For brevity, the \"width=\" and/or \"position=\" prefixes may be omitted, and bare <width> and <position> used instead.  For instance, `%(align:<width>,<position>)`. If the contents length is more than the width then no alignment is performed. If used with `--quote` everything in between %(align:...) and %(end) is quoted, but if nested then only the topmost level performs quoting."
 msgstr ""
 
@@ -23906,7 +23906,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:210
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Used as %(if)...%(then)...%(end) or %(if)...%(then)...%(else)...%(end).  If there is an atom with value or string literal after the %(if) then everything after the %(then) is printed, else if the %(else) atom is used, then everything after %(else) is printed. We ignore space when evaluating the string before %(then), this is useful when we use the %(HEAD) atom which prints either \"*\" or \" \" and we want to apply the 'if' condition only on the 'HEAD' ref.  Append \":equals=<string>\" or \":notequals=<string>\" to compare the value between the %(if:...) and %(then) atoms with the given string."
 msgstr ""
 
@@ -24127,7 +24127,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:361
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "An example to show the usage of %(if)...%(then)...%(else)...%(end).  This prefixes the current branch with a star."
 msgstr ""
 
@@ -24139,7 +24139,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:369
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "An example to show the usage of %(if)...%(then)...%(end).  This prints the authorname, if present."
 msgstr ""
 
@@ -24785,7 +24785,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:372
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "Do the same for ia64 so we can have sleek & trim looking\n"
 "...\n"
@@ -24793,7 +24793,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:380
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Typically it will be placed in a MUA's drafts folder, edited to add timely commentary that should not go in the changelog after the three dashes, and then sent as a message whose body, in our example, starts with \"arch/arm config files were...\".  On the receiving end, readers can save interesting patches in a UNIX mailbox and apply them with linkgit:git-am[1]."
 msgstr ""
 
@@ -24805,7 +24805,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:390
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "...\n"
 "> So we should do such-and-such.\n"
@@ -24827,7 +24827,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:398
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "arch/arm config files were slimmed down using a python script\n"
 "...\n"
@@ -25001,7 +25001,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:499
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Configure your mail server composition as plain text: Edit...Account Settings...Composition & Addressing, uncheck \"Compose Messages in HTML\"."
 msgstr ""
 
@@ -25138,7 +25138,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:573
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Use Message -> Insert file... and insert the patch."
 msgstr ""
 
@@ -25313,7 +25313,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fsck-objects.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git fsck-objects' ...\n"
 msgstr ""
 
@@ -25701,7 +25701,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-gc.txt:55
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Once housekeeping is triggered by exceeding the limits of configuration options such as `gc.auto` and `gc.autoPackLimit`, all other housekeeping tasks (e.g. rerere, working trees, reflog...) will be performed as well."
 msgstr ""
 
@@ -25875,7 +25875,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-grep.txt:32
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git grep' [-a | --text] [-I] [--textconv] [-i | --ignore-case] [-w | --word-regexp]\n"
 "\t   [-v | --invert-match] [-h|-H] [--full-name]\n"
@@ -26484,7 +26484,7 @@ msgstr "--not"
 
 #. type: Labeled list
 #: en/git-grep.txt:284
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "( ... )"
 msgstr ""
 
@@ -26514,7 +26514,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-grep.txt:300
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<tree>..."
 msgstr ""
 
@@ -26832,7 +26832,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-hash-object.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git hash-object' [-t <type>] [-w] [--path=<file>|--no-filters] [--stdin [--literally]] [--] <file>...\n"
 "'git hash-object' [-t <type>] [-w] --stdin-paths [--no-filters]\n"
@@ -26962,7 +26962,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-help.txt:38
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Note that `git --help ...` is identical to `git help ...` because the former is internally converted into the latter."
 msgstr ""
 
@@ -27412,7 +27412,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:102
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tAuthType Basic\n"
 "\tAuthName \"Git Access\"\n"
@@ -27430,7 +27430,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:115
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "<LocationMatch \"^/git/.*/git-receive-pack$\">\n"
 "\tAuthType Basic\n"
@@ -27454,7 +27454,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:136
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "<Location /git/private>\n"
 "\tAuthType Basic\n"
@@ -27604,7 +27604,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:231
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "auth.require = (\n"
 "\t\"/\" => (\n"
@@ -27807,7 +27807,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-http-push.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git http-push' [--all] [--dry-run] [--force] [--verbose] <url> <ref> [<ref>...]\n"
 msgstr ""
 
@@ -27876,7 +27876,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-http-push.txt:54 en/git-send-pack.txt:98
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<ref>..."
 msgstr ""
 
@@ -28741,7 +28741,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-interpret-trailers.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git interpret-trailers' [<options>] [(--trailer <token>[(=|:)<value>])...] [<file>...]\n"
 "'git interpret-trailers' [<options>] [--parse] [<file>...]\n"
@@ -29413,7 +29413,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-log.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'git log' [<options>] [<revision range>] [[--] <path>...]\n"
 msgstr ""
 
@@ -29511,7 +29511,7 @@ msgstr "--full-diff"
 
 #. type: Plain text
 #: en/git-log.txt:63
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Without this flag, `git log -p <path>...` shows commits that touch the specified paths, and diffs about the same specified paths.  With this, the full diff is shown for commits that touch the specified paths; this means that \"<path>...\" limits only commits, and doesn't limit diff for those commits."
 msgstr ""
 
@@ -29565,7 +29565,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-log.txt:93 en/git-shortlog.txt:72
-#, fuzzy, no-wrap, priority:260
+#, fuzzy, ignore-ellipsis, no-wrap, priority:260
 #| msgid "--path"
 msgid "[--] <path>..."
 msgstr "--path"
@@ -29842,7 +29842,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-files.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-files' [-z] [-t] [-v] [-f]\n"
 "\t\t(--[cached|deleted|others|ignored|stage|unmerged|killed|modified])*\n"
@@ -30323,7 +30323,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-remote.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-remote' [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
 "\t      [-q | --quiet] [--exit-code] [--get-url] [--sort=<key>]\n"
@@ -30428,7 +30428,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-remote.txt:91
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When unspecified, all references, after filtering done with --heads and --tags, are shown.  When <refs>... are specified, only references matching the given patterns are displayed."
 msgstr ""
 
@@ -30474,7 +30474,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-tree' [-d] [-r] [-t] [-l] [-z]\n"
 "\t    [--name-only] [--name-status] [--full-name] [--full-tree] [--abbrev[=<n>]]\n"
@@ -30555,7 +30555,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-ls-tree.txt:76
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<path>...]"
 msgstr ""
 
@@ -30765,7 +30765,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mailsplit.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git mailsplit' [-b] [-f<nn>] [-d<prec>] [--keep-cr] [--mboxrd]\n"
 "\t\t-o<directory> [--] [(<mbox>|<Maildir>)...]\n"
@@ -30887,7 +30887,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git merge-base' [-a|--all] <commit> <commit>...\n"
 "'git merge-base' [-a|--all] --octopus <commit>...\n"
@@ -31084,7 +31084,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:139
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tA=$(git rev-parse --verify A)\n"
 "\tif test \"$A\" = \"$(git merge-base A B)\"\n"
@@ -31101,7 +31101,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:146
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tif git merge-base --is-ancestor A B\n"
 "\tthen\n"
@@ -31588,7 +31588,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mergetool.txt:12
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git mergetool' [--tool=<tool>] [-y | --[no-]prompt] [<file>...]\n"
 msgstr ""
 
@@ -31750,7 +31750,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge.txt:17
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git merge' [-n] [--stat] [--no-commit] [--squash] [--[no-]edit]\n"
 "\t[-s <strategy>] [-X <strategy-option>] [-S[<keyid>]]\n"
@@ -32343,7 +32343,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mv.txt:13
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git mv' <options>... <args>...\n"
 msgstr ""
 
@@ -32355,7 +32355,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mv.txt:20
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 " git mv [-v] [-f] [-n] [-k] <source> <destination>\n"
 " git mv [-v] [-f] [-n] [-k] <source> ... <destination directory>\n"
@@ -32423,7 +32423,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-name-rev.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git name-rev' [--tags] [--refs=<pattern>]\n"
 "\t       ( --all | --stdin | <commit-ish>... )\n"
@@ -32541,7 +32541,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-notes.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git notes' [list [<object>]]\n"
 "'git notes' add [-f] [--allow-empty] [-F <file> | -m <msg> | (-c | -C) <object>] [<object>]\n"
@@ -32877,7 +32877,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-notes.txt:229
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Commit notes are blobs containing extra information about an object (usually information to supplement a commit's message).  These blobs are taken from notes refs.  A notes ref is usually a branch which contains \"files\" whose paths are the object names for the objects they describe, with some directory separators included for performance reasons footnote:[Permitted pathnames have the form 'ab'`/`'cd'`/`'ef'`/`'...'`/`'abcdef...': a sequence of directory names of two hexadecimal digits each followed by a filename with the rest of the object ID.]."
 msgstr ""
 
@@ -32943,7 +32943,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-notes.txt:288
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git notes add -m 'Tested-by: Johannes Sixt <j6t@kdbg.org>' 72a144e2\n"
 "$ git show -s 72a144e\n"
@@ -33162,7 +33162,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-p4.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git p4 clone' [<sync options>] [<clone options>] <p4 depot path>...\n"
 "'git p4 sync' [<sync options>] [<p4 depot path>...]\n"
@@ -33996,7 +33996,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-p4.txt:445
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The full syntax for a p4 view is documented in 'p4 help views'.  'git p4' knows only a subset of the view syntax.  It understands multi-line mappings, overlays with '+', exclusions with '-' and double-quotes around whitespace.  Of the possible wildcards, 'git p4' only handles '...', and only when it is at the end of the path.  'git p4' will complain if it encounters an unhandled wildcard."
 msgstr ""
 
@@ -34038,7 +34038,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-p4.txt:475
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "//depot/main/...\n"
 "//depot/branch1/...\n"
@@ -34052,7 +34052,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-p4.txt:480
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "//depot/main/... //depot/branch1/...\n"
 msgstr ""
 
@@ -35170,7 +35170,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-pack-redundant.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git pack-redundant' [ --verbose ] [ --alt-odb ] < --all | .pack filename ... >\n"
 msgstr ""
 
@@ -35470,7 +35470,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-prune.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git prune' [-n] [-v] [--progress] [--expire <time>] [--] [<head>...]\n"
 msgstr ""
 
@@ -35525,7 +35525,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-prune.txt:54
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<head>..."
 msgstr ""
 
@@ -35579,7 +35579,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-pull.txt:13
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "'git pull' [<options>] [<repository> [<refspec>...]]\n"
 msgstr ""
 
@@ -35927,7 +35927,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:18
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git push' [--all | --mirror | --tags] [--follow-tags] [--atomic] [-n | --dry-run] [--receive-pack=<git-receive-pack>]\n"
 "\t   [--repo=<repository>] [-f | --force] [-d | --delete] [--prune] [-v | --verbose]\n"
@@ -35957,7 +35957,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:39
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "When the command line does not specify what to push with `<refspec>...` arguments or `--all`, `--mirror`, `--tags` options, the command finds the default `<refspec>` by consulting `remote.*.push` configuration, and if it is not found, honors `push.default` configuration to decide what to push (See linkgit:git-config[1] for the meaning of `push.default`)."
 msgstr ""
 
@@ -35981,7 +35981,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:56
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "<refspec>..."
 msgstr ""
 
@@ -36342,7 +36342,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:343
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "Note that `--force` applies to all the refs that are pushed, hence using it with `push.default` set to `matching` or with multiple push destinations configured with `remote.*.push` may overwrite refs other than the current branch (including local refs that are strictly behind their remote counterpart).  To force a push to only one branch, use a `+` in front of the refspec to push (e.g `git push origin +master` to force a push to the `master` branch). See the `<refspec>...` section above for details."
 msgstr ""
 
@@ -36474,7 +36474,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:445
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "For a successfully pushed ref, the summary shows the old and new values of the ref in a form suitable for using as an argument to `git log` (this is `<old>..<new>` in most cases, and `<old>...<new>` for forced non-fast-forward updates)."
 msgstr ""
 
@@ -36735,7 +36735,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:616
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "See the section describing `<refspec>...` above for a discussion of the matching semantics."
 msgstr ""
 
@@ -37436,7 +37436,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-read-tree.txt:357
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git fetch git://.... linus\n"
 "$ LT=`git rev-parse FETCH_HEAD`\n"
@@ -37490,7 +37490,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-read-tree.txt:405
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "'git read-tree' and other merge-based commands ('git merge', 'git checkout'...) can help maintaining the skip-worktree bitmap and working directory update. `$GIT_DIR/info/sparse-checkout` is used to define the skip-worktree reference bitmap. When 'git read-tree' needs to update the working directory, it resets the skip-worktree bit in the index based on this file, which uses the same syntax as .gitignore files.  If an entry matches a pattern in this file, skip-worktree will not be set on that entry. Otherwise, skip-worktree will be set."
 msgstr ""
 
@@ -37870,7 +37870,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:219
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "As a special case, you may use \"A\\...B\" as a shortcut for the merge base of A and B if there is exactly one merge base. You can leave out at most one of A and B, in which case it defaults to HEAD."
 msgstr ""
 
@@ -38134,7 +38134,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:430
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "It is currently only possible to recreate the merge commits using the `recursive` merge strategy; Different merge strategies can be used only via explicit `exec git merge -s <strategy> [...]` commands."
 msgstr ""
 
@@ -38188,7 +38188,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:457
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "\tgit rebase -i --exec \"cmd1 && cmd2 && ...\"\n"
 msgstr ""
 
@@ -38200,7 +38200,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:461
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "\tgit rebase -i --exec \"cmd1\" --exec \"cmd2\" --exec ...\n"
 msgstr ""
 
@@ -38236,7 +38236,7 @@ msgstr "--no-autosquash"
 
 #. type: Plain text
 #: en/git-rebase.txt:495
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When the commit log message begins with \"squash! ...\" (or \"fixup! ...\"), and there is already a commit in the todo list that matches the same `...`, automatically modify the todo list of rebase -i so that the commit marked for squashing comes right after the commit to be modified, and change the action of the moved commit from `pick` to `squash` (or `fixup`).  A commit matches the `...` if the commit subject matches, or if the `...` refers to the commit's hash. As a fall-back, partial matches of the commit subject work, too.  The recommended way to create fixup/squash commits is by using the `--fixup`/`--squash` options of linkgit:git-commit[1]."
 msgstr ""
 
@@ -38566,7 +38566,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:636
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "pick deadbee The oneline of this commit\n"
 "pick fa1afe1 The oneline of the next commit\n"
@@ -38670,7 +38670,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:710
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "pick deadbee Implement feature XXX\n"
 "fixup f1a5c00 Fix to feature XXX\n"
@@ -38689,7 +38689,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:720
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The \"exec\" command launches the command in a shell (the one specified in `$SHELL`, or the default shell if `$SHELL` is not set), so you can use shell features (like \"cd\", \">\", \";\" ...). The command is run from the root of the working tree."
 msgstr ""
 
@@ -38833,7 +38833,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:815
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "    o---o---o---o---o---o---o---o  master\n"
 "\t \\\t\t\t \\\n"
@@ -39631,7 +39631,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reflog.txt:27
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git reflog' ['show'] [log-options] [<ref>]\n"
 "'git reflog expire' [--expire=<time>] [--expire-unreachable=<time>]\n"
@@ -39818,7 +39818,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-remote-ext.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git remote add <nick> \"ext::<command>[ <arguments>...]\"\n"
 msgstr ""
 
@@ -39956,7 +39956,7 @@ msgstr "GIT_EXT_SERVICE"
 
 #. type: Plain text
 #: en/git-remote-ext.txt:70
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Set to long name (git-upload-pack, etc...) of service helper needs to invoke."
 msgstr ""
 
@@ -39968,7 +39968,7 @@ msgstr "GIT_EXT_SERVICE_NOPREFIX"
 
 #. type: Plain text
 #: en/git-remote-ext.txt:74
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Set to long name (upload-pack, etc...) of service helper needs to invoke."
 msgstr ""
 
@@ -40148,7 +40148,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-remote.txt:25
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git remote' [-v | --verbose]\n"
 "'git remote add' [-t <branch>] [-m <master>] [-f] [--[no-]tags] [--mirror=<fetch|push>] <name> <url>\n"
@@ -40467,7 +40467,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-remote.txt:235
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "$ git remote\n"
 "origin\n"
@@ -40711,7 +40711,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-replace.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git replace' [-f] <object> <replacement>\n"
 "'git replace' [-f] --edit <object>\n"
@@ -40831,13 +40831,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-replace.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--graft <commit> [<parent>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/git-replace.txt:93
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Create a graft commit. A new commit is created with the same content as <commit> except that its parents will be [<parent>...] instead of <commit>'s parents. A replacement ref is then created to replace <commit> with the newly created commit. Use `--convert-graft-file` to convert a `$GIT_DIR/info/grafts` file and use replace refs instead."
 msgstr ""
 
@@ -41259,7 +41259,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rerere.txt:121
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git switch topic\n"
 "\t$ git merge master\n"
@@ -41291,7 +41291,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rerere.txt:145
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git switch topic\n"
 "\t$ git merge master\n"
@@ -41396,7 +41396,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reset.txt:14
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git reset' [-q] [<tree-ish>] [--] <paths>...\n"
 "'git reset' (--patch | -p) [<tree-ish>] [--] [<paths>...]\n"
@@ -41411,7 +41411,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-reset.txt:22
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git reset' [-q] [<tree-ish>] [--] <paths>..."
 msgstr ""
 
@@ -41423,7 +41423,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reset.txt:30
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "This means that `git reset <paths>` is the opposite of `git add <paths>`. This command is equivalent to `git restore [--source=<tree-ish>] --staged <paths>...`."
 msgstr ""
 
@@ -41435,7 +41435,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-reset.txt:38
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git reset' (--patch | -p) [<tree-ish>] [--] [<paths>...]"
 msgstr ""
 
@@ -41590,7 +41590,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:138
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git commit ...\n"
 "$ git reset --soft HEAD^      <1>\n"
@@ -41663,7 +41663,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:170
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git commit ...\n"
 "$ git reset --hard HEAD~3   <1>\n"
@@ -41683,7 +41683,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:190
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git pull                         <1>\n"
 "Auto-merging nitfol\n"
@@ -41728,7 +41728,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:215
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git pull                         <1>\n"
 "Auto-merging nitfol\n"
@@ -41854,7 +41854,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:289
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git tag start\n"
 "$ git switch -c branch1\n"
@@ -41897,7 +41897,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:317
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git reset -N HEAD^                        <1>\n"
 "$ git add -p                                <2>\n"
@@ -42123,7 +42123,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-restore.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git restore' [<options>] [--source=<tree>] [--staged] [--worktree] <pathspec>...\n"
 "'git restore' (-p|--patch) [<options>] [--source=<tree>] [--staged] [--worktree] [<pathspec>...]\n"
@@ -42376,7 +42376,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-revert.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git revert' [--[no-]edit] [-n] [-m parent-number] [-s] [-S[<keyid>]] <commit>...\n"
 "'git revert' (--continue | --skip | --abort | --quit)\n"
@@ -42480,7 +42480,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-list.txt:65
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git rev-list' [ --max-count=<number> ]\n"
 "\t     [ --skip=<number> ]\n"
@@ -42583,13 +42583,13 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-list.txt:102
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Another special notation is \"'<commit1>'...'<commit2>'\" which is useful for merges.  The resulting set of commits is the symmetric difference between the two operands.  The following two commands are equivalent:"
 msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-list.txt:106
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git rev-list A B --not $(git merge-base --all A B)\n"
 "\t$ git rev-list A...B\n"
@@ -42615,7 +42615,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-parse.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git rev-parse' [<options>] <args>...\n"
 msgstr ""
 
@@ -43100,7 +43100,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-parse.txt:253
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Resolve \"$GIT_DIR/<path>\" and takes other path relocation variables such as $GIT_OBJECT_DIRECTORY, $GIT_INDEX_FILE... into account. For example, if $GIT_OBJECT_DIRECTORY is set to /foo/bar then \"git rev-parse --git-path objects/abc\" returns /foo/bar/abc."
 msgstr ""
 
@@ -43208,7 +43208,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:290
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<args>..."
 msgstr ""
 
@@ -43340,7 +43340,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:364
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "OPTS_SPEC=\"\\\n"
 "some-command [<options>] <args>...\n"
@@ -43398,7 +43398,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:389
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "usage: some-command [<options>] <args>...\n"
 msgstr ""
 
@@ -43410,7 +43410,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:397
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "    -h, --help            show the help\n"
 "    --foo                 some nifty option --foo\n"
@@ -43421,7 +43421,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:400
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "An option group Header\n"
 "    -C[...]               option C with an optional argument\n"
@@ -43526,7 +43526,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rm.txt:12
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git rm' [-f | --force] [-n] [-r] [--cached] [--ignore-unmatch] [--quiet] [--] <file>...\n"
 msgstr ""
 
@@ -43754,7 +43754,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-email.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git send-email' [<options>] <file|directory|rev-list options>...\n"
 "'git send-email' --dump-aliases\n"
@@ -43822,7 +43822,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:53
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--bcc=<address>,..."
 msgstr ""
 
@@ -43840,7 +43840,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:59
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--cc=<address>,..."
 msgstr ""
 
@@ -43924,7 +43924,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-email.txt:110
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "  [PATCH 0/2] Here is what I did...\n"
 "    [PATCH 1/2] Clean up and tests\n"
@@ -43955,7 +43955,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:119
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--to=<address>,..."
 msgstr ""
 
@@ -44087,7 +44087,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-send-email.txt:188
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "$ git send-email --smtp-auth=\"PLAIN LOGIN GSSAPI\" ...\n"
 msgstr ""
 
@@ -44783,7 +44783,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-pack.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git send-pack' [--all] [--dry-run] [--force] [--receive-pack=<git-receive-pack>]\n"
 "\t\t[--verbose] [--thin] [--atomic]\n"
@@ -45157,7 +45157,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-shortlog.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "'git shortlog' [<options>] [<revision range>] [[--] <path>...]\n"
 "git log --pretty=short | 'git shortlog' [<options>]\n"
@@ -45285,7 +45285,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show-branch.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git show-branch' [-a|--all] [-r|--remotes] [--topo-order | --date-order]\n"
 "\t\t[--current] [--color[=<when>] | --no-color] [--sparse]\n"
@@ -45646,7 +45646,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show-ref.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git show-ref' [-q|--quiet] [--verify] [--head] [-d|--dereference]\n"
 "\t     [-s|--hash[=<n>]] [--abbrev[=<n>]] [--tags]\n"
@@ -45794,7 +45794,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-show-ref.txt:111
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git show-ref --head --dereference\n"
 "832e76a9899f560a90ffd62ae2ce83bbeff58f54 HEAD\n"
@@ -45815,7 +45815,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-show-ref.txt:121
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git show-ref --heads --hash\n"
 "2e3ba0114a1f52b47df29743d6915d056be13278\n"
@@ -45936,7 +45936,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'git show' [<options>] [<object>...]\n"
 msgstr ""
 
@@ -45984,7 +45984,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-show.txt:37
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "<object>..."
 msgstr ""
 
@@ -46242,7 +46242,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stage.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git stage' args...\n"
 msgstr ""
 
@@ -46266,7 +46266,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stash.txt:22
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git stash' list [<options>]\n"
 "'git stash' show [<options>] [<stash>]\n"
@@ -46289,7 +46289,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stash.txt:38
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "The modifications stashed away by this command can be listed with `git stash list`, inspected with `git stash show`, and restored (potentially on top of a different commit) with `git stash apply`.  Calling `git stash` without any arguments is equivalent to `git stash push`.  A stash is by default listed as \"WIP on 'branchname' ...\", but you can give a more descriptive message on the command line when you create one."
 msgstr ""
 
@@ -46301,7 +46301,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-stash.txt:49
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "push [-p|--patch] [-k|--[no-]keep-index] [-u|--include-untracked] [-a|--all] [-q|--quiet] [-m|--message <message>] [--] [<pathspec>...]"
 msgstr ""
 
@@ -46373,7 +46373,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:104
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "stash@{0}: WIP on submit: 6ebd0e2... Update git-stash documentation\n"
 "stash@{1}: On master: 9cc0589... Add git-stash\n"
@@ -46546,7 +46546,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:227
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git pull\n"
 " ...\n"
@@ -46564,7 +46564,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:246
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git switch -c my_wip\n"
@@ -46585,7 +46585,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:257
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git stash\n"
@@ -46609,7 +46609,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:275
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git add --patch foo            # add just first part to the index\n"
@@ -46663,7 +46663,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-status.txt:13
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git status' [<options>...] [--] [<pathspec>...]\n"
 msgstr ""
 
@@ -47143,7 +47143,7 @@ msgstr ""
 
 #. type: delimited block .
 #: en/git-status.txt:345
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "Field       Meaning\n"
 "--------------------------------------------------------\n"
@@ -47464,7 +47464,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-submodule.txt:23
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git submodule' [--quiet] [--cached]\n"
 "'git submodule' [--quiet] add [<options>] [--] <repository> [<path>]\n"
@@ -47535,7 +47535,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:74
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "status [--cached] [--recursive] [--] [<path>...]"
 msgstr ""
 
@@ -47559,7 +47559,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:91
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "init [--] [<path>...]"
 msgstr ""
 
@@ -47589,7 +47589,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:114
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "deinit [-f|--force] (--all|[--] <path>...)"
 msgstr ""
 
@@ -47619,7 +47619,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:132
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "update [--init] [--remote] [-N|--no-fetch] [--[no-]recommend-shallow] [-f|--force] [--checkout|--rebase|--merge] [--reference <repository>] [--depth <depth>] [--recursive] [--jobs <n>] [--] [<path>...]"
 msgstr ""
 
@@ -47743,7 +47743,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:182
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "summary [--cached|--files] [(-n|--summary-limit) <n>] [commit] [--] [<path>...]"
 msgstr ""
 
@@ -47785,7 +47785,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:224
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "sync [--recursive] [--] [<path>...]"
 msgstr ""
 
@@ -48313,7 +48313,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:127
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Fetch unfetched revisions from the Subversion remote we are tracking.  The name of the [svn-remote \"...\"] section in the $GIT_DIR/config file may be specified as an optional command-line argument."
 msgstr ""
 
@@ -48759,7 +48759,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:366
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "is supported, non-numeric args are not: HEAD, NEXT, BASE, PREV, etc ..."
 msgstr ""
 
@@ -49662,7 +49662,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-svn.txt:876
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "# Clone a repo (like git clone):\n"
 "\tgit svn clone http://svn.example.com/project/trunk\n"
@@ -49715,7 +49715,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-svn.txt:924
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "# Do the initial import on a server\n"
 "\tssh server \"cd /pub && git svn clone http://svn.example.com/project [options...]\"\n"
@@ -50430,7 +50430,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-tag.txt:20
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git tag' [-a | -s | -u <keyid>] [-f] [-m <msg> | -F <file>] [-e]\n"
 "\t<tagname> [<commit> | <object>]\n"
@@ -50576,7 +50576,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-tag.txt:103
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "List tags. With optional `<pattern>...`, e.g. `git tag --list 'v-*'`, list only the tags that match the pattern(s)."
 msgstr ""
 
@@ -50866,13 +50866,13 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:319
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "\tgit://git..../proj.git master\n"
 msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:321
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "to get the following updates...\n"
 msgstr ""
 
@@ -50884,7 +50884,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:327
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "$ git pull git://git..../proj.git master\n"
 msgstr ""
 
@@ -51004,7 +51004,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git.txt:55
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Other options are available to control how the manual page is displayed. See linkgit:git-help[1] for more information, because `git --help ...` is converted internally into `git help ...`."
 msgstr ""
 
@@ -51048,7 +51048,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git.txt:82
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Note that omitting the `=` in `git -c foo.bar ...` is allowed and sets `foo.bar` to the boolean true value (just like `[foo]bar` would in a config file). Including the equals but with an empty value (like `git -c foo.bar= ...`) sets `foo.bar` to the empty string which `git config --type=bool` will convert to `false`."
 msgstr ""
 
@@ -51252,7 +51252,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:169
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--list-cmds=group[,group...]"
 msgstr ""
 
@@ -51755,7 +51755,7 @@ msgstr "`GIT_COMMON_DIR`"
 
 #. type: Plain text
 #: en/git.txt:481
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If this variable is set to a path, non-worktree files that are normally in $GIT_DIR will be taken from this path instead. Worktree-specific files such as HEAD or index are taken from $GIT_DIR. See linkgit:gitrepository-layout[5] and linkgit:git-worktree[1] for details. This variable has lower precedence than other path variables such as GIT_INDEX_FILE, GIT_OBJECT_DIRECTORY..."
 msgstr ""
 
@@ -52226,10 +52226,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:685
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2`"
-msgstr "`GIT_TRACE`"
+msgstr "`GIT_TRACE2`"
 
 #. type: Plain text
 #: en/git.txt:689
@@ -52257,10 +52256,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:720
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE_SETUP`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2_EVENT`"
-msgstr "`GIT_TRACE_SETUP`"
+msgstr "`GIT_TRACE2_EVENT`"
 
 #. type: Plain text
 #: en/git.txt:725
@@ -52270,10 +52268,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:726
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE_PERFORMANCE`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2_PERF`"
-msgstr "`GIT_TRACE_PERFORMANCE`"
+msgstr "`GIT_TRACE2_PERF`"
 
 #. type: Plain text
 #: en/git.txt:732
@@ -52712,7 +52709,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-update-index.txt:29
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git update-index'\n"
 "\t     [--add] [--remove | --force-remove] [--replace]\n"
@@ -53272,7 +53269,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-update-index.txt:348
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The command looks at `core.ignorestat` configuration variable.  When this is true, paths updated with `git update-index paths...` and paths updated with other Git commands that update both index and working tree (e.g. 'git apply --index', 'git checkout-index -u', and 'git read-tree -u') are automatically marked as \"assume unchanged\".  Note that \"assume unchanged\" bit is *not* set if `git update-index --refresh` finds the working tree file matches the index (use `git update-index --really-refresh` if you want to mark them as \"assume unchanged\")."
 msgstr ""
 
@@ -54142,7 +54139,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-commit.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-commit' <commit>...\n"
 msgstr ""
 
@@ -54184,7 +54181,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-pack.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-pack' [-v|--verbose] [-s|--stat-only] [--] <pack>.idx ...\n"
 msgstr ""
 
@@ -54196,7 +54193,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-verify-pack.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<pack>.idx ..."
 msgstr ""
 
@@ -54274,7 +54271,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-tag.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-tag' [--format=<format>] <tag>...\n"
 msgstr ""
 
@@ -54292,7 +54289,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-verify-tag.txt:27
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<tag>..."
 msgstr ""
 
@@ -54316,7 +54313,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-web--browse.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git web{litdd}browse' [<options>] <url|file>...\n"
 msgstr ""
 
@@ -54590,7 +54587,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-whatchanged.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git whatchanged' <option>...\n"
 msgstr ""
 
@@ -55121,7 +55118,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-worktree.txt:372
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git worktree add -b emergency-fix ../temp master\n"
 "$ pushd ../temp\n"
@@ -56326,7 +56323,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/pretty-formats.txt:115
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'%C(...)'"
 msgstr ""
 
@@ -56338,7 +56335,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/pretty-formats.txt:129
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "\"CONFIGURATION FILE\" section of linkgit:git-config[1].  By default, colors are shown only when enabled for log output (by `color.diff`, `color.ui`, or `--color`, and respecting the `auto` settings of the former if we are going to a terminal). `%C(auto,...)` is accepted as a historical synonym for the default (e.g., `%C(auto,red)`). Specifying `%C(always,...)` will show the colors even when color is not otherwise enabled (though consider just using `--color=always` to enable color for the whole output, including this format and anything else git might color).  `auto` alone (i.e. `%C(auto)`) will turn on auto coloring on the next placeholders until the color is switched again."
 msgstr ""
 
@@ -57431,7 +57428,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/pull-fetch-param.txt:45
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "Whether that update is allowed without `--force` depends on the ref namespace it's being fetched to, the type of object being fetched, and whether the update is considered to be a fast-forward. Generally, the same rules apply for fetching as when pushing, see the `<refspec>...` section of linkgit:git-push[1] for what those are. Exceptions to those rules particular to 'git fetch' are noted below."
 msgstr ""
 
@@ -57902,13 +57899,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/revisions.txt:280
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "The '...' (three-dot) Symmetric Difference Notation"
 msgstr ""
 
 #. type: Plain text
 #: en/revisions.txt:286
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "A similar notation 'r1\\...r2' is called symmetric difference of 'r1' and 'r2' and is defined as 'r1 r2 --not $(git merge-base --all r1 r2)'.  It is the set of commits that are reachable from either one of 'r1' (left side) or 'r2' (right side) but not from both."
 msgstr ""
 
@@ -57998,7 +57995,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/revisions.txt:331
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'<rev1>\\...<rev2>'"
 msgstr ""
 
@@ -58052,7 +58049,7 @@ msgstr ""
 
 #. type: delimited block .
 #: en/revisions.txt:377
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "   Args   Expanded arguments    Selected commits\n"
 "   D                            G H D\n"
@@ -58542,7 +58539,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:256
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "For example, `--cherry-pick --right-only A...B` omits those commits from `B` which are in `A` or are patch-equivalent to a commit in `A`. In other words, this lists the `+` commits from `git cherry A B`.  More precisely, `--cherry-pick --right-only --no-merges` gives the exact list."
 msgstr ""
 
@@ -58554,7 +58551,7 @@ msgstr "--cherry"
 
 #. type: Plain text
 #: en/rev-list-options.txt:263
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "A synonym for `--right-only --cherry-mark --no-merges`; useful to limit the output to the commits on our side and mark those that have been applied to the other side of a forked history with `git log --cherry upstream...mybranch`, similar to `git cherry upstream mybranch`."
 msgstr ""
 
@@ -58566,7 +58563,7 @@ msgstr "--walk-reflogs"
 
 #. type: Plain text
 #: en/rev-list-options.txt:271
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Instead of walking the commit ancestry chain, walk reflog entries from the most recent one to older ones.  When this option is used you cannot specify commits to exclude (that is, '{caret}commit', 'commit1..commit2', and 'commit1\\...commit2' notations cannot be used)."
 msgstr ""
 
@@ -59559,7 +59556,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:875
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "`--date=format:...` feeds the format `...` to your system `strftime`, except for %z and %Z, which are handled internally.  Use `--date=format:%c` to show the date in your system locale's preferred format.  See the `strftime` manual for a complete list of format placeholders. When using `-local`, the correct syntax is `--date=format-local:...`."
 msgstr ""
 
@@ -59595,7 +59592,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:892
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Print also the parents of the commit (in the form \"commit parent...\").  Also enables parent rewriting, see 'History Simplification' above."
 msgstr ""
 
@@ -59607,7 +59604,7 @@ msgstr "--children"
 
 #. type: Plain text
 #: en/rev-list-options.txt:896
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Print also the children of the commit (in the form \"commit child...\").  Also enables parent rewriting, see 'History Simplification' above."
 msgstr ""
 
@@ -59660,13 +59657,13 @@ msgstr ""
 
 #. type: delimited block -
 #: en/rev-list-options.txt:922
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "\t$ git rev-list --left-right --boundary --pretty=oneline A...B\n"
 msgstr ""
 
 #. type: delimited block -
 #: en/rev-list-options.txt:929
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "\t>bbbbbbb... 3rd on b\n"
 "\t>bbbbbbb... 2nd on b\n"

--- a/po/documentation.zh_HANS-CN.po
+++ b/po/documentation.zh_HANS-CN.po
@@ -2437,7 +2437,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/config.txt:256
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The value for many variables that specify various sizes can be suffixed with `k`, `M`,... to mean \"scale the number by 1024\", \"by 1024x1024\", etc."
 msgstr ""
 
@@ -2827,7 +2827,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-format.txt:16
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "git-diff-tree [-r] <tree-ish-1> <tree-ish-2> [<pattern>...]"
 msgstr ""
 
@@ -2839,7 +2839,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-format.txt:19
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "git-diff-files [<pattern>...]"
 msgstr ""
 
@@ -3519,7 +3519,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/diff-generate-patch.txt:179
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Unlike the traditional 'unified' diff format, which shows two files A and B with a single column that has `-` (minus -- appears in A but removed in B), `+` (plus -- missing in A but added to B), or `\" \"` (space -- unchanged) prefix, this format compares two or more files file1, file2,... with one file X, and shows how X differs from each of fileN.  One column for each of fileN is prepended to the output line to note how X's line is different from it."
 msgstr ""
 
@@ -3842,7 +3842,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:137
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Generate a diffstat. By default, as much space as necessary will be used for the filename part, and the rest for the graph part. Maximum width defaults to terminal width, or 80 columns if not connected to a terminal, and can be overridden by `<width>`. The width of the filename part can be limited by giving another width `<name-width>` after a comma. The width of the graph part can be limited by using `--stat-graph-width=<width>` (affects all commands generating a stat graph) or by setting `diff.statGraphWidth=<width>` (does not affect `git format-patch`).  By giving a third parameter `<count>`, you can limit the output to the first `<count>` lines, followed by `...` if there are more."
 msgstr ""
 
@@ -3890,13 +3890,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:161
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "-X[<param1,param2,...>]"
 msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:162
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--dirstat[=<param1,param2,...>]"
 msgstr ""
 
@@ -3986,13 +3986,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:209
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--dirstat-by-file[=<param1,param2>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:211
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Synonym for --dirstat=files,param1,param2..."
 msgstr ""
 
@@ -4653,13 +4653,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:527
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--diff-filter=[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:538
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Select only files that are Added (`A`), Copied (`C`), Deleted (`D`), Modified (`M`), Renamed (`R`), have their type (i.e. regular file, symlink, submodule, ...) changed (`T`), are Unmerged (`U`), are Unknown (`X`), or have had their pairing Broken (`B`).  Any combination of the filter characters (including none) can be used.  When `*` (All-or-none) is added to the combination, all paths are selected if there is any file that matches other criteria in the comparison; if there is no file that matches other criteria, nothing is selected."
 msgstr ""
 
@@ -4719,7 +4719,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/diff-options.txt:573
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "+    return !regexec(regexp, two->ptr, 1, &regmatch, 0);\n"
 "...\n"
@@ -5642,7 +5642,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-add.txt:15
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "'git add' [--verbose | -v] [--dry-run | -n] [--force | -f] [--interactive | -i] [--patch | -p]\n"
 "\t  [--edit | -e] [--[no-]all | --[no-]ignore-removal | [--update | -u]]\n"
@@ -5700,7 +5700,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-add.txt:52 en/git-grep.txt:308 en/git-status.txt:148
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid "<pathspec>..."
 msgstr ""
 
@@ -5844,7 +5844,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-add.txt:145
-#, priority:300
+#, ignore-ellipsis, priority:300
 msgid "This option is primarily to help users who are used to older versions of Git, whose \"git add <pathspec>...\" was a synonym for \"git add --no-all <pathspec>...\", i.e. ignored removed files."
 msgstr ""
 
@@ -6342,7 +6342,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-am.txt:20
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git am' [--signoff] [--keep] [--[no-]keep-cr] [--[no-]utf8]\n"
 "\t [--[no-]3way] [--interactive] [--committer-date-is-author-date]\n"
@@ -6362,7 +6362,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-am.txt:29
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "(<mbox>|<Maildir>)..."
 msgstr ""
 
@@ -6898,7 +6898,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-apply.txt:20
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git apply' [--stat] [--numstat] [--summary] [--check] [--index | --intent-to-add] [--3way]\n"
 "\t  [--apply] [--no-add] [--build-fake-ancestor=<file>] [-R | --reverse]\n"
@@ -6924,7 +6924,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-apply.txt:37
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<patch>..."
 msgstr ""
 
@@ -7338,7 +7338,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-archimport.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git archimport' [-h] [-v] [-o] [-a] [-f] [-T] [-D depth] [-t tempdir]\n"
 "               <archive/branch>[:<git-branch>] ...\n"
@@ -7502,7 +7502,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-archive.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git archive' [--format=<fmt>] [--list] [--prefix=<prefix>/] [<extra>]\n"
 "\t      [-o <file> | --output=<file>] [--worktree-attributes]\n"
@@ -7890,7 +7890,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bisect.txt:31
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 " git bisect start [--term-{old,good}=<term> --term-{new,bad}=<term>]\n"
 "\t\t  [--no-checkout] [<bad> [<good>...]] [--] [<paths>...]\n"
@@ -8085,7 +8085,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-bisect.txt:158
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git bisect new [<rev>...]\n"
 msgstr ""
 
@@ -8115,7 +8115,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bisect.txt:175
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If you would like to use your own terms instead of \"bad\"/\"good\" or \"new\"/\"old\", you can choose any names you like (except existing bisect subcommands like `reset`, `start`, ...) by starting the bisection using"
 msgstr ""
 
@@ -8555,7 +8555,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-bisect.txt:463
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git bisect start HEAD <known-good-commit> [ <boundary-commit> ... ] --no-checkout\n"
 "$ git bisect run sh -c '\n"
@@ -9023,7 +9023,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:26
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git branch' [--color[=<when>] | --no-color] [--show-current]\n"
 "\t[-v [--abbrev=<length> | --no-abbrev]]\n"
@@ -9068,7 +9068,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:61
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "The command's second form creates a new branch head named <branchname> which points to the current `HEAD`, or <start-point> if given. As a special case, for <start-point>, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -9266,7 +9266,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:176
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "List branches.  With optional `<pattern>...`, e.g. `git branch --list 'maint-*'`, list only the branches that match the pattern(s)."
 msgstr ""
 
@@ -9512,7 +9512,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:291
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "Sort based on the key given. Prefix `-` to sort in descending order of the value. You may use the --sort=<key> option multiple times, in which case the last key becomes the primary key. The keys supported are the same as those in `git for-each-ref`. Sort order defaults to the value configured for the `branch.sort` variable if exists, or to sorting based on the full refname (including `refs/...` prefix). This lists detached HEAD (if present) first, then local branches and finally remote-tracking branches. See linkgit:git-config[1]."
 msgstr ""
 
@@ -9554,7 +9554,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-branch.txt:317
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git clone git://git.kernel.org/pub/scm/.../linux-2.6 my2.6\n"
 "$ cd my2.6\n"
@@ -9576,7 +9576,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-branch.txt:329
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git clone git://git.kernel.org/.../git.git my.git\n"
 "$ cd my.git\n"
@@ -9690,7 +9690,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bundle.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git bundle' create <file> <git-rev-list-args>\n"
 "'git bundle' verify <file>\n"
@@ -9766,7 +9766,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-bundle.txt:71
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<refname>...]"
 msgstr ""
 
@@ -10542,7 +10542,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-attr.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git check-attr' [-a | --all | <attr>...] [--] <pathname>...\n"
 "'git check-attr' --stdin [-z] [-a | --all | <attr>...]\n"
@@ -10783,7 +10783,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-ignore.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git check-ignore' [<options>] <pathname>...\n"
 "'git check-ignore' [<options>] --stdin\n"
@@ -10959,7 +10959,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-mailmap.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git check-mailmap' [<options>] <contact>...\n"
 msgstr ""
 
@@ -10995,7 +10995,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout-index.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git checkout-index' [-u] [-q] [-a] [-f] [-n] [--prefix=<string>]\n"
 "\t\t   [--stage=<number>|all]\n"
@@ -11270,7 +11270,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:18
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git checkout' [-q] [-f] [-m] [<branch>]\n"
 "'git checkout' [-q] [-f] [-m] --detach [<branch>]\n"
@@ -11381,7 +11381,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-checkout.txt:82
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git checkout' [<tree-ish>] [--] <pathspec>..."
 msgstr ""
 
@@ -11399,7 +11399,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-checkout.txt:98
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git checkout' (-p|--patch) [<tree-ish>] [--] [<pathspec>...]"
 msgstr ""
 
@@ -11741,7 +11741,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:326 en/git-switch.txt:58
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "As a special case, you may use `A...B` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -11771,7 +11771,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:337
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "As a special case, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -12342,7 +12342,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git cherry-pick' [--edit] [-n] [-m parent-number] [-s] [-x] [--ff]\n"
 "\t\t  [-S[<keyid>]] <commit>...\n"
@@ -12399,13 +12399,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-cherry-pick.txt:43 en/git-merge.txt:116 en/git-revert.txt:36 en/git-verify-commit.txt:27
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "<commit>..."
 msgstr ""
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:52
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Commits to cherry-pick.  For a more complete list of ways to spell commits, see linkgit:gitrevisions[7].  Sets of commits can be passed but no traversal is done by default, as if the `--no-walk` option was specified, see linkgit:git-rev-list[1]. Note that specifying a range will feed all <commit>... arguments to a single revision walk (see a later example that uses 'maint master..next')."
 msgstr ""
 
@@ -12435,7 +12435,7 @@ msgstr "-x"
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:78
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When recording the commit, append a line that says \"(cherry picked from commit ...)\" to the original commit message in order to indicate which commit this change was cherry-picked from.  This is done only for cherry picks without conflicts.  Do not use this option if you are cherry-picking from your private branch because the information is useless to the recipient.  If on the other hand you are cherry-picking between two publicly visible branches (e.g. backporting a fix to a maintenance branch for an older release from a development branch), adding this information can be useful."
 msgstr ""
 
@@ -12793,7 +12793,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:58
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git checkout -b topic origin/master\n"
 "# work and create some commits\n"
@@ -12829,7 +12829,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git log --graph --oneline --decorate --boundary origin/master...topic\n"
 "* 7654321 (origin/master) upstream tip commit\n"
@@ -12852,7 +12852,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:96
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git cherry origin/master topic\n"
 "- cccc000... commit C\n"
@@ -12880,7 +12880,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:126
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git log --graph --oneline --decorate --boundary origin/master...topic\n"
 "* 7654321 (origin/master) upstream tip commit\n"
@@ -12906,7 +12906,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:136
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git cherry origin/master topic base\n"
 "- cccc000... commit C\n"
@@ -12958,7 +12958,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-clean.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git clean' [-d] [-f] [-i] [-n] [-q] [-e <pattern>] [-x | -X] [--] <path>...\n"
 msgstr ""
 
@@ -12976,7 +12976,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-clean.txt:25
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If any optional `<path>...` arguments are given, only those paths are affected."
 msgstr ""
 
@@ -13587,7 +13587,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-clone.txt:306
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "$ git clone git://git.kernel.org/pub/scm/.../linux.git my-linux\n"
 "$ cd my-linux\n"
@@ -13617,7 +13617,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-clone.txt:325
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "$ git clone --reference /git/linux.git \\\n"
 "\tgit://git.kernel.org/pub/scm/.../linux.git \\\n"
@@ -13810,7 +13810,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-commit-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git commit-tree' <tree> [(-p <parent>)...]\n"
 "'git commit-tree' [(-p <parent>)...] [-S[<keyid>]] [(-m <message>)...]\n"
@@ -14011,7 +14011,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-commit.txt:17
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git commit' [-a | --interactive | --patch] [-s] [-v] [-u<mode>] [--amend]\n"
 "\t   [--dry-run] [(-c | -C | --fixup | --squash) <commit>]\n"
@@ -14431,7 +14431,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-commit.txt:248
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "\t$ git reset --soft HEAD^\n"
 "\t$ ... do something else to come up with the right tree ...\n"
@@ -14596,7 +14596,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-commit.txt:346 en/git-rm.txt:29
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "<file>..."
 msgstr ""
 
@@ -15573,7 +15573,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-config.txt:428
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "However, if you really only want to replace the line for the default proxy, i.e. the one without a \"for ...\" postfix, do something like this:"
 msgstr ""
 
@@ -16931,7 +16931,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-cvsserver.txt:26
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git-cvsserver' [<options>] [pserver|server] [<directory> ...]\n"
 msgstr ""
 
@@ -17629,7 +17629,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-daemon.txt:25
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git daemon' [--verbose] [--syslog] [--export-all]\n"
 "\t     [--timeout=<n>] [--init-timeout=<n>] [--max-connections=<n>]\n"
@@ -18195,7 +18195,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-describe.txt:14
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "'git describe' [--all] [--tags] [--contains] [--abbrev=<n>] [<commit-ish>...]\n"
 "'git describe' [--all] [--tags] [--contains] [--abbrev=<n>] --dirty[=<mark>]\n"
@@ -18222,7 +18222,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-describe.txt:37
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "<commit-ish>..."
 msgstr ""
 
@@ -18318,7 +18318,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-describe.txt:95
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Always output the long format (the tag, the number of commits and the abbreviated commit name) even when it matches a tag.  This is useful when you want to see parts of the commit object name in \"describe\" output, even when the commit in question happens to be a tagged version.  Instead of just emitting the tag name, it will describe such a commit as v1.2-0-gdeadbee (0th commit since tag v1.2 that points at object deadbee....)."
 msgstr ""
 
@@ -18496,7 +18496,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-files.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git diff-files' [-q] [-0|-1|-2|-3|-c|--cc] [<common diff options>] [<path>...]\n"
 msgstr ""
 
@@ -18568,7 +18568,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-index.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git diff-index' [-m] [--cached] [<common diff options>] <tree-ish> [<path>...]\n"
 msgstr ""
 
@@ -18707,7 +18707,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-index.txt:102
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "  torvalds@ppc970:~/v2.6/linux> git diff-index --abbrev HEAD\n"
 "  :100644 100664 7476bb... 000000...      kernel/sched.c\n"
@@ -18745,7 +18745,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-difftool.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git difftool' [<options>] [<commit> [<commit>]] [--] [<path>...]\n"
 msgstr ""
 
@@ -19057,7 +19057,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git diff-tree' [--stdin] [-m] [-s] [-v] [--no-commit-id] [--pretty]\n"
 "\t      [-t] [-r] [-c | --cc] [--combined-all-paths] [--root]\n"
@@ -19090,7 +19090,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff-tree.txt:32 en/git-diff.txt:114 en/git-submodule.txt:422
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "<path>..."
 msgstr ""
 
@@ -19216,7 +19216,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:17
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git diff' [<options>] [<commit>] [--] [<path>...]\n"
 "'git diff' [<options>] --cached [<commit>] [--] [<path>...]\n"
@@ -19233,7 +19233,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:24
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] [--] [<path>...]"
 msgstr ""
 
@@ -19257,7 +19257,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:41
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] --cached [<commit>] [--] [<path>...]"
 msgstr ""
 
@@ -19269,7 +19269,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:51
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit> [--] [<path>...]"
 msgstr ""
 
@@ -19281,7 +19281,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:59
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit> <commit> [--] [<path>...]"
 msgstr ""
 
@@ -19293,7 +19293,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:64
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit>..<commit> [--] [<path>...]"
 msgstr ""
 
@@ -19305,13 +19305,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:70
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit>\\...<commit> [--] [<path>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:77
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "This form is to view the changes on the branch containing and up to the second <commit>, starting at a common ancestor of both <commit>.  \"git diff A\\...B\" is equivalent to \"git diff $(git merge-base A B) B\".  You can omit any one of <commit>, which has the same effect as using HEAD instead."
 msgstr ""
 
@@ -19323,7 +19323,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:89
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "For a more complete list of ways to spell <commit>, see \"SPECIFYING REVISIONS\" section in linkgit:gitrevisions[7].  However, \"diff\" is about comparing two _endpoints_, not ranges, and the range notations (\"<commit>..<commit>\" and \"<commit>\\...<commit>\") do not mean a range as defined in the \"SPECIFYING RANGES\" section in linkgit:gitrevisions[7]."
 msgstr ""
 
@@ -19431,7 +19431,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-diff.txt:160
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git diff topic master    <1>\n"
 "$ git diff topic..master   <2>\n"
@@ -19751,7 +19751,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:143
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<git-rev-list-args>...]"
 msgstr ""
 
@@ -19832,7 +19832,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-fast-export.txt:215
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git init anon-repo\n"
 "$ cd anon-repo\n"
@@ -22142,7 +22142,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch-pack.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git fetch-pack' [--all] [--quiet|-q] [--keep|-k] [--thin] [--include-tag]\n"
 "\t[--upload-pack=<git-upload-pack>]\n"
@@ -22296,7 +22296,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fetch-pack.txt:117 en/git-ls-remote.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<refs>..."
 msgstr ""
 
@@ -22326,7 +22326,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch.txt:16
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git fetch' [<options>] [<repository> [<refspec>...]]\n"
 "'git fetch' [<options>] <group>\n"
@@ -22667,7 +22667,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch.txt:226
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "For a successfully fetched ref, the summary shows the old and new values of the ref in a form suitable for using as an argument to `git log` (this is `<old>..<new>` in most cases, and `<old>...<new>` for forced non-fast-forward updates)."
 msgstr ""
 
@@ -22789,7 +22789,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:18
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git filter-branch' [--setup <command>] [--subdirectory-filter <directory>]\n"
 "\t[--env-filter <command>] [--tree-filter <command>]\n"
@@ -22928,7 +22928,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:117
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for rewriting the index.  It is similar to the tree filter but does not check out the tree, which makes it much faster.  Frequently used with `git rm --cached --ignore-unmatch ...`, see EXAMPLES below.  For hairy cases, see linkgit:git-update-index[1]."
 msgstr ""
 
@@ -22940,7 +22940,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:125
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for rewriting the commit's parent list.  It will receive the parent string on stdin and shall output the new parent string on stdout.  The parent string is in the format described in linkgit:git-commit-tree[1]: empty for the initial commit, \"-p parent\" for a normal commit and \"-p parent1 -p parent2 -p parent3 ...\" for a merge commit."
 msgstr ""
 
@@ -22964,7 +22964,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:138
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for performing the commit.  If this filter is specified, it will be called instead of the 'git commit-tree' command, with arguments of the form \"<TREE_ID> [(-p <PARENT_COMMIT_ID>)...]\" and the log message on stdin.  The commit id is expected on stdout."
 msgstr ""
 
@@ -23066,7 +23066,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-filter-branch.txt:207
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<rev-list options>..."
 msgstr ""
 
@@ -23327,7 +23327,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-filter-branch.txt:388
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git filter-branch ... C..H\n"
 msgstr ""
 
@@ -23339,7 +23339,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-filter-branch.txt:395
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "git filter-branch ... C..H --not D\n"
 "git filter-branch ... D..H --not C\n"
@@ -23578,7 +23578,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git for-each-ref' [--count=<count>] [--shell|--perl|--python|--tcl]\n"
 "\t\t   [(--sort=<key>)...] [--format=<format>] [<pattern>...]\n"
@@ -23595,7 +23595,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-for-each-ref.txt:29 en/git-show-ref.txt:88
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<pattern>..."
 msgstr ""
 
@@ -23883,7 +23883,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:197
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Left-, middle-, or right-align the content between %(align:...) and %(end). The \"align:\" is followed by `width=<width>` and `position=<position>` in any order separated by a comma, where the `<position>` is either left, right or middle, default being left and `<width>` is the total length of the content with alignment. For brevity, the \"width=\" and/or \"position=\" prefixes may be omitted, and bare <width> and <position> used instead.  For instance, `%(align:<width>,<position>)`. If the contents length is more than the width then no alignment is performed. If used with `--quote` everything in between %(align:...) and %(end) is quoted, but if nested then only the topmost level performs quoting."
 msgstr ""
 
@@ -23895,7 +23895,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:210
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Used as %(if)...%(then)...%(end) or %(if)...%(then)...%(else)...%(end).  If there is an atom with value or string literal after the %(if) then everything after the %(then) is printed, else if the %(else) atom is used, then everything after %(else) is printed. We ignore space when evaluating the string before %(then), this is useful when we use the %(HEAD) atom which prints either \"*\" or \" \" and we want to apply the 'if' condition only on the 'HEAD' ref.  Append \":equals=<string>\" or \":notequals=<string>\" to compare the value between the %(if:...) and %(then) atoms with the given string."
 msgstr ""
 
@@ -24116,7 +24116,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:361
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "An example to show the usage of %(if)...%(then)...%(else)...%(end).  This prefixes the current branch with a star."
 msgstr ""
 
@@ -24128,7 +24128,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:369
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "An example to show the usage of %(if)...%(then)...%(end).  This prints the authorname, if present."
 msgstr ""
 
@@ -24774,7 +24774,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:372
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "Do the same for ia64 so we can have sleek & trim looking\n"
 "...\n"
@@ -24782,7 +24782,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:380
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Typically it will be placed in a MUA's drafts folder, edited to add timely commentary that should not go in the changelog after the three dashes, and then sent as a message whose body, in our example, starts with \"arch/arm config files were...\".  On the receiving end, readers can save interesting patches in a UNIX mailbox and apply them with linkgit:git-am[1]."
 msgstr ""
 
@@ -24794,7 +24794,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:390
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "...\n"
 "> So we should do such-and-such.\n"
@@ -24816,7 +24816,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:398
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "arch/arm config files were slimmed down using a python script\n"
 "...\n"
@@ -24990,7 +24990,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:499
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Configure your mail server composition as plain text: Edit...Account Settings...Composition & Addressing, uncheck \"Compose Messages in HTML\"."
 msgstr ""
 
@@ -25127,7 +25127,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:573
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Use Message -> Insert file... and insert the patch."
 msgstr ""
 
@@ -25302,7 +25302,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fsck-objects.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git fsck-objects' ...\n"
 msgstr ""
 
@@ -25690,7 +25690,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-gc.txt:55
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Once housekeeping is triggered by exceeding the limits of configuration options such as `gc.auto` and `gc.autoPackLimit`, all other housekeeping tasks (e.g. rerere, working trees, reflog...) will be performed as well."
 msgstr ""
 
@@ -25864,7 +25864,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-grep.txt:32
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git grep' [-a | --text] [-I] [--textconv] [-i | --ignore-case] [-w | --word-regexp]\n"
 "\t   [-v | --invert-match] [-h|-H] [--full-name]\n"
@@ -26472,7 +26472,7 @@ msgstr "--not"
 
 #. type: Labeled list
 #: en/git-grep.txt:284
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "( ... )"
 msgstr ""
 
@@ -26502,7 +26502,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-grep.txt:300
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<tree>..."
 msgstr ""
 
@@ -26820,7 +26820,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-hash-object.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git hash-object' [-t <type>] [-w] [--path=<file>|--no-filters] [--stdin [--literally]] [--] <file>...\n"
 "'git hash-object' [-t <type>] [-w] --stdin-paths [--no-filters]\n"
@@ -26950,7 +26950,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-help.txt:38
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Note that `git --help ...` is identical to `git help ...` because the former is internally converted into the latter."
 msgstr ""
 
@@ -27400,7 +27400,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:102
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tAuthType Basic\n"
 "\tAuthName \"Git Access\"\n"
@@ -27418,7 +27418,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:115
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "<LocationMatch \"^/git/.*/git-receive-pack$\">\n"
 "\tAuthType Basic\n"
@@ -27442,7 +27442,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:136
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "<Location /git/private>\n"
 "\tAuthType Basic\n"
@@ -27592,7 +27592,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:231
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "auth.require = (\n"
 "\t\"/\" => (\n"
@@ -27795,7 +27795,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-http-push.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git http-push' [--all] [--dry-run] [--force] [--verbose] <url> <ref> [<ref>...]\n"
 msgstr ""
 
@@ -27864,7 +27864,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-http-push.txt:54 en/git-send-pack.txt:98
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<ref>..."
 msgstr ""
 
@@ -28729,7 +28729,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-interpret-trailers.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git interpret-trailers' [<options>] [(--trailer <token>[(=|:)<value>])...] [<file>...]\n"
 "'git interpret-trailers' [<options>] [--parse] [<file>...]\n"
@@ -29399,7 +29399,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-log.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'git log' [<options>] [<revision range>] [[--] <path>...]\n"
 msgstr ""
 
@@ -29495,7 +29495,7 @@ msgstr "--full-diff"
 
 #. type: Plain text
 #: en/git-log.txt:63
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Without this flag, `git log -p <path>...` shows commits that touch the specified paths, and diffs about the same specified paths.  With this, the full diff is shown for commits that touch the specified paths; this means that \"<path>...\" limits only commits, and doesn't limit diff for those commits."
 msgstr ""
 
@@ -29549,7 +29549,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-log.txt:93 en/git-shortlog.txt:72
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "[--] <path>..."
 msgstr ""
 
@@ -29825,7 +29825,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-files.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-files' [-z] [-t] [-v] [-f]\n"
 "\t\t(--[cached|deleted|others|ignored|stage|unmerged|killed|modified])*\n"
@@ -30306,7 +30306,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-remote.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-remote' [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
 "\t      [-q | --quiet] [--exit-code] [--get-url] [--sort=<key>]\n"
@@ -30411,7 +30411,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-remote.txt:91
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When unspecified, all references, after filtering done with --heads and --tags, are shown.  When <refs>... are specified, only references matching the given patterns are displayed."
 msgstr ""
 
@@ -30456,7 +30456,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-tree' [-d] [-r] [-t] [-l] [-z]\n"
 "\t    [--name-only] [--name-status] [--full-name] [--full-tree] [--abbrev[=<n>]]\n"
@@ -30537,7 +30537,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-ls-tree.txt:76
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<path>...]"
 msgstr ""
 
@@ -30747,7 +30747,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mailsplit.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git mailsplit' [-b] [-f<nn>] [-d<prec>] [--keep-cr] [--mboxrd]\n"
 "\t\t-o<directory> [--] [(<mbox>|<Maildir>)...]\n"
@@ -30869,7 +30869,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git merge-base' [-a|--all] <commit> <commit>...\n"
 "'git merge-base' [-a|--all] --octopus <commit>...\n"
@@ -31066,7 +31066,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:139
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tA=$(git rev-parse --verify A)\n"
 "\tif test \"$A\" = \"$(git merge-base A B)\"\n"
@@ -31083,7 +31083,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:146
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tif git merge-base --is-ancestor A B\n"
 "\tthen\n"
@@ -31570,7 +31570,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mergetool.txt:12
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git mergetool' [--tool=<tool>] [-y | --[no-]prompt] [<file>...]\n"
 msgstr ""
 
@@ -31732,7 +31732,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge.txt:17
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git merge' [-n] [--stat] [--no-commit] [--squash] [--[no-]edit]\n"
 "\t[-s <strategy>] [-X <strategy-option>] [-S[<keyid>]]\n"
@@ -32325,7 +32325,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mv.txt:13
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git mv' <options>... <args>...\n"
 msgstr ""
 
@@ -32337,7 +32337,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mv.txt:20
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 " git mv [-v] [-f] [-n] [-k] <source> <destination>\n"
 " git mv [-v] [-f] [-n] [-k] <source> ... <destination directory>\n"
@@ -32405,7 +32405,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-name-rev.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git name-rev' [--tags] [--refs=<pattern>]\n"
 "\t       ( --all | --stdin | <commit-ish>... )\n"
@@ -32523,7 +32523,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-notes.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git notes' [list [<object>]]\n"
 "'git notes' add [-f] [--allow-empty] [-F <file> | -m <msg> | (-c | -C) <object>] [<object>]\n"
@@ -32859,7 +32859,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-notes.txt:229
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Commit notes are blobs containing extra information about an object (usually information to supplement a commit's message).  These blobs are taken from notes refs.  A notes ref is usually a branch which contains \"files\" whose paths are the object names for the objects they describe, with some directory separators included for performance reasons footnote:[Permitted pathnames have the form 'ab'`/`'cd'`/`'ef'`/`'...'`/`'abcdef...': a sequence of directory names of two hexadecimal digits each followed by a filename with the rest of the object ID.]."
 msgstr ""
 
@@ -32925,7 +32925,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-notes.txt:288
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git notes add -m 'Tested-by: Johannes Sixt <j6t@kdbg.org>' 72a144e2\n"
 "$ git show -s 72a144e\n"
@@ -33144,7 +33144,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-p4.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git p4 clone' [<sync options>] [<clone options>] <p4 depot path>...\n"
 "'git p4 sync' [<sync options>] [<p4 depot path>...]\n"
@@ -33977,7 +33977,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-p4.txt:445
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The full syntax for a p4 view is documented in 'p4 help views'.  'git p4' knows only a subset of the view syntax.  It understands multi-line mappings, overlays with '+', exclusions with '-' and double-quotes around whitespace.  Of the possible wildcards, 'git p4' only handles '...', and only when it is at the end of the path.  'git p4' will complain if it encounters an unhandled wildcard."
 msgstr ""
 
@@ -34019,7 +34019,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-p4.txt:475
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "//depot/main/...\n"
 "//depot/branch1/...\n"
@@ -34033,7 +34033,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-p4.txt:480
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "//depot/main/... //depot/branch1/...\n"
 msgstr ""
 
@@ -35150,7 +35150,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-pack-redundant.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git pack-redundant' [ --verbose ] [ --alt-odb ] < --all | .pack filename ... >\n"
 msgstr ""
 
@@ -35450,7 +35450,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-prune.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git prune' [-n] [-v] [--progress] [--expire <time>] [--] [<head>...]\n"
 msgstr ""
 
@@ -35504,7 +35504,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-prune.txt:54
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<head>..."
 msgstr ""
 
@@ -35558,7 +35558,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-pull.txt:13
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "'git pull' [<options>] [<repository> [<refspec>...]]\n"
 msgstr ""
 
@@ -35906,7 +35906,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:18
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git push' [--all | --mirror | --tags] [--follow-tags] [--atomic] [-n | --dry-run] [--receive-pack=<git-receive-pack>]\n"
 "\t   [--repo=<repository>] [-f | --force] [-d | --delete] [--prune] [-v | --verbose]\n"
@@ -35936,7 +35936,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:39
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "When the command line does not specify what to push with `<refspec>...` arguments or `--all`, `--mirror`, `--tags` options, the command finds the default `<refspec>` by consulting `remote.*.push` configuration, and if it is not found, honors `push.default` configuration to decide what to push (See linkgit:git-config[1] for the meaning of `push.default`)."
 msgstr ""
 
@@ -35960,7 +35960,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:56
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "<refspec>..."
 msgstr ""
 
@@ -36320,7 +36320,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:343
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "Note that `--force` applies to all the refs that are pushed, hence using it with `push.default` set to `matching` or with multiple push destinations configured with `remote.*.push` may overwrite refs other than the current branch (including local refs that are strictly behind their remote counterpart).  To force a push to only one branch, use a `+` in front of the refspec to push (e.g `git push origin +master` to force a push to the `master` branch). See the `<refspec>...` section above for details."
 msgstr ""
 
@@ -36452,7 +36452,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:445
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "For a successfully pushed ref, the summary shows the old and new values of the ref in a form suitable for using as an argument to `git log` (this is `<old>..<new>` in most cases, and `<old>...<new>` for forced non-fast-forward updates)."
 msgstr ""
 
@@ -36713,7 +36713,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:616
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "See the section describing `<refspec>...` above for a discussion of the matching semantics."
 msgstr ""
 
@@ -37414,7 +37414,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-read-tree.txt:357
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git fetch git://.... linus\n"
 "$ LT=`git rev-parse FETCH_HEAD`\n"
@@ -37468,7 +37468,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-read-tree.txt:405
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "'git read-tree' and other merge-based commands ('git merge', 'git checkout'...) can help maintaining the skip-worktree bitmap and working directory update. `$GIT_DIR/info/sparse-checkout` is used to define the skip-worktree reference bitmap. When 'git read-tree' needs to update the working directory, it resets the skip-worktree bit in the index based on this file, which uses the same syntax as .gitignore files.  If an entry matches a pattern in this file, skip-worktree will not be set on that entry. Otherwise, skip-worktree will be set."
 msgstr ""
 
@@ -37848,7 +37848,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:219
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "As a special case, you may use \"A\\...B\" as a shortcut for the merge base of A and B if there is exactly one merge base. You can leave out at most one of A and B, in which case it defaults to HEAD."
 msgstr ""
 
@@ -38112,7 +38112,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:430
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "It is currently only possible to recreate the merge commits using the `recursive` merge strategy; Different merge strategies can be used only via explicit `exec git merge -s <strategy> [...]` commands."
 msgstr ""
 
@@ -38166,7 +38166,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:457
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "\tgit rebase -i --exec \"cmd1 && cmd2 && ...\"\n"
 msgstr ""
 
@@ -38178,7 +38178,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:461
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "\tgit rebase -i --exec \"cmd1\" --exec \"cmd2\" --exec ...\n"
 msgstr ""
 
@@ -38214,7 +38214,7 @@ msgstr "--no-autosquash"
 
 #. type: Plain text
 #: en/git-rebase.txt:495
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When the commit log message begins with \"squash! ...\" (or \"fixup! ...\"), and there is already a commit in the todo list that matches the same `...`, automatically modify the todo list of rebase -i so that the commit marked for squashing comes right after the commit to be modified, and change the action of the moved commit from `pick` to `squash` (or `fixup`).  A commit matches the `...` if the commit subject matches, or if the `...` refers to the commit's hash. As a fall-back, partial matches of the commit subject work, too.  The recommended way to create fixup/squash commits is by using the `--fixup`/`--squash` options of linkgit:git-commit[1]."
 msgstr ""
 
@@ -38541,7 +38541,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:636
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "pick deadbee The oneline of this commit\n"
 "pick fa1afe1 The oneline of the next commit\n"
@@ -38645,7 +38645,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:710
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "pick deadbee Implement feature XXX\n"
 "fixup f1a5c00 Fix to feature XXX\n"
@@ -38664,7 +38664,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:720
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The \"exec\" command launches the command in a shell (the one specified in `$SHELL`, or the default shell if `$SHELL` is not set), so you can use shell features (like \"cd\", \">\", \";\" ...). The command is run from the root of the working tree."
 msgstr ""
 
@@ -38808,7 +38808,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:815
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "    o---o---o---o---o---o---o---o  master\n"
 "\t \\\t\t\t \\\n"
@@ -39606,7 +39606,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reflog.txt:27
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git reflog' ['show'] [log-options] [<ref>]\n"
 "'git reflog expire' [--expire=<time>] [--expire-unreachable=<time>]\n"
@@ -39793,7 +39793,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-remote-ext.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git remote add <nick> \"ext::<command>[ <arguments>...]\"\n"
 msgstr ""
 
@@ -39931,7 +39931,7 @@ msgstr "GIT_EXT_SERVICE"
 
 #. type: Plain text
 #: en/git-remote-ext.txt:70
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Set to long name (git-upload-pack, etc...) of service helper needs to invoke."
 msgstr ""
 
@@ -39943,7 +39943,7 @@ msgstr "GIT_EXT_SERVICE_NOPREFIX"
 
 #. type: Plain text
 #: en/git-remote-ext.txt:74
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Set to long name (upload-pack, etc...) of service helper needs to invoke."
 msgstr ""
 
@@ -40123,7 +40123,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-remote.txt:25
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git remote' [-v | --verbose]\n"
 "'git remote add' [-t <branch>] [-m <master>] [-f] [--[no-]tags] [--mirror=<fetch|push>] <name> <url>\n"
@@ -40442,7 +40442,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-remote.txt:235
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "$ git remote\n"
 "origin\n"
@@ -40686,7 +40686,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-replace.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git replace' [-f] <object> <replacement>\n"
 "'git replace' [-f] --edit <object>\n"
@@ -40806,13 +40806,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-replace.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--graft <commit> [<parent>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/git-replace.txt:93
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Create a graft commit. A new commit is created with the same content as <commit> except that its parents will be [<parent>...] instead of <commit>'s parents. A replacement ref is then created to replace <commit> with the newly created commit. Use `--convert-graft-file` to convert a `$GIT_DIR/info/grafts` file and use replace refs instead."
 msgstr ""
 
@@ -41234,7 +41234,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rerere.txt:121
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git switch topic\n"
 "\t$ git merge master\n"
@@ -41266,7 +41266,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rerere.txt:145
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git switch topic\n"
 "\t$ git merge master\n"
@@ -41371,7 +41371,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reset.txt:14
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git reset' [-q] [<tree-ish>] [--] <paths>...\n"
 "'git reset' (--patch | -p) [<tree-ish>] [--] [<paths>...]\n"
@@ -41386,7 +41386,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-reset.txt:22
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git reset' [-q] [<tree-ish>] [--] <paths>..."
 msgstr ""
 
@@ -41398,7 +41398,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reset.txt:30
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "This means that `git reset <paths>` is the opposite of `git add <paths>`. This command is equivalent to `git restore [--source=<tree-ish>] --staged <paths>...`."
 msgstr ""
 
@@ -41410,7 +41410,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-reset.txt:38
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git reset' (--patch | -p) [<tree-ish>] [--] [<paths>...]"
 msgstr ""
 
@@ -41565,7 +41565,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:138
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git commit ...\n"
 "$ git reset --soft HEAD^      <1>\n"
@@ -41638,7 +41638,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:170
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git commit ...\n"
 "$ git reset --hard HEAD~3   <1>\n"
@@ -41658,7 +41658,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:190
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git pull                         <1>\n"
 "Auto-merging nitfol\n"
@@ -41703,7 +41703,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:215
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git pull                         <1>\n"
 "Auto-merging nitfol\n"
@@ -41829,7 +41829,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:289
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git tag start\n"
 "$ git switch -c branch1\n"
@@ -41872,7 +41872,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:317
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git reset -N HEAD^                        <1>\n"
 "$ git add -p                                <2>\n"
@@ -42098,7 +42098,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-restore.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git restore' [<options>] [--source=<tree>] [--staged] [--worktree] <pathspec>...\n"
 "'git restore' (-p|--patch) [<options>] [--source=<tree>] [--staged] [--worktree] [<pathspec>...]\n"
@@ -42351,7 +42351,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-revert.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git revert' [--[no-]edit] [-n] [-m parent-number] [-s] [-S[<keyid>]] <commit>...\n"
 "'git revert' (--continue | --skip | --abort | --quit)\n"
@@ -42455,7 +42455,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-list.txt:65
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git rev-list' [ --max-count=<number> ]\n"
 "\t     [ --skip=<number> ]\n"
@@ -42558,13 +42558,13 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-list.txt:102
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Another special notation is \"'<commit1>'...'<commit2>'\" which is useful for merges.  The resulting set of commits is the symmetric difference between the two operands.  The following two commands are equivalent:"
 msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-list.txt:106
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git rev-list A B --not $(git merge-base --all A B)\n"
 "\t$ git rev-list A...B\n"
@@ -42590,7 +42590,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-parse.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git rev-parse' [<options>] <args>...\n"
 msgstr ""
 
@@ -43074,7 +43074,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-parse.txt:253
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Resolve \"$GIT_DIR/<path>\" and takes other path relocation variables such as $GIT_OBJECT_DIRECTORY, $GIT_INDEX_FILE... into account. For example, if $GIT_OBJECT_DIRECTORY is set to /foo/bar then \"git rev-parse --git-path objects/abc\" returns /foo/bar/abc."
 msgstr ""
 
@@ -43182,7 +43182,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:290
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<args>..."
 msgstr ""
 
@@ -43314,7 +43314,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:364
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "OPTS_SPEC=\"\\\n"
 "some-command [<options>] <args>...\n"
@@ -43372,7 +43372,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:389
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "usage: some-command [<options>] <args>...\n"
 msgstr ""
 
@@ -43384,7 +43384,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:397
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "    -h, --help            show the help\n"
 "    --foo                 some nifty option --foo\n"
@@ -43395,7 +43395,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:400
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "An option group Header\n"
 "    -C[...]               option C with an optional argument\n"
@@ -43500,7 +43500,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rm.txt:12
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git rm' [-f | --force] [-n] [-r] [--cached] [--ignore-unmatch] [--quiet] [--] <file>...\n"
 msgstr ""
 
@@ -43728,7 +43728,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-email.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git send-email' [<options>] <file|directory|rev-list options>...\n"
 "'git send-email' --dump-aliases\n"
@@ -43796,7 +43796,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:53
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--bcc=<address>,..."
 msgstr ""
 
@@ -43814,7 +43814,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:59
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--cc=<address>,..."
 msgstr ""
 
@@ -43898,7 +43898,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-email.txt:110
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "  [PATCH 0/2] Here is what I did...\n"
 "    [PATCH 1/2] Clean up and tests\n"
@@ -43929,7 +43929,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:119
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--to=<address>,..."
 msgstr ""
 
@@ -44061,7 +44061,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-send-email.txt:188
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "$ git send-email --smtp-auth=\"PLAIN LOGIN GSSAPI\" ...\n"
 msgstr ""
 
@@ -44757,7 +44757,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-pack.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git send-pack' [--all] [--dry-run] [--force] [--receive-pack=<git-receive-pack>]\n"
 "\t\t[--verbose] [--thin] [--atomic]\n"
@@ -45130,7 +45130,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-shortlog.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "'git shortlog' [<options>] [<revision range>] [[--] <path>...]\n"
 "git log --pretty=short | 'git shortlog' [<options>]\n"
@@ -45258,7 +45258,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show-branch.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git show-branch' [-a|--all] [-r|--remotes] [--topo-order | --date-order]\n"
 "\t\t[--current] [--color[=<when>] | --no-color] [--sparse]\n"
@@ -45619,7 +45619,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show-ref.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git show-ref' [-q|--quiet] [--verify] [--head] [-d|--dereference]\n"
 "\t     [-s|--hash[=<n>]] [--abbrev[=<n>]] [--tags]\n"
@@ -45767,7 +45767,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-show-ref.txt:111
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git show-ref --head --dereference\n"
 "832e76a9899f560a90ffd62ae2ce83bbeff58f54 HEAD\n"
@@ -45788,7 +45788,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-show-ref.txt:121
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git show-ref --heads --hash\n"
 "2e3ba0114a1f52b47df29743d6915d056be13278\n"
@@ -45909,7 +45909,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'git show' [<options>] [<object>...]\n"
 msgstr ""
 
@@ -45957,7 +45957,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-show.txt:37
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "<object>..."
 msgstr ""
 
@@ -46215,7 +46215,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stage.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git stage' args...\n"
 msgstr ""
 
@@ -46239,7 +46239,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stash.txt:22
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git stash' list [<options>]\n"
 "'git stash' show [<options>] [<stash>]\n"
@@ -46262,7 +46262,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stash.txt:38
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "The modifications stashed away by this command can be listed with `git stash list`, inspected with `git stash show`, and restored (potentially on top of a different commit) with `git stash apply`.  Calling `git stash` without any arguments is equivalent to `git stash push`.  A stash is by default listed as \"WIP on 'branchname' ...\", but you can give a more descriptive message on the command line when you create one."
 msgstr ""
 
@@ -46274,7 +46274,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-stash.txt:49
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "push [-p|--patch] [-k|--[no-]keep-index] [-u|--include-untracked] [-a|--all] [-q|--quiet] [-m|--message <message>] [--] [<pathspec>...]"
 msgstr ""
 
@@ -46346,7 +46346,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:104
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "stash@{0}: WIP on submit: 6ebd0e2... Update git-stash documentation\n"
 "stash@{1}: On master: 9cc0589... Add git-stash\n"
@@ -46519,7 +46519,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:227
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git pull\n"
 " ...\n"
@@ -46537,7 +46537,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:246
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git switch -c my_wip\n"
@@ -46558,7 +46558,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:257
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git stash\n"
@@ -46582,7 +46582,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:275
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git add --patch foo            # add just first part to the index\n"
@@ -46636,7 +46636,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-status.txt:13
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git status' [<options>...] [--] [<pathspec>...]\n"
 msgstr ""
 
@@ -47113,7 +47113,7 @@ msgstr ""
 
 #. type: delimited block .
 #: en/git-status.txt:345
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "Field       Meaning\n"
 "--------------------------------------------------------\n"
@@ -47434,7 +47434,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-submodule.txt:23
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git submodule' [--quiet] [--cached]\n"
 "'git submodule' [--quiet] add [<options>] [--] <repository> [<path>]\n"
@@ -47505,7 +47505,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:74
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "status [--cached] [--recursive] [--] [<path>...]"
 msgstr ""
 
@@ -47529,7 +47529,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:91
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "init [--] [<path>...]"
 msgstr ""
 
@@ -47559,7 +47559,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:114
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "deinit [-f|--force] (--all|[--] <path>...)"
 msgstr ""
 
@@ -47589,7 +47589,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:132
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "update [--init] [--remote] [-N|--no-fetch] [--[no-]recommend-shallow] [-f|--force] [--checkout|--rebase|--merge] [--reference <repository>] [--depth <depth>] [--recursive] [--jobs <n>] [--] [<path>...]"
 msgstr ""
 
@@ -47713,7 +47713,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:182
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "summary [--cached|--files] [(-n|--summary-limit) <n>] [commit] [--] [<path>...]"
 msgstr ""
 
@@ -47755,7 +47755,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:224
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "sync [--recursive] [--] [<path>...]"
 msgstr ""
 
@@ -48281,7 +48281,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:127
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Fetch unfetched revisions from the Subversion remote we are tracking.  The name of the [svn-remote \"...\"] section in the $GIT_DIR/config file may be specified as an optional command-line argument."
 msgstr ""
 
@@ -48727,7 +48727,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:366
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "is supported, non-numeric args are not: HEAD, NEXT, BASE, PREV, etc ..."
 msgstr ""
 
@@ -49628,7 +49628,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-svn.txt:876
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "# Clone a repo (like git clone):\n"
 "\tgit svn clone http://svn.example.com/project/trunk\n"
@@ -49681,7 +49681,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-svn.txt:924
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "# Do the initial import on a server\n"
 "\tssh server \"cd /pub && git svn clone http://svn.example.com/project [options...]\"\n"
@@ -50396,7 +50396,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-tag.txt:20
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git tag' [-a | -s | -u <keyid>] [-f] [-m <msg> | -F <file>] [-e]\n"
 "\t<tagname> [<commit> | <object>]\n"
@@ -50542,7 +50542,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-tag.txt:103
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "List tags. With optional `<pattern>...`, e.g. `git tag --list 'v-*'`, list only the tags that match the pattern(s)."
 msgstr ""
 
@@ -50832,13 +50832,13 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:319
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "\tgit://git..../proj.git master\n"
 msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:321
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "to get the following updates...\n"
 msgstr ""
 
@@ -50850,7 +50850,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:327
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "$ git pull git://git..../proj.git master\n"
 msgstr ""
 
@@ -50970,7 +50970,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git.txt:55
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Other options are available to control how the manual page is displayed. See linkgit:git-help[1] for more information, because `git --help ...` is converted internally into `git help ...`."
 msgstr ""
 
@@ -51014,7 +51014,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git.txt:82
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Note that omitting the `=` in `git -c foo.bar ...` is allowed and sets `foo.bar` to the boolean true value (just like `[foo]bar` would in a config file). Including the equals but with an empty value (like `git -c foo.bar= ...`) sets `foo.bar` to the empty string which `git config --type=bool` will convert to `false`."
 msgstr ""
 
@@ -51218,7 +51218,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:169
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--list-cmds=group[,group...]"
 msgstr ""
 
@@ -51721,7 +51721,7 @@ msgstr "`GIT_COMMON_DIR`"
 
 #. type: Plain text
 #: en/git.txt:481
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If this variable is set to a path, non-worktree files that are normally in $GIT_DIR will be taken from this path instead. Worktree-specific files such as HEAD or index are taken from $GIT_DIR. See linkgit:gitrepository-layout[5] and linkgit:git-worktree[1] for details. This variable has lower precedence than other path variables such as GIT_INDEX_FILE, GIT_OBJECT_DIRECTORY..."
 msgstr ""
 
@@ -52192,10 +52192,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:685
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2`"
-msgstr "`GIT_TRACE`"
+msgstr "`GIT_TRACE2`"
 
 #. type: Plain text
 #: en/git.txt:689
@@ -52223,10 +52222,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:720
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE_SETUP`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2_EVENT`"
-msgstr "`GIT_TRACE_SETUP`"
+msgstr "`GIT_TRACE2_EVENT`"
 
 #. type: Plain text
 #: en/git.txt:725
@@ -52236,10 +52234,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:726
-#, fuzzy, no-wrap, priority:100
-#| msgid "`GIT_TRACE_PERFORMANCE`"
+#, ignore-same, no-wrap, priority:100
 msgid "`GIT_TRACE2_PERF`"
-msgstr "`GIT_TRACE_PERFORMANCE`"
+msgstr "`GIT_TRACE2_PERF`"
 
 #. type: Plain text
 #: en/git.txt:732
@@ -52678,7 +52675,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-update-index.txt:29
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git update-index'\n"
 "\t     [--add] [--remove | --force-remove] [--replace]\n"
@@ -53238,7 +53235,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-update-index.txt:348
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The command looks at `core.ignorestat` configuration variable.  When this is true, paths updated with `git update-index paths...` and paths updated with other Git commands that update both index and working tree (e.g. 'git apply --index', 'git checkout-index -u', and 'git read-tree -u') are automatically marked as \"assume unchanged\".  Note that \"assume unchanged\" bit is *not* set if `git update-index --refresh` finds the working tree file matches the index (use `git update-index --really-refresh` if you want to mark them as \"assume unchanged\")."
 msgstr ""
 
@@ -54107,7 +54104,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-commit.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-commit' <commit>...\n"
 msgstr ""
 
@@ -54149,7 +54146,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-pack.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-pack' [-v|--verbose] [-s|--stat-only] [--] <pack>.idx ...\n"
 msgstr ""
 
@@ -54161,7 +54158,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-verify-pack.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<pack>.idx ..."
 msgstr ""
 
@@ -54239,7 +54236,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-tag.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-tag' [--format=<format>] <tag>...\n"
 msgstr ""
 
@@ -54257,7 +54254,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-verify-tag.txt:27
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<tag>..."
 msgstr ""
 
@@ -54281,7 +54278,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-web--browse.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git web{litdd}browse' [<options>] <url|file>...\n"
 msgstr ""
 
@@ -54555,7 +54552,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-whatchanged.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git whatchanged' <option>...\n"
 msgstr ""
 
@@ -55085,7 +55082,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-worktree.txt:372
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git worktree add -b emergency-fix ../temp master\n"
 "$ pushd ../temp\n"
@@ -56288,7 +56285,7 @@ msgstr "颜色"
 
 #. type: Labeled list
 #: en/pretty-formats.txt:115
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'%C(...)'"
 msgstr ""
 
@@ -56300,7 +56297,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/pretty-formats.txt:129
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "\"CONFIGURATION FILE\" section of linkgit:git-config[1].  By default, colors are shown only when enabled for log output (by `color.diff`, `color.ui`, or `--color`, and respecting the `auto` settings of the former if we are going to a terminal). `%C(auto,...)` is accepted as a historical synonym for the default (e.g., `%C(auto,red)`). Specifying `%C(always,...)` will show the colors even when color is not otherwise enabled (though consider just using `--color=always` to enable color for the whole output, including this format and anything else git might color).  `auto` alone (i.e. `%C(auto)`) will turn on auto coloring on the next placeholders until the color is switched again."
 msgstr ""
 
@@ -57392,7 +57389,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/pull-fetch-param.txt:45
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "Whether that update is allowed without `--force` depends on the ref namespace it's being fetched to, the type of object being fetched, and whether the update is considered to be a fast-forward. Generally, the same rules apply for fetching as when pushing, see the `<refspec>...` section of linkgit:git-push[1] for what those are. Exceptions to those rules particular to 'git fetch' are noted below."
 msgstr ""
 
@@ -57863,13 +57860,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/revisions.txt:280
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "The '...' (three-dot) Symmetric Difference Notation"
 msgstr ""
 
 #. type: Plain text
 #: en/revisions.txt:286
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "A similar notation 'r1\\...r2' is called symmetric difference of 'r1' and 'r2' and is defined as 'r1 r2 --not $(git merge-base --all r1 r2)'.  It is the set of commits that are reachable from either one of 'r1' (left side) or 'r2' (right side) but not from both."
 msgstr ""
 
@@ -57959,7 +57956,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/revisions.txt:331
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'<rev1>\\...<rev2>'"
 msgstr ""
 
@@ -58013,7 +58010,7 @@ msgstr ""
 
 #. type: delimited block .
 #: en/revisions.txt:377
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "   Args   Expanded arguments    Selected commits\n"
 "   D                            G H D\n"
@@ -58503,7 +58500,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:256
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "For example, `--cherry-pick --right-only A...B` omits those commits from `B` which are in `A` or are patch-equivalent to a commit in `A`. In other words, this lists the `+` commits from `git cherry A B`.  More precisely, `--cherry-pick --right-only --no-merges` gives the exact list."
 msgstr ""
 
@@ -58515,7 +58512,7 @@ msgstr "--cherry"
 
 #. type: Plain text
 #: en/rev-list-options.txt:263
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "A synonym for `--right-only --cherry-mark --no-merges`; useful to limit the output to the commits on our side and mark those that have been applied to the other side of a forked history with `git log --cherry upstream...mybranch`, similar to `git cherry upstream mybranch`."
 msgstr ""
 
@@ -58527,7 +58524,7 @@ msgstr "--walk-reflogs"
 
 #. type: Plain text
 #: en/rev-list-options.txt:271
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Instead of walking the commit ancestry chain, walk reflog entries from the most recent one to older ones.  When this option is used you cannot specify commits to exclude (that is, '{caret}commit', 'commit1..commit2', and 'commit1\\...commit2' notations cannot be used)."
 msgstr ""
 
@@ -59520,7 +59517,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:875
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "`--date=format:...` feeds the format `...` to your system `strftime`, except for %z and %Z, which are handled internally.  Use `--date=format:%c` to show the date in your system locale's preferred format.  See the `strftime` manual for a complete list of format placeholders. When using `-local`, the correct syntax is `--date=format-local:...`."
 msgstr ""
 
@@ -59556,7 +59553,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:892
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Print also the parents of the commit (in the form \"commit parent...\").  Also enables parent rewriting, see 'History Simplification' above."
 msgstr ""
 
@@ -59568,7 +59565,7 @@ msgstr "--children"
 
 #. type: Plain text
 #: en/rev-list-options.txt:896
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Print also the children of the commit (in the form \"commit child...\").  Also enables parent rewriting, see 'History Simplification' above."
 msgstr ""
 
@@ -59621,13 +59618,13 @@ msgstr ""
 
 #. type: delimited block -
 #: en/rev-list-options.txt:922
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "\t$ git rev-list --left-right --boundary --pretty=oneline A...B\n"
 msgstr ""
 
 #. type: delimited block -
 #: en/rev-list-options.txt:929
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "\t>bbbbbbb... 3rd on b\n"
 "\t>bbbbbbb... 2nd on b\n"

--- a/po/documentation.zh_HANT.po
+++ b/po/documentation.zh_HANT.po
@@ -2357,7 +2357,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/config.txt:237
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The value for many variables that specify various sizes can be suffixed with `k`, `M`,... to mean \"scale the number by 1024\", \"by 1024x1024\", etc."
 msgstr ""
 
@@ -2543,7 +2543,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-format.txt:16
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "git-diff-tree [-r] <tree-ish-1> <tree-ish-2> [<pattern>...]"
 msgstr ""
 
@@ -2555,7 +2555,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-format.txt:19
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "git-diff-files [<pattern>...]"
 msgstr ""
 
@@ -3193,7 +3193,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/diff-generate-patch.txt:166
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Unlike the traditional 'unified' diff format, which shows two files A and B with a single column that has `-` (minus -- appears in A but removed in B), `+` (plus -- missing in A but added to B), or `\" \"` (space -- unchanged) prefix, this format compares two or more files file1, file2,... with one file X, and shows how X differs from each of fileN.  One column for each of fileN is prepended to the output line to note how X's line is different from it."
 msgstr ""
 
@@ -3480,7 +3480,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:127
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Generate a diffstat. By default, as much space as necessary will be used for the filename part, and the rest for the graph part. Maximum width defaults to terminal width, or 80 columns if not connected to a terminal, and can be overridden by `<width>`. The width of the filename part can be limited by giving another width `<name-width>` after a comma. The width of the graph part can be limited by using `--stat-graph-width=<width>` (affects all commands generating a stat graph) or by setting `diff.statGraphWidth=<width>` (does not affect `git format-patch`).  By giving a third parameter `<count>`, you can limit the output to the first `<count>` lines, followed by `...` if there are more."
 msgstr ""
 
@@ -3528,7 +3528,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:151
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--dirstat[=<param1,param2,...>]"
 msgstr ""
 
@@ -4249,13 +4249,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:507
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "--diff-filter=[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr ""
 
 #. type: Plain text
 #: en/diff-options.txt:518
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "Select only files that are Added (`A`), Copied (`C`), Deleted (`D`), Modified (`M`), Renamed (`R`), have their type (i.e. regular file, symlink, submodule, ...) changed (`T`), are Unmerged (`U`), are Unknown (`X`), or have had their pairing Broken (`B`).  Any combination of the filter characters (including none) can be used.  When `*` (All-or-none) is added to the combination, all paths are selected if there is any file that matches other criteria in the comparison; if there is no file that matches other criteria, nothing is selected."
 msgstr ""
 
@@ -4315,7 +4315,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/diff-options.txt:553
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "+    return !regexec(regexp, two->ptr, 1, &regmatch, 0);\n"
 "...\n"
@@ -5202,7 +5202,7 @@ msgstr "格式"
 
 #. type: Plain text
 #: en/git-add.txt:15
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "'git add' [--verbose | -v] [--dry-run | -n] [--force | -f] [--interactive | -i] [--patch | -p]\n"
 "\t  [--edit | -e] [--[no-]all | --[no-]ignore-removal | [--update | -u]]\n"
@@ -5260,7 +5260,7 @@ msgstr "選項"
 
 #. type: Labeled list
 #: en/git-add.txt:52 en/git-grep.txt:308 en/git-status.txt:148
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid "<pathspec>..."
 msgstr ""
 
@@ -5404,7 +5404,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-add.txt:145
-#, priority:300
+#, ignore-ellipsis, priority:300
 msgid "This option is primarily to help users who are used to older versions of Git, whose \"git add <pathspec>...\" was a synonym for \"git add --no-all <pathspec>...\", i.e. ignored removed files."
 msgstr ""
 
@@ -5914,7 +5914,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-am.txt:20
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git am' [--signoff] [--keep] [--[no-]keep-cr] [--[no-]utf8]\n"
 "\t [--[no-]3way] [--interactive] [--committer-date-is-author-date]\n"
@@ -5934,7 +5934,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-am.txt:29
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "(<mbox>|<Maildir>)..."
 msgstr ""
 
@@ -6452,7 +6452,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-apply.txt:20
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git apply' [--stat] [--numstat] [--summary] [--check] [--index | --intent-to-add] [--3way]\n"
 "\t  [--apply] [--no-add] [--build-fake-ancestor=<file>] [-R | --reverse]\n"
@@ -6478,7 +6478,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-apply.txt:37
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<patch>..."
 msgstr ""
 
@@ -6886,7 +6886,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-archimport.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git archimport' [-h] [-v] [-o] [-a] [-f] [-T] [-D depth] [-t tempdir]\n"
 "               <archive/branch>[:<git-branch>] ...\n"
@@ -7050,7 +7050,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-archive.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git archive' [--format=<fmt>] [--list] [--prefix=<prefix>/] [<extra>]\n"
 "\t      [-o <file> | --output=<file>] [--worktree-attributes]\n"
@@ -7444,7 +7444,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bisect.txt:31
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 " git bisect start [--term-{old,good}=<term> --term-{new,bad}=<term>]\n"
 "\t\t  [--no-checkout] [<bad> [<good>...]] [--] [<paths>...]\n"
@@ -7639,7 +7639,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-bisect.txt:158
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git bisect new [<rev>...]\n"
 msgstr ""
 
@@ -7669,7 +7669,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bisect.txt:175
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If you would like to use your own terms instead of \"bad\"/\"good\" or \"new\"/\"old\", you can choose any names you like (except existing bisect subcommands like `reset`, `start`, ...) by starting the bisection using"
 msgstr ""
 
@@ -8109,7 +8109,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-bisect.txt:463
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git bisect start HEAD <known-good-commit> [ <boundary-commit> ... ] --no-checkout\n"
 "$ git bisect run sh -c '\n"
@@ -8576,7 +8576,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:24
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git branch' [--color[=<when>] | --no-color] [-r | -a]\n"
 "\t[--list] [-v [--abbrev=<length> | --no-abbrev]]\n"
@@ -8805,7 +8805,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:162
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "List branches.  With optional `<pattern>...`, e.g. `git branch --list 'maint-*'`, list only the branches that match the pattern(s)."
 msgstr ""
 
@@ -9039,7 +9039,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-branch.txt:271
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "Sort based on the key given. Prefix `-` to sort in descending order of the value. You may use the --sort=<key> option multiple times, in which case the last key becomes the primary key. The keys supported are the same as those in `git for-each-ref`. Sort order defaults to the value configured for the `branch.sort` variable if exists, or to sorting based on the full refname (including `refs/...` prefix). This lists detached HEAD (if present) first, then local branches and finally remote-tracking branches. See linkgit:git-config[1]."
 msgstr ""
 
@@ -9081,7 +9081,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-branch.txt:297
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git clone git://git.kernel.org/pub/scm/.../linux-2.6 my2.6\n"
 "$ cd my2.6\n"
@@ -9103,7 +9103,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-branch.txt:309
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git clone git://git.kernel.org/.../git.git my.git\n"
 "$ cd my.git\n"
@@ -9185,7 +9185,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-bundle.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git bundle' create <file> <git-rev-list-args>\n"
 "'git bundle' verify <file>\n"
@@ -9261,7 +9261,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-bundle.txt:71
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<refname>...]"
 msgstr ""
 
@@ -10037,7 +10037,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-attr.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git check-attr' [-a | --all | <attr>...] [--] <pathname>...\n"
 "'git check-attr' --stdin [-z] [-a | --all | <attr>...]\n"
@@ -10278,7 +10278,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-ignore.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git check-ignore' [<options>] <pathname>...\n"
 "'git check-ignore' [<options>] --stdin\n"
@@ -10454,7 +10454,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-check-mailmap.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git check-mailmap' [<options>] <contact>...\n"
 msgstr ""
 
@@ -10490,7 +10490,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout-index.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git checkout-index' [-u] [-q] [-a] [-f] [-n] [--prefix=<string>]\n"
 "\t\t   [--stage=<number>|all]\n"
@@ -10765,7 +10765,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:18
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git checkout' [-q] [-f] [-m] [<branch>]\n"
 "'git checkout' [-q] [-f] [-m] --detach [<branch>]\n"
@@ -10882,7 +10882,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-checkout.txt:91
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git checkout' [<tree-ish>] [--] <pathspec>..."
 msgstr ""
 
@@ -10900,7 +10900,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-checkout.txt:107
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git checkout' (-p|--patch) [<tree-ish>] [--] [<pathspec>...]"
 msgstr ""
 
@@ -11164,7 +11164,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-checkout.txt:297
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "As a special case, you may use `\"A...B\"` as a shortcut for the merge base of `A` and `B` if there is exactly one merge base. You can leave out at most one of `A` and `B`, in which case it defaults to `HEAD`."
 msgstr ""
 
@@ -11753,7 +11753,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git cherry-pick' [--edit] [-n] [-m parent-number] [-s] [-x] [--ff]\n"
 "\t\t  [-S[<keyid>]] <commit>...\n"
@@ -11812,13 +11812,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-cherry-pick.txt:45 en/git-merge.txt:107 en/git-revert.txt:35 en/git-verify-commit.txt:27
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "<commit>..."
 msgstr ""
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:54
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Commits to cherry-pick.  For a more complete list of ways to spell commits, see linkgit:gitrevisions[7].  Sets of commits can be passed but no traversal is done by default, as if the `--no-walk` option was specified, see linkgit:git-rev-list[1]. Note that specifying a range will feed all <commit>... arguments to a single revision walk (see a later example that uses 'maint master..next')."
 msgstr ""
 
@@ -11836,7 +11836,7 @@ msgstr "-x"
 
 #. type: Plain text
 #: en/git-cherry-pick.txt:73
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When recording the commit, append a line that says \"(cherry picked from commit ...)\" to the original commit message in order to indicate which commit this change was cherry-picked from.  This is done only for cherry picks without conflicts.  Do not use this option if you are cherry-picking from your private branch because the information is useless to the recipient.  If on the other hand you are cherry-picking between two publicly visible branches (e.g. backporting a fix to a maintenance branch for an older release from a development branch), adding this information can be useful."
 msgstr ""
 
@@ -12194,7 +12194,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:58
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git checkout -b topic origin/master\n"
 "# work and create some commits\n"
@@ -12230,7 +12230,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git log --graph --oneline --decorate --boundary origin/master...topic\n"
 "* 7654321 (origin/master) upstream tip commit\n"
@@ -12253,7 +12253,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:96
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git cherry origin/master topic\n"
 "- cccc000... commit C\n"
@@ -12281,7 +12281,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:126
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git log --graph --oneline --decorate --boundary origin/master...topic\n"
 "* 7654321 (origin/master) upstream tip commit\n"
@@ -12307,7 +12307,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-cherry.txt:136
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git cherry origin/master topic base\n"
 "- cccc000... commit C\n"
@@ -12359,7 +12359,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-clean.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git clean' [-d] [-f] [-i] [-n] [-q] [-e <pattern>] [-x | -X] [--] <path>...\n"
 msgstr ""
 
@@ -12377,7 +12377,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-clean.txt:25
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If any optional `<path>...` arguments are given, only those paths are affected."
 msgstr ""
 
@@ -12969,7 +12969,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-clone.txt:291
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "$ git clone git://git.kernel.org/pub/scm/.../linux.git my-linux\n"
 "$ cd my-linux\n"
@@ -12999,7 +12999,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-clone.txt:310
-#, no-wrap, priority:300
+#, ignore-ellipsis, no-wrap, priority:300
 msgid ""
 "$ git clone --reference /git/linux.git \\\n"
 "\tgit://git.kernel.org/pub/scm/.../linux.git \\\n"
@@ -13192,7 +13192,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-commit-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git commit-tree' <tree> [(-p <parent>)...]\n"
 "'git commit-tree' [(-p <parent>)...] [-S[<keyid>]] [(-m <message>)...]\n"
@@ -13387,7 +13387,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-commit.txt:17
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git commit' [-a | --interactive | --patch] [-s] [-v] [-u<mode>] [--amend]\n"
 "\t   [--dry-run] [(-c | -C | --fixup | --squash) <commit>]\n"
@@ -13813,7 +13813,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-commit.txt:248
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "\t$ git reset --soft HEAD^\n"
 "\t$ ... do something else to come up with the right tree ...\n"
@@ -13978,7 +13978,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-commit.txt:346 en/git-rm.txt:29
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "<file>..."
 msgstr ""
 
@@ -14955,7 +14955,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-config.txt:426
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "However, if you really only want to replace the line for the default proxy, i.e. the one without a \"for ...\" postfix, do something like this:"
 msgstr ""
 
@@ -16313,7 +16313,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-cvsserver.txt:26
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git-cvsserver' [<options>] [pserver|server] [<directory> ...]\n"
 msgstr ""
 
@@ -17011,7 +17011,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-daemon.txt:25
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git daemon' [--verbose] [--syslog] [--export-all]\n"
 "\t     [--timeout=<n>] [--init-timeout=<n>] [--max-connections=<n>]\n"
@@ -17577,7 +17577,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-describe.txt:14
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "'git describe' [--all] [--tags] [--contains] [--abbrev=<n>] [<commit-ish>...]\n"
 "'git describe' [--all] [--tags] [--contains] [--abbrev=<n>] --dirty[=<mark>]\n"
@@ -17604,7 +17604,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-describe.txt:37
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "<commit-ish>..."
 msgstr ""
 
@@ -17700,7 +17700,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-describe.txt:95
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Always output the long format (the tag, the number of commits and the abbreviated commit name) even when it matches a tag.  This is useful when you want to see parts of the commit object name in \"describe\" output, even when the commit in question happens to be a tagged version.  Instead of just emitting the tag name, it will describe such a commit as v1.2-0-gdeadbee (0th commit since tag v1.2 that points at object deadbee....)."
 msgstr ""
 
@@ -17878,7 +17878,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-files.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git diff-files' [-q] [-0|-1|-2|-3|-c|--cc] [<common diff options>] [<path>...]\n"
 msgstr ""
 
@@ -17950,7 +17950,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-index.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git diff-index' [-m] [--cached] [<common diff options>] <tree-ish> [<path>...]\n"
 msgstr ""
 
@@ -18089,7 +18089,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-index.txt:102
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "  torvalds@ppc970:~/v2.6/linux> git diff-index --abbrev HEAD\n"
 "  :100644 100664 7476bb... 000000...      kernel/sched.c\n"
@@ -18127,7 +18127,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-difftool.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git difftool' [<options>] [<commit> [<commit>]] [--] [<path>...]\n"
 msgstr ""
 
@@ -18439,7 +18439,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git diff-tree' [--stdin] [-m] [-s] [-v] [--no-commit-id] [--pretty]\n"
 "\t      [-t] [-r] [-c | --cc] [--root] [<common diff options>]\n"
@@ -18472,7 +18472,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff-tree.txt:32 en/git-diff.txt:114 en/git-submodule.txt:410
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "<path>..."
 msgstr ""
 
@@ -18586,7 +18586,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:17
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git diff' [<options>] [<commit>] [--] [<path>...]\n"
 "'git diff' [<options>] --cached [<commit>] [--] [<path>...]\n"
@@ -18603,7 +18603,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:24
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] [--] [<path>...]"
 msgstr ""
 
@@ -18627,7 +18627,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:41
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] --cached [<commit>] [--] [<path>...]"
 msgstr ""
 
@@ -18639,7 +18639,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:51
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit> [--] [<path>...]"
 msgstr ""
 
@@ -18651,7 +18651,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:59
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit> <commit> [--] [<path>...]"
 msgstr ""
 
@@ -18663,7 +18663,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:64
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit>..<commit> [--] [<path>...]"
 msgstr ""
 
@@ -18675,13 +18675,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-diff.txt:70
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git diff' [<options>] <commit>\\...<commit> [--] [<path>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:77
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "This form is to view the changes on the branch containing and up to the second <commit>, starting at a common ancestor of both <commit>.  \"git diff A\\...B\" is equivalent to \"git diff $(git merge-base A B) B\".  You can omit any one of <commit>, which has the same effect as using HEAD instead."
 msgstr ""
 
@@ -18693,7 +18693,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-diff.txt:89
-#, priority:280
+#, ignore-ellipsis, priority:280
 msgid "For a more complete list of ways to spell <commit>, see \"SPECIFYING REVISIONS\" section in linkgit:gitrevisions[7].  However, \"diff\" is about comparing two _endpoints_, not ranges, and the range notations (\"<commit>..<commit>\" and \"<commit>\\...<commit>\") do not mean a range as defined in the \"SPECIFYING RANGES\" section in linkgit:gitrevisions[7]."
 msgstr ""
 
@@ -18801,7 +18801,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-diff.txt:160
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git diff topic master    <1>\n"
 "$ git diff topic..master   <2>\n"
@@ -19109,7 +19109,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:136
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<git-rev-list-args>...]"
 msgstr ""
 
@@ -19190,7 +19190,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-fast-export.txt:208
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git init anon-repo\n"
 "$ cd anon-repo\n"
@@ -21481,7 +21481,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch-pack.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git fetch-pack' [--all] [--quiet|-q] [--keep|-k] [--thin] [--include-tag]\n"
 "\t[--upload-pack=<git-upload-pack>]\n"
@@ -21641,7 +21641,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fetch-pack.txt:117 en/git-ls-remote.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<refs>..."
 msgstr ""
 
@@ -21671,7 +21671,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch.txt:16
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git fetch' [<options>] [<repository> [<refspec>...]]\n"
 "'git fetch' [<options>] <group>\n"
@@ -22012,7 +22012,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fetch.txt:226
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "For a successfully fetched ref, the summary shows the old and new values of the ref in a form suitable for using as an argument to `git log` (this is `<old>..<new>` in most cases, and `<old>...<new>` for forced non-fast-forward updates)."
 msgstr ""
 
@@ -22134,7 +22134,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:18
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git filter-branch' [--setup <command>] [--subdirectory-filter <directory>]\n"
 "\t[--env-filter <command>] [--tree-filter <command>]\n"
@@ -22273,7 +22273,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:117
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for rewriting the index.  It is similar to the tree filter but does not check out the tree, which makes it much faster.  Frequently used with `git rm --cached --ignore-unmatch ...`, see EXAMPLES below.  For hairy cases, see linkgit:git-update-index[1]."
 msgstr ""
 
@@ -22285,7 +22285,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:125
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for rewriting the commit's parent list.  It will receive the parent string on stdin and shall output the new parent string on stdout.  The parent string is in the format described in linkgit:git-commit-tree[1]: empty for the initial commit, \"-p parent\" for a normal commit and \"-p parent1 -p parent2 -p parent3 ...\" for a merge commit."
 msgstr ""
 
@@ -22309,7 +22309,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-filter-branch.txt:138
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "This is the filter for performing the commit.  If this filter is specified, it will be called instead of the 'git commit-tree' command, with arguments of the form \"<TREE_ID> [(-p <PARENT_COMMIT_ID>)...]\" and the log message on stdin.  The commit id is expected on stdout."
 msgstr ""
 
@@ -22411,7 +22411,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-filter-branch.txt:207
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<rev-list options>..."
 msgstr ""
 
@@ -22672,7 +22672,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-filter-branch.txt:388
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git filter-branch ... C..H\n"
 msgstr ""
 
@@ -22684,7 +22684,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-filter-branch.txt:395
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "git filter-branch ... C..H --not D\n"
 "git filter-branch ... D..H --not C\n"
@@ -22923,7 +22923,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git for-each-ref' [--count=<count>] [--shell|--perl|--python|--tcl]\n"
 "\t\t   [(--sort=<key>)...] [--format=<format>] [<pattern>...]\n"
@@ -22940,7 +22940,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-for-each-ref.txt:29 en/git-show-ref.txt:88
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<pattern>..."
 msgstr ""
 
@@ -23228,7 +23228,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:197
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Left-, middle-, or right-align the content between %(align:...) and %(end). The \"align:\" is followed by `width=<width>` and `position=<position>` in any order separated by a comma, where the `<position>` is either left, right or middle, default being left and `<width>` is the total length of the content with alignment. For brevity, the \"width=\" and/or \"position=\" prefixes may be omitted, and bare <width> and <position> used instead.  For instance, `%(align:<width>,<position>)`. If the contents length is more than the width then no alignment is performed. If used with `--quote` everything in between %(align:...) and %(end) is quoted, but if nested then only the topmost level performs quoting."
 msgstr ""
 
@@ -23240,7 +23240,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:210
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Used as %(if)...%(then)...%(end) or %(if)...%(then)...%(else)...%(end).  If there is an atom with value or string literal after the %(if) then everything after the %(then) is printed, else if the %(else) atom is used, then everything after %(else) is printed. We ignore space when evaluating the string before %(then), this is useful when we use the %(HEAD) atom which prints either \"*\" or \" \" and we want to apply the 'if' condition only on the 'HEAD' ref.  Append \":equals=<string>\" or \":notequals=<string>\" to compare the value between the %(if:...) and %(then) atoms with the given string."
 msgstr ""
 
@@ -23448,7 +23448,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:356
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "An example to show the usage of %(if)...%(then)...%(else)...%(end).  This prefixes the current branch with a star."
 msgstr ""
 
@@ -23460,7 +23460,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-for-each-ref.txt:364
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "An example to show the usage of %(if)...%(then)...%(end).  This prints the authorname, if present."
 msgstr ""
 
@@ -24093,7 +24093,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:367
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "Do the same for ia64 so we can have sleek & trim looking\n"
 "...\n"
@@ -24101,7 +24101,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:375
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Typically it will be placed in a MUA's drafts folder, edited to add timely commentary that should not go in the changelog after the three dashes, and then sent as a message whose body, in our example, starts with \"arch/arm config files were...\".  On the receiving end, readers can save interesting patches in a UNIX mailbox and apply them with linkgit:git-am[1]."
 msgstr ""
 
@@ -24113,7 +24113,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:385
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "...\n"
 "> So we should do such-and-such.\n"
@@ -24135,7 +24135,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-format-patch.txt:393
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "arch/arm config files were slimmed down using a python script\n"
 "...\n"
@@ -24309,7 +24309,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:494
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Configure your mail server composition as plain text: Edit...Account Settings...Composition & Addressing, uncheck \"Compose Messages in HTML\"."
 msgstr ""
 
@@ -24446,7 +24446,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-format-patch.txt:568
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Use Message -> Insert file... and insert the patch."
 msgstr ""
 
@@ -24621,7 +24621,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-fsck-objects.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git fsck-objects' ...\n"
 msgstr ""
 
@@ -25015,7 +25015,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-gc.txt:74
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If houskeeping is required due to many loose objects or packs, all other housekeeping tasks (e.g. rerere, working trees, reflog...) will be performed as well."
 msgstr ""
 
@@ -25228,7 +25228,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-grep.txt:32
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git grep' [-a | --text] [-I] [--textconv] [-i | --ignore-case] [-w | --word-regexp]\n"
 "\t   [-v | --invert-match] [-h|-H] [--full-name]\n"
@@ -25842,7 +25842,7 @@ msgstr "--not"
 
 #. type: Labeled list
 #: en/git-grep.txt:284
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "( ... )"
 msgstr ""
 
@@ -25872,7 +25872,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-grep.txt:300
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<tree>..."
 msgstr ""
 
@@ -26190,7 +26190,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-hash-object.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git hash-object' [-t <type>] [-w] [--path=<file>|--no-filters] [--stdin [--literally]] [--] <file>...\n"
 "'git hash-object' [-t <type>] [-w] --stdin-paths [--no-filters]\n"
@@ -26320,7 +26320,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-help.txt:38
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Note that `git --help ...` is identical to `git help ...` because the former is internally converted into the latter."
 msgstr ""
 
@@ -26770,7 +26770,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:102
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tAuthType Basic\n"
 "\tAuthName \"Git Access\"\n"
@@ -26788,7 +26788,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:115
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "<LocationMatch \"^/git/.*/git-receive-pack$\">\n"
 "\tAuthType Basic\n"
@@ -26812,7 +26812,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:136
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "<Location /git/private>\n"
 "\tAuthType Basic\n"
@@ -26962,7 +26962,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-http-backend.txt:231
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "auth.require = (\n"
 "\t\"/\" => (\n"
@@ -27165,7 +27165,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-http-push.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git http-push' [--all] [--dry-run] [--force] [--verbose] <url> <ref> [<ref>...]\n"
 msgstr ""
 
@@ -27234,7 +27234,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-http-push.txt:54 en/git-send-pack.txt:98
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<ref>..."
 msgstr ""
 
@@ -28110,7 +28110,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-interpret-trailers.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git interpret-trailers' [<options>] [(--trailer <token>[(=|:)<value>])...] [<file>...]\n"
 "'git interpret-trailers' [<options>] [--parse] [<file>...]\n"
@@ -28780,7 +28780,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-log.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'git log' [<options>] [<revision range>] [[--] <path>...]\n"
 msgstr ""
 
@@ -28876,7 +28876,7 @@ msgstr "--full-diff"
 
 #. type: Plain text
 #: en/git-log.txt:63
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Without this flag, `git log -p <path>...` shows commits that touch the specified paths, and diffs about the same specified paths.  With this, the full diff is shown for commits that touch the specified paths; this means that \"<path>...\" limits only commits, and doesn't limit diff for those commits."
 msgstr ""
 
@@ -28930,7 +28930,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-log.txt:93 en/git-shortlog.txt:72
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "[--] <path>..."
 msgstr ""
 
@@ -29206,7 +29206,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-files.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-files' [-z] [-t] [-v] [-f]\n"
 "\t\t(--[cached|deleted|others|ignored|stage|unmerged|killed|modified])*\n"
@@ -29687,7 +29687,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-remote.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-remote' [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
 "\t      [-q | --quiet] [--exit-code] [--get-url] [--sort=<key>]\n"
@@ -29786,7 +29786,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-remote.txt:91
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When unspecified, all references, after filtering done with --heads and --tags, are shown.  When <refs>... are specified, only references matching the given patterns are displayed."
 msgstr ""
 
@@ -29831,7 +29831,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-ls-tree.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git ls-tree' [-d] [-r] [-t] [-l] [-z]\n"
 "\t    [--name-only] [--name-status] [--full-name] [--full-tree] [--abbrev[=<n>]]\n"
@@ -29912,7 +29912,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-ls-tree.txt:76
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "[<path>...]"
 msgstr ""
 
@@ -30122,7 +30122,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mailsplit.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git mailsplit' [-b] [-f<nn>] [-d<prec>] [--keep-cr] [--mboxrd]\n"
 "\t\t-o<directory> [--] [(<mbox>|<Maildir>)...]\n"
@@ -30244,7 +30244,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git merge-base' [-a|--all] <commit> <commit>...\n"
 "'git merge-base' [-a|--all] --octopus <commit>...\n"
@@ -30441,7 +30441,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:139
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tA=$(git rev-parse --verify A)\n"
 "\tif test \"$A\" = \"$(git merge-base A B)\"\n"
@@ -30458,7 +30458,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge-base.txt:146
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\tif git merge-base --is-ancestor A B\n"
 "\tthen\n"
@@ -30945,7 +30945,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mergetool.txt:12
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "'git mergetool' [--tool=<tool>] [-y | --[no-]prompt] [<file>...]\n"
 msgstr ""
 
@@ -31107,7 +31107,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-merge.txt:18
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git merge' [-n] [--stat] [--no-commit] [--squash] [--[no-]edit]\n"
 "\t[-s <strategy>] [-X <strategy-option>] [-S[<keyid>]]\n"
@@ -31701,7 +31701,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mv.txt:13
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git mv' <options>... <args>...\n"
 msgstr ""
 
@@ -31713,7 +31713,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-mv.txt:20
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 " git mv [-v] [-f] [-n] [-k] <source> <destination>\n"
 " git mv [-v] [-f] [-n] [-k] <source> ... <destination directory>\n"
@@ -31781,7 +31781,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-name-rev.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git name-rev' [--tags] [--refs=<pattern>]\n"
 "\t       ( --all | --stdin | <commit-ish>... )\n"
@@ -31899,7 +31899,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-notes.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git notes' [list [<object>]]\n"
 "'git notes' add [-f] [--allow-empty] [-F <file> | -m <msg> | (-c | -C) <object>] [<object>]\n"
@@ -32235,7 +32235,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-notes.txt:229
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Commit notes are blobs containing extra information about an object (usually information to supplement a commit's message).  These blobs are taken from notes refs.  A notes ref is usually a branch which contains \"files\" whose paths are the object names for the objects they describe, with some directory separators included for performance reasons footnote:[Permitted pathnames have the form 'ab'`/`'cd'`/`'ef'`/`'...'`/`'abcdef...': a sequence of directory names of two hexadecimal digits each followed by a filename with the rest of the object ID.]."
 msgstr ""
 
@@ -32301,7 +32301,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-notes.txt:288
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git notes add -m 'Tested-by: Johannes Sixt <j6t@kdbg.org>' 72a144e2\n"
 "$ git show -s 72a144e\n"
@@ -32520,7 +32520,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-p4.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git p4 clone' [<sync options>] [<clone options>] <p4 depot path>...\n"
 "'git p4 sync' [<sync options>] [<p4 depot path>...]\n"
@@ -33353,7 +33353,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-p4.txt:445
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The full syntax for a p4 view is documented in 'p4 help views'.  'git p4' knows only a subset of the view syntax.  It understands multi-line mappings, overlays with '+', exclusions with '-' and double-quotes around whitespace.  Of the possible wildcards, 'git p4' only handles '...', and only when it is at the end of the path.  'git p4' will complain if it encounters an unhandled wildcard."
 msgstr ""
 
@@ -33395,7 +33395,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-p4.txt:475
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "//depot/main/...\n"
 "//depot/branch1/...\n"
@@ -33409,7 +33409,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-p4.txt:480
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "//depot/main/... //depot/branch1/...\n"
 msgstr ""
 
@@ -34526,7 +34526,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-pack-redundant.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git pack-redundant' [ --verbose ] [ --alt-odb ] < --all | .pack filename ... >\n"
 msgstr ""
 
@@ -34826,7 +34826,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-prune.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git prune' [-n] [-v] [--progress] [--expire <time>] [--] [<head>...]\n"
 msgstr ""
 
@@ -34880,7 +34880,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-prune.txt:54
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<head>..."
 msgstr ""
 
@@ -34934,7 +34934,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-pull.txt:13
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "'git pull' [<options>] [<repository> [<refspec>...]]\n"
 msgstr ""
 
@@ -35282,7 +35282,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:18
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git push' [--all | --mirror | --tags] [--follow-tags] [--atomic] [-n | --dry-run] [--receive-pack=<git-receive-pack>]\n"
 "\t   [--repo=<repository>] [-f | --force] [-d | --delete] [--prune] [-v | --verbose]\n"
@@ -35312,7 +35312,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:39
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "When the command line does not specify what to push with `<refspec>...` arguments or `--all`, `--mirror`, `--tags` options, the command finds the default `<refspec>` by consulting `remote.*.push` configuration, and if it is not found, honors `push.default` configuration to decide what to push (See linkgit:git-config[1] for the meaning of `push.default`)."
 msgstr ""
 
@@ -35336,7 +35336,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:56
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "<refspec>..."
 msgstr ""
 
@@ -35696,7 +35696,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:343
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "Note that `--force` applies to all the refs that are pushed, hence using it with `push.default` set to `matching` or with multiple push destinations configured with `remote.*.push` may overwrite refs other than the current branch (including local refs that are strictly behind their remote counterpart).  To force a push to only one branch, use a `+` in front of the refspec to push (e.g `git push origin +master` to force a push to the `master` branch). See the `<refspec>...` section above for details."
 msgstr ""
 
@@ -35828,7 +35828,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:445
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "For a successfully pushed ref, the summary shows the old and new values of the ref in a form suitable for using as an argument to `git log` (this is `<old>..<new>` in most cases, and `<old>...<new>` for forced non-fast-forward updates)."
 msgstr ""
 
@@ -36089,7 +36089,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-push.txt:616
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "See the section describing `<refspec>...` above for a discussion of the matching semantics."
 msgstr ""
 
@@ -36784,7 +36784,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-read-tree.txt:352
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git fetch git://.... linus\n"
 "$ LT=`git rev-parse FETCH_HEAD`\n"
@@ -36838,7 +36838,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-read-tree.txt:400
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "'git read-tree' and other merge-based commands ('git merge', 'git checkout'...) can help maintaining the skip-worktree bitmap and working directory update. `$GIT_DIR/info/sparse-checkout` is used to define the skip-worktree reference bitmap. When 'git read-tree' needs to update the working directory, it resets the skip-worktree bit in the index based on this file, which uses the same syntax as .gitignore files.  If an entry matches a pattern in this file, skip-worktree will not be set on that entry. Otherwise, skip-worktree will be set."
 msgstr ""
 
@@ -37218,7 +37218,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:219
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "As a special case, you may use \"A\\...B\" as a shortcut for the merge base of A and B if there is exactly one merge base. You can leave out at most one of A and B, in which case it defaults to HEAD."
 msgstr ""
 
@@ -37482,7 +37482,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:425
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "It is currently only possible to recreate the merge commits using the `recursive` merge strategy; Different merge strategies can be used only via explicit `exec git merge -s <strategy> [...]` commands."
 msgstr ""
 
@@ -37536,7 +37536,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:451
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "\tgit rebase -i --exec \"cmd1 && cmd2 && ...\"\n"
 msgstr ""
 
@@ -37548,7 +37548,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:455
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "\tgit rebase -i --exec \"cmd1\" --exec \"cmd2\" --exec ...\n"
 msgstr ""
 
@@ -37584,7 +37584,7 @@ msgstr "--no-autosquash"
 
 #. type: Plain text
 #: en/git-rebase.txt:489
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "When the commit log message begins with \"squash! ...\" (or \"fixup! ...\"), and there is already a commit in the todo list that matches the same `...`, automatically modify the todo list of rebase -i so that the commit marked for squashing comes right after the commit to be modified, and change the action of the moved commit from `pick` to `squash` (or `fixup`).  A commit matches the `...` if the commit subject matches, or if the `...` refers to the commit's hash. As a fall-back, partial matches of the commit subject work, too.  The recommended way to create fixup/squash commits is by using the `--fixup`/`--squash` options of linkgit:git-commit[1]."
 msgstr ""
 
@@ -37917,7 +37917,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:633
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "pick deadbee The oneline of this commit\n"
 "pick fa1afe1 The oneline of the next commit\n"
@@ -38021,7 +38021,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:706
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "pick deadbee Implement feature XXX\n"
 "fixup f1a5c00 Fix to feature XXX\n"
@@ -38040,7 +38040,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rebase.txt:716
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The \"exec\" command launches the command in a shell (the one specified in `$SHELL`, or the default shell if `$SHELL` is not set), so you can use shell features (like \"cd\", \">\", \";\" ...). The command is run from the root of the working tree."
 msgstr ""
 
@@ -38184,7 +38184,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rebase.txt:811
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "    o---o---o---o---o---o---o---o  master\n"
 "\t \\\t\t\t \\\n"
@@ -38982,7 +38982,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reflog.txt:27
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git reflog' ['show'] [log-options] [<ref>]\n"
 "'git reflog expire' [--expire=<time>] [--expire-unreachable=<time>]\n"
@@ -39169,7 +39169,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-remote-ext.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "git remote add <nick> \"ext::<command>[ <arguments>...]\"\n"
 msgstr ""
 
@@ -39307,7 +39307,7 @@ msgstr "GIT_EXT_SERVICE"
 
 #. type: Plain text
 #: en/git-remote-ext.txt:70
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Set to long name (git-upload-pack, etc...) of service helper needs to invoke."
 msgstr ""
 
@@ -39319,7 +39319,7 @@ msgstr "GIT_EXT_SERVICE_NOPREFIX"
 
 #. type: Plain text
 #: en/git-remote-ext.txt:74
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Set to long name (upload-pack, etc...) of service helper needs to invoke."
 msgstr ""
 
@@ -39529,7 +39529,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-remote.txt:25
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git remote' [-v | --verbose]\n"
 "'git remote add' [-t <branch>] [-m <master>] [-f] [--[no-]tags] [--mirror=<fetch|push>] <name> <url>\n"
@@ -39848,7 +39848,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-remote.txt:235
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "$ git remote\n"
 "origin\n"
@@ -40092,7 +40092,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-replace.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git replace' [-f] <object> <replacement>\n"
 "'git replace' [-f] --edit <object>\n"
@@ -40212,13 +40212,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-replace.txt:86
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--graft <commit> [<parent>...]"
 msgstr ""
 
 #. type: Plain text
 #: en/git-replace.txt:93
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Create a graft commit. A new commit is created with the same content as <commit> except that its parents will be [<parent>...] instead of <commit>'s parents. A replacement ref is then created to replace <commit> with the newly created commit. Use `--convert-graft-file` to convert a `$GIT_DIR/info/grafts` file and use replace refs instead."
 msgstr ""
 
@@ -40640,7 +40640,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rerere.txt:121
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git checkout topic\n"
 "\t$ git merge master\n"
@@ -40672,7 +40672,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rerere.txt:145
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git checkout topic\n"
 "\t$ git merge master\n"
@@ -40777,7 +40777,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-reset.txt:14
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "'git reset' [-q] [<tree-ish>] [--] <paths>...\n"
 "'git reset' (--patch | -p) [<tree-ish>] [--] [<paths>...]\n"
@@ -40792,7 +40792,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-reset.txt:22
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git reset' [-q] [<tree-ish>] [--] <paths>..."
 msgstr ""
 
@@ -40816,7 +40816,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-reset.txt:37
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git reset' (--patch | -p) [<tree-ish>] [--] [<paths>...]"
 msgstr ""
 
@@ -40971,7 +40971,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:137
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git commit ...\n"
 "$ git reset --soft HEAD^      <1>\n"
@@ -41044,7 +41044,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:169
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git commit ...\n"
 "$ git reset --hard HEAD~3   <1>\n"
@@ -41064,7 +41064,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:189
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git pull                         <1>\n"
 "Auto-merging nitfol\n"
@@ -41109,7 +41109,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:214
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git pull                         <1>\n"
 "Auto-merging nitfol\n"
@@ -41235,7 +41235,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:288
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git tag start\n"
 "$ git checkout -b branch1\n"
@@ -41278,7 +41278,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-reset.txt:316
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "$ git reset -N HEAD^                        <1>\n"
 "$ git add -p                                <2>\n"
@@ -41504,7 +41504,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-revert.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git revert' [--[no-]edit] [-n] [-m parent-number] [-s] [-S[<keyid>]] <commit>...\n"
 "'git revert' --continue\n"
@@ -41610,7 +41610,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-list.txt:64
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git rev-list' [ --max-count=<number> ]\n"
 "\t     [ --skip=<number> ]\n"
@@ -41712,13 +41712,13 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-list.txt:101
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Another special notation is \"'<commit1>'...'<commit2>'\" which is useful for merges.  The resulting set of commits is the symmetric difference between the two operands.  The following two commands are equivalent:"
 msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-list.txt:105
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "\t$ git rev-list A B --not $(git merge-base --all A B)\n"
 "\t$ git rev-list A...B\n"
@@ -41744,7 +41744,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-parse.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git rev-parse' [<options>] <args>...\n"
 msgstr ""
 
@@ -42228,7 +42228,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rev-parse.txt:253
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Resolve \"$GIT_DIR/<path>\" and takes other path relocation variables such as $GIT_OBJECT_DIRECTORY, $GIT_INDEX_FILE... into account. For example, if $GIT_OBJECT_DIRECTORY is set to /foo/bar then \"git rev-parse --git-path objects/abc\" returns /foo/bar/abc."
 msgstr ""
 
@@ -42336,7 +42336,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:290
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<args>..."
 msgstr ""
 
@@ -42468,7 +42468,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:364
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "OPTS_SPEC=\"\\\n"
 "some-command [<options>] <args>...\n"
@@ -42526,7 +42526,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:389
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "usage: some-command [<options>] <args>...\n"
 msgstr ""
 
@@ -42538,7 +42538,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:397
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "    -h, --help            show the help\n"
 "    --foo                 some nifty option --foo\n"
@@ -42549,7 +42549,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-rev-parse.txt:400
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "An option group Header\n"
 "    -C[...]               option C with an optional argument\n"
@@ -42654,7 +42654,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-rm.txt:12
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git rm' [-f | --force] [-n] [-r] [--cached] [--ignore-unmatch] [--quiet] [--] <file>...\n"
 msgstr ""
 
@@ -42882,7 +42882,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-email.txt:14
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git send-email' [<options>] <file|directory|rev-list options>...\n"
 "'git send-email' --dump-aliases\n"
@@ -42950,7 +42950,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:53
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--bcc=<address>,..."
 msgstr ""
 
@@ -42968,7 +42968,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:59
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--cc=<address>,..."
 msgstr ""
 
@@ -43052,7 +43052,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-email.txt:110
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "  [PATCH 0/2] Here is what I did...\n"
 "    [PATCH 1/2] Clean up and tests\n"
@@ -43083,7 +43083,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:119
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--to=<address>,..."
 msgstr ""
 
@@ -43215,7 +43215,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-send-email.txt:188
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "$ git send-email --smtp-auth=\"PLAIN LOGIN GSSAPI\" ...\n"
 msgstr ""
 
@@ -43889,7 +43889,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-send-pack.txt:16
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git send-pack' [--all] [--dry-run] [--force] [--receive-pack=<git-receive-pack>]\n"
 "\t\t[--verbose] [--thin] [--atomic]\n"
@@ -44262,7 +44262,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-shortlog.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "'git shortlog' [<options>] [<revision range>] [[--] <path>...]\n"
 "git log --pretty=short | 'git shortlog' [<options>]\n"
@@ -44390,7 +44390,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show-branch.txt:17
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git show-branch' [-a|--all] [-r|--remotes] [--topo-order | --date-order]\n"
 "\t\t[--current] [--color[=<when>] | --no-color] [--sparse]\n"
@@ -44751,7 +44751,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show-ref.txt:15
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git show-ref' [-q|--quiet] [--verify] [--head] [-d|--dereference]\n"
 "\t     [-s|--hash[=<n>]] [--abbrev[=<n>]] [--tags]\n"
@@ -44899,7 +44899,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-show-ref.txt:111
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git show-ref --head --dereference\n"
 "832e76a9899f560a90ffd62ae2ce83bbeff58f54 HEAD\n"
@@ -44920,7 +44920,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-show-ref.txt:121
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "$ git show-ref --heads --hash\n"
 "2e3ba0114a1f52b47df29743d6915d056be13278\n"
@@ -45041,7 +45041,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-show.txt:13
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "'git show' [<options>] [<object>...]\n"
 msgstr ""
 
@@ -45089,7 +45089,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-show.txt:37
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "<object>..."
 msgstr ""
 
@@ -45347,7 +45347,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stage.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git stage' args...\n"
 msgstr ""
 
@@ -45371,7 +45371,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stash.txt:22
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git stash' list [<options>]\n"
 "'git stash' show [<stash>]\n"
@@ -45394,7 +45394,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-stash.txt:38
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "The modifications stashed away by this command can be listed with `git stash list`, inspected with `git stash show`, and restored (potentially on top of a different commit) with `git stash apply`.  Calling `git stash` without any arguments is equivalent to `git stash push`.  A stash is by default listed as \"WIP on 'branchname' ...\", but you can give a more descriptive message on the command line when you create one."
 msgstr ""
 
@@ -45406,7 +45406,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-stash.txt:49
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "push [-p|--patch] [-k|--[no-]keep-index] [-u|--include-untracked] [-a|--all] [-q|--quiet] [-m|--message <message>] [--] [<pathspec>...]"
 msgstr ""
 
@@ -45478,7 +45478,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:104
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "stash@{0}: WIP on submit: 6ebd0e2... Update git-stash documentation\n"
 "stash@{1}: On master: 9cc0589... Add git-stash\n"
@@ -45651,7 +45651,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:227
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git pull\n"
 " ...\n"
@@ -45669,7 +45669,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:246
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git checkout -b my_wip\n"
@@ -45690,7 +45690,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:257
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git stash\n"
@@ -45714,7 +45714,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-stash.txt:275
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "# ... hack hack hack ...\n"
 "$ git add --patch foo            # add just first part to the index\n"
@@ -45768,7 +45768,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-status.txt:13
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid "'git status' [<options>...] [--] [<pathspec>...]\n"
 msgstr ""
 
@@ -46245,7 +46245,7 @@ msgstr ""
 
 #. type: delimited block .
 #: en/git-status.txt:343
-#, no-wrap, priority:280
+#, ignore-ellipsis, no-wrap, priority:280
 msgid ""
 "Field       Meaning\n"
 "--------------------------------------------------------\n"
@@ -46566,7 +46566,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-submodule.txt:21
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid ""
 "'git submodule' [--quiet] add [<options>] [--] <repository> [<path>]\n"
 "'git submodule' [--quiet] status [--cached] [--recursive] [--] [<path>...]\n"
@@ -46629,7 +46629,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:69
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "status [--cached] [--recursive] [--] [<path>...]"
 msgstr ""
 
@@ -46653,7 +46653,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:86
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "init [--] [<path>...]"
 msgstr ""
 
@@ -46683,7 +46683,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:109
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "deinit [-f|--force] (--all|[--] <path>...)"
 msgstr ""
 
@@ -46713,7 +46713,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:127
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "update [--init] [--remote] [-N|--no-fetch] [--[no-]recommend-shallow] [-f|--force] [--checkout|--rebase|--merge] [--reference <repository>] [--depth <depth>] [--recursive] [--jobs <n>] [--] [<path>...]"
 msgstr ""
 
@@ -46825,7 +46825,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:171
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "summary [--cached|--files] [(-n|--summary-limit) <n>] [commit] [--] [<path>...]"
 msgstr ""
 
@@ -46867,7 +46867,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-submodule.txt:213
-#, no-wrap, priority:220
+#, ignore-ellipsis, no-wrap, priority:220
 msgid "sync [--recursive] [--] [<path>...]"
 msgstr ""
 
@@ -47386,7 +47386,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:127
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Fetch unfetched revisions from the Subversion remote we are tracking.  The name of the [svn-remote \"...\"] section in the $GIT_DIR/config file may be specified as an optional command-line argument."
 msgstr ""
 
@@ -47832,7 +47832,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-svn.txt:366
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "is supported, non-numeric args are not: HEAD, NEXT, BASE, PREV, etc ..."
 msgstr ""
 
@@ -48733,7 +48733,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-svn.txt:876
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "# Clone a repo (like git clone):\n"
 "\tgit svn clone http://svn.example.com/project/trunk\n"
@@ -48786,7 +48786,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-svn.txt:924
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "# Do the initial import on a server\n"
 "\tssh server \"cd /pub && git svn clone http://svn.example.com/project [options...]\"\n"
@@ -49189,7 +49189,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-tag.txt:20
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "'git tag' [-a | -s | -u <keyid>] [-f] [-m <msg> | -F <file>] [-e]\n"
 "\t<tagname> [<commit> | <object>]\n"
@@ -49323,7 +49323,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-tag.txt:96
-#, priority:240
+#, ignore-ellipsis, priority:240
 msgid "List tags. With optional `<pattern>...`, e.g. `git tag --list 'v-*'`, list only the tags that match the pattern(s)."
 msgstr ""
 
@@ -49613,13 +49613,13 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:312
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "\tgit://git..../proj.git master\n"
 msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:314
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "to get the following updates...\n"
 msgstr ""
 
@@ -49631,7 +49631,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-tag.txt:320
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid "$ git pull git://git..../proj.git master\n"
 msgstr ""
 
@@ -49751,7 +49751,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git.txt:54
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Other options are available to control how the manual page is displayed. See linkgit:git-help[1] for more information, because `git --help ...` is converted internally into `git help ...`."
 msgstr ""
 
@@ -49795,7 +49795,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git.txt:80
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "Note that omitting the `=` in `git -c foo.bar ...` is allowed and sets `foo.bar` to the boolean true value (just like `[foo]bar` would in a config file). Including the equals but with an empty value (like `git -c foo.bar= ...`) sets `foo.bar` to the empty string which `git config --type=bool` will convert to `false`."
 msgstr ""
 
@@ -49999,7 +49999,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git.txt:167
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "--list-cmds=group[,group...]"
 msgstr ""
 
@@ -50466,7 +50466,7 @@ msgstr "`GIT_COMMON_DIR`"
 
 #. type: Plain text
 #: en/git.txt:459
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "If this variable is set to a path, non-worktree files that are normally in $GIT_DIR will be taken from this path instead. Worktree-specific files such as HEAD or index are taken from $GIT_DIR. See linkgit:gitrepository-layout[5] and linkgit:git-worktree[1] for details. This variable has lower precedence than other path variables such as GIT_INDEX_FILE, GIT_OBJECT_DIRECTORY..."
 msgstr ""
 
@@ -51366,7 +51366,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-update-index.txt:29
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "'git update-index'\n"
 "\t     [--add] [--remove | --force-remove] [--replace]\n"
@@ -51926,7 +51926,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-update-index.txt:348
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "The command looks at `core.ignorestat` configuration variable.  When this is true, paths updated with `git update-index paths...` and paths updated with other Git commands that update both index and working tree (e.g. 'git apply --index', 'git checkout-index -u', and 'git read-tree -u') are automatically marked as \"assume unchanged\".  Note that \"assume unchanged\" bit is *not* set if `git update-index --refresh` finds the working tree file matches the index (use `git update-index --really-refresh` if you want to mark them as \"assume unchanged\")."
 msgstr ""
 
@@ -52800,7 +52800,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-commit.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-commit' <commit>...\n"
 msgstr ""
 
@@ -52842,7 +52842,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-pack.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-pack' [-v|--verbose] [-s|--stat-only] [--] <pack>.idx ...\n"
 msgstr ""
 
@@ -52854,7 +52854,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-verify-pack.txt:23
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<pack>.idx ..."
 msgstr ""
 
@@ -52932,7 +52932,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-verify-tag.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git verify-tag' [--format=<format>] <tag>...\n"
 msgstr ""
 
@@ -52950,7 +52950,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-verify-tag.txt:27
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "<tag>..."
 msgstr ""
 
@@ -52974,7 +52974,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-web--browse.txt:12
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git web{litdd}browse' [<options>] <url|file>...\n"
 msgstr ""
 
@@ -53248,7 +53248,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/git-whatchanged.txt:13
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'git whatchanged' <option>...\n"
 msgstr ""
 
@@ -53778,7 +53778,7 @@ msgstr ""
 
 #. type: delimited block -
 #: en/git-worktree.txt:372
-#, no-wrap, priority:240
+#, ignore-ellipsis, no-wrap, priority:240
 msgid ""
 "$ git worktree add -b emergency-fix ../temp master\n"
 "$ pushd ../temp\n"
@@ -55175,7 +55175,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/pretty-formats.txt:192
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "'%C(...)': color specification, as described under Values in the \"CONFIGURATION FILE\" section of linkgit:git-config[1].  By default, colors are shown only when enabled for log output (by `color.diff`, `color.ui`, or `--color`, and respecting the `auto` settings of the former if we are going to a terminal). `%C(auto,...)` is accepted as a historical synonym for the default (e.g., `%C(auto,red)`). Specifying `%C(always,...)` will show the colors even when color is not otherwise enabled (though consider just using `--color=always` to enable color for the whole output, including this format and anything else git might color).  `auto` alone (i.e. `%C(auto)`) will turn on auto coloring on the next placeholders until the color is switched again."
 msgstr ""
 
@@ -55545,7 +55545,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/pull-fetch-param.txt:45
-#, priority:220
+#, ignore-ellipsis, priority:220
 msgid "Whether that update is allowed without `--force` depends on the ref namespace it's being fetched to, the type of object being fetched, and whether the update is considered to be a fast-forward. Generally, the same rules apply for fetching as when pushing, see the `<refspec>...` section of linkgit:git-push[1] for what those are. Exceptions to those rules particular to 'git fetch' are noted below."
 msgstr ""
 
@@ -56016,13 +56016,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/revisions.txt:281
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "The '...' (three-dot) Symmetric Difference Notation"
 msgstr ""
 
 #. type: Plain text
 #: en/revisions.txt:287
-#, priority:100
+#, ignore-ellipsis, priority:100
 msgid "A similar notation 'r1\\...r2' is called symmetric difference of 'r1' and 'r2' and is defined as 'r1 r2 --not $(git merge-base --all r1 r2)'.  It is the set of commits that are reachable from either one of 'r1' (left side) or 'r2' (right side) but not from both."
 msgstr ""
 
@@ -56112,7 +56112,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/revisions.txt:332
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid "'<rev1>\\...<rev2>'"
 msgstr ""
 
@@ -56166,7 +56166,7 @@ msgstr ""
 
 #. type: delimited block .
 #: en/revisions.txt:378
-#, no-wrap, priority:100
+#, ignore-ellipsis, no-wrap, priority:100
 msgid ""
 "   Args   Expanded arguments    Selected commits\n"
 "   D                            G H D\n"
@@ -56644,7 +56644,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:248
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "For example, `--cherry-pick --right-only A...B` omits those commits from `B` which are in `A` or are patch-equivalent to a commit in `A`. In other words, this lists the `+` commits from `git cherry A B`.  More precisely, `--cherry-pick --right-only --no-merges` gives the exact list."
 msgstr ""
 
@@ -56656,7 +56656,7 @@ msgstr "--cherry"
 
 #. type: Plain text
 #: en/rev-list-options.txt:255
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "A synonym for `--right-only --cherry-mark --no-merges`; useful to limit the output to the commits on our side and mark those that have been applied to the other side of a forked history with `git log --cherry upstream...mybranch`, similar to `git cherry upstream mybranch`."
 msgstr ""
 
@@ -56668,7 +56668,7 @@ msgstr "--walk-reflogs"
 
 #. type: Plain text
 #: en/rev-list-options.txt:263
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Instead of walking the commit ancestry chain, walk reflog entries from the most recent one to older ones.  When this option is used you cannot specify commits to exclude (that is, '{caret}commit', 'commit1..commit2', and 'commit1\\...commit2' notations cannot be used)."
 msgstr ""
 
@@ -57637,7 +57637,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:856
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "`--date=format:...` feeds the format `...` to your system `strftime`, except for %z and %Z, which are handled internally.  Use `--date=format:%c` to show the date in your system locale's preferred format.  See the `strftime` manual for a complete list of format placeholders. When using `-local`, the correct syntax is `--date=format-local:...`."
 msgstr ""
 
@@ -57673,7 +57673,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/rev-list-options.txt:873
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Print also the parents of the commit (in the form \"commit parent...\").  Also enables parent rewriting, see 'History Simplification' above."
 msgstr ""
 
@@ -57685,7 +57685,7 @@ msgstr "--children"
 
 #. type: Plain text
 #: en/rev-list-options.txt:877
-#, priority:260
+#, ignore-ellipsis, priority:260
 msgid "Print also the children of the commit (in the form \"commit child...\").  Also enables parent rewriting, see 'History Simplification' above."
 msgstr ""
 
@@ -57738,13 +57738,13 @@ msgstr ""
 
 #. type: delimited block -
 #: en/rev-list-options.txt:903
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid "\t$ git rev-list --left-right --boundary --pretty=oneline A...B\n"
 msgstr ""
 
 #. type: delimited block -
 #: en/rev-list-options.txt:910
-#, no-wrap, priority:260
+#, ignore-ellipsis, no-wrap, priority:260
 msgid ""
 "\t>bbbbbbb... 3rd on b\n"
 "\t>bbbbbbb... 2nd on b\n"

--- a/scripts/pre-translate-po
+++ b/scripts/pre-translate-po
@@ -9,7 +9,7 @@ def main (f, d=None):
     option_re = re.compile(r'-[-a-z0-9[\]]+')
     linkgit_re = re.compile(r'((linkgit:)?(git[-a-z0-9[\]]+|mail)(\[[157]\]|\([157]\))(,|;)?(\n| )?)+')
     quoted_re = re.compile(r'`[a-zA-Z-_]+`|(user|transfer|submodule|stash|status|splitIndex|showbranch|sendemail|repack|remote|receive|push|merge(tool)?|mailinfo|log|interactive|instaweb|i18n|help|gui|gitweb|fastimport|format|fetch|diff(tool)?|credential|commit|column|core|branch|apply|color|git-p4)\.[a-zA-Z_.]+|araxis|bc3?|codecompare|deltawalker|guiffy|meld|diff(use|merge)|ec?merge|(exam|g?vim|t?k|open|xx)?diff[23]?|(p4|tortoise|win)merge')
-    env_var_re = re.compile(r'`?GIT_[A-Z_]+`?')
+    env_var_re = re.compile(r'`?GIT_[A-Z_\d]+`?')
     if not d is None:
             po_file=polib.pofile(d)
             pod = [(re.compile(entry.msgid), entry.msgstr) for entry in po_file]


### PR DESCRIPTION
The new GIT_TRACE2 variables require digits and future variables might do so, too.