### PR TITLE
possible typos in source file fixed

### DIFF
--- a/en/git-diff.txt
+++ b/en/git-diff.txt
@@ -61,7 +61,7 @@ two blob objects, or changes between two files on disk.
 	This is to view the changes between two arbitrary
 	<commit>.
 
-'git diff' [<options>] <commit>..<commit> [--] [<path>...]::
+'git diff' [<options>] <commit>...<commit> [--] [<path>...]::
 
 	This is synonymous to the previous form.  If <commit> on
 	one side is omitted, it will have the same effect as
@@ -77,7 +77,7 @@ two blob objects, or changes between two files on disk.
 
 Just in case you are doing something exotic, it should be
 noted that all of the <commit> in the above description, except
-in the last two forms that use ".." notations, can be any
+in the last two forms that use "..." notations, can be any
 <tree>.
 
 For a more complete list of ways to spell <commit>, see


### PR DESCRIPTION
possible typos fixed

See line 70 in comparison:
`'git diff' [<options>] <commit>\...<commit> [--] [<path>...]::`