### PR TITLE
pre-translate-po: handle more options

### DIFF
--- a/po/documentation.de.po
+++ b/po/documentation.de.po
@@ -3978,9 +3978,9 @@ msgstr "Diff-Ausgabe unterdrücken. Sinnvoll für Befehle wie `git show`, die de
 
 #. type: Labeled list
 #: en/diff-options.txt:37
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
-msgstr ""
+msgstr "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
 
 #. type: Labeled list
 #: en/diff-options.txt:38
@@ -3996,17 +3996,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:43
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none):"
-msgstr "diffmerge"
+msgstr "--diff-merges=(off|none):"
 
 #. type: Labeled list
 #: en/diff-options.txt:44
-#, fuzzy, no-wrap, priority:280
-#| msgid "--no-diff-merges"
+#, ignore-same, no-wrap, priority:280
 msgid "--no-diff-merges:"
-msgstr "--no-diff-merges"
+msgstr "--no-diff-merges:"
 
 #. type: Plain text
 #: en/diff-options.txt:47
@@ -4016,17 +4014,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:48
-#, fuzzy, no-wrap, priority:280
-#| msgid "--first-parent"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=first-parent:"
-msgstr "--first-parent"
+msgstr "--diff-merges=first-parent:"
 
 #. type: Labeled list
 #: en/diff-options.txt:49
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=1:"
-msgstr "diffmerge"
+msgstr "--diff-merges=1:"
 
 #. type: Plain text
 #: en/diff-options.txt:52
@@ -4036,24 +4032,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:53
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=separate:"
-msgstr "diffmerge"
+msgstr "--diff-merges=separate:"
 
 #. type: Labeled list
 #: en/diff-options.txt:54
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=m:"
-msgstr "diffmerge"
+msgstr "--diff-merges=m:"
 
 #. type: Labeled list
 #: en/diff-options.txt:55
-#, fuzzy, no-wrap, priority:280
-#| msgid "-m"
+#, ignore-same, no-wrap, priority:280
 msgid "-m:"
-msgstr "-m"
+msgstr "-m:"
 
 #. type: Plain text
 #: en/diff-options.txt:59
@@ -4063,24 +4056,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:60
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:61
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=c:"
-msgstr "diffmerge"
+msgstr "--diff-merges=c:"
 
 #. type: Labeled list
 #: en/diff-options.txt:62
-#, fuzzy, no-wrap, priority:280
-#| msgid "-c"
+#, ignore-same, no-wrap, priority:280
 msgid "-c:"
-msgstr "-c"
+msgstr "-c:"
 
 #. type: Plain text
 #: en/diff-options.txt:69
@@ -4090,24 +4080,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:70
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=dense-combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=dense-combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:71
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=cc:"
-msgstr "diffmerge"
+msgstr "--diff-merges=cc:"
 
 #. type: Labeled list
 #: en/diff-options.txt:72
-#, fuzzy, no-wrap, priority:280
-#| msgid "--cc"
+#, ignore-same, no-wrap, priority:280
 msgid "--cc:"
-msgstr "--cc"
+msgstr "--cc:"
 
 #. type: Plain text
 #: en/diff-options.txt:78
@@ -20987,9 +20974,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:30
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
-msgstr ""
+msgstr "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:34
@@ -21005,9 +20992,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:42
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--tag-of-filtered-object=(abort|drop|rewrite)"
-msgstr ""
+msgstr "--tag-of-filtered-object=(abort|drop|rewrite)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:46
@@ -21173,9 +21160,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:146
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--reencode=(yes|no|abort)"
-msgstr ""
+msgstr "--reencode=(yes|no|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:152
@@ -35969,9 +35956,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-p4.txt:352
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--conflict=(ask|skip|quit)"
-msgstr ""
+msgstr "--conflict=(ask|skip|quit)"
 
 #. type: Plain text
 #: en/git-p4.txt:358
@@ -38296,9 +38283,9 @@ msgstr "--[no-]signed"
 
 #. type: Labeled list
 #: en/git-push.txt:200 en/git-send-pack.txt:74
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--signed=(true|false|if-asked)"
-msgstr ""
+msgstr "--signed=(true|false|if-asked)"
 
 #. type: Plain text
 #: en/git-push.txt:209 en/git-send-pack.txt:83
@@ -38572,9 +38559,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:402
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--recurse-submodules=check|on-demand|only|no"
-msgstr ""
+msgstr "--recurse-submodules=check|on-demand|only|no"
 
 #. type: Plain text
 #: en/git-push.txt:416
@@ -45952,10 +45939,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:179
-#, fuzzy, no-wrap, priority:100
-#| msgid "--global"
+#, ignore-same, no-wrap, priority:100
 msgid "--glob=pattern"
-msgstr "--global"
+msgstr "--glob=pattern"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:185
@@ -46013,9 +45999,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:215
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--path-format=(absolute|relative)"
-msgstr ""
+msgstr "--path-format=(absolute|relative)"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:220
@@ -46235,15 +46221,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:306
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--since=datestring"
-msgstr ""
+msgstr "--since=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:307
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--after=datestring"
-msgstr ""
+msgstr "--after=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:310
@@ -46253,15 +46239,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:311
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--until=datestring"
-msgstr ""
+msgstr "--until=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:312
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--before=datestring"
-msgstr ""
+msgstr "--before=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:315
@@ -47069,9 +47055,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:140
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
-msgstr ""
+msgstr "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
 
 #. type: Plain text
 #: en/git-send-email.txt:148
@@ -47279,9 +47265,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:258
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--smtp-debug=0|1"
-msgstr ""
+msgstr "--smtp-debug=0|1"
 
 #. type: Plain text
 #: en/git-send-email.txt:262

--- a/po/documentation.es.po
+++ b/po/documentation.es.po
@@ -3910,9 +3910,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:37
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
-msgstr ""
+msgstr "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
 
 #. type: Labeled list
 #: en/diff-options.txt:38
@@ -3928,17 +3928,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:43
-#, fuzzy, no-wrap, priority:280
-#| msgid "--diff-merges=off"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none):"
-msgstr "--diff-merges=off"
+msgstr "--diff-merges=(off|none):"
 
 #. type: Labeled list
 #: en/diff-options.txt:44
-#, fuzzy, no-wrap, priority:280
-#| msgid "--no-diff-merges"
+#, ignore-same, no-wrap, priority:280
 msgid "--no-diff-merges:"
-msgstr "--no-diff-merges"
+msgstr "--no-diff-merges:"
 
 #. type: Plain text
 #: en/diff-options.txt:47
@@ -3948,17 +3946,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:48
-#, fuzzy, no-wrap, priority:280
-#| msgid "--first-parent"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=first-parent:"
-msgstr "--first-parent"
+msgstr "--diff-merges=first-parent:"
 
 #. type: Labeled list
 #: en/diff-options.txt:49
-#, fuzzy, no-wrap, priority:280
-#| msgid "--diff-merges=off"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=1:"
-msgstr "--diff-merges=off"
+msgstr "--diff-merges=1:"
 
 #. type: Plain text
 #: en/diff-options.txt:52
@@ -3968,24 +3964,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:53
-#, fuzzy, no-wrap, priority:280
-#| msgid "--diff-merges=off"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=separate:"
-msgstr "--diff-merges=off"
+msgstr "--diff-merges=separate:"
 
 #. type: Labeled list
 #: en/diff-options.txt:54
-#, fuzzy, no-wrap, priority:280
-#| msgid "--diff-merges=off"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=m:"
-msgstr "--diff-merges=off"
+msgstr "--diff-merges=m:"
 
 #. type: Labeled list
 #: en/diff-options.txt:55
-#, fuzzy, no-wrap, priority:280
-#| msgid "-m"
+#, ignore-same, no-wrap, priority:280
 msgid "-m:"
-msgstr "-m"
+msgstr "-m:"
 
 #. type: Plain text
 #: en/diff-options.txt:59
@@ -3995,24 +3988,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:60
-#, fuzzy, no-wrap, priority:280
-#| msgid "--diff-merges=off"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=combined:"
-msgstr "--diff-merges=off"
+msgstr "--diff-merges=combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:61
-#, fuzzy, no-wrap, priority:280
-#| msgid "--diff-merges=off"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=c:"
-msgstr "--diff-merges=off"
+msgstr "--diff-merges=c:"
 
 #. type: Labeled list
 #: en/diff-options.txt:62
-#, fuzzy, no-wrap, priority:280
-#| msgid "-c"
+#, ignore-same, no-wrap, priority:280
 msgid "-c:"
-msgstr "-c"
+msgstr "-c:"
 
 #. type: Plain text
 #: en/diff-options.txt:69
@@ -4022,24 +4012,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:70
-#, fuzzy, no-wrap, priority:280
-#| msgid "--diff-merges=off"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=dense-combined:"
-msgstr "--diff-merges=off"
+msgstr "--diff-merges=dense-combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:71
-#, fuzzy, no-wrap, priority:280
-#| msgid "--diff-merges=off"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=cc:"
-msgstr "--diff-merges=off"
+msgstr "--diff-merges=cc:"
 
 #. type: Labeled list
 #: en/diff-options.txt:72
-#, fuzzy, no-wrap, priority:280
-#| msgid "--cc"
+#, ignore-same, no-wrap, priority:280
 msgid "--cc:"
-msgstr "--cc"
+msgstr "--cc:"
 
 #. type: Plain text
 #: en/diff-options.txt:78
@@ -20616,9 +20603,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:30
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
-msgstr ""
+msgstr "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:34
@@ -20634,9 +20621,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:42
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--tag-of-filtered-object=(abort|drop|rewrite)"
-msgstr ""
+msgstr "--tag-of-filtered-object=(abort|drop|rewrite)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:46
@@ -20802,9 +20789,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:146
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--reencode=(yes|no|abort)"
-msgstr ""
+msgstr "--reencode=(yes|no|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:152
@@ -35491,9 +35478,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-p4.txt:352
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--conflict=(ask|skip|quit)"
-msgstr ""
+msgstr "--conflict=(ask|skip|quit)"
 
 #. type: Plain text
 #: en/git-p4.txt:358
@@ -37812,9 +37799,9 @@ msgstr "--[no-]signed"
 
 #. type: Labeled list
 #: en/git-push.txt:200 en/git-send-pack.txt:74
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--signed=(true|false|if-asked)"
-msgstr ""
+msgstr "--signed=(true|false|if-asked)"
 
 #. type: Plain text
 #: en/git-push.txt:209 en/git-send-pack.txt:83
@@ -38088,9 +38075,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:402
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--recurse-submodules=check|on-demand|only|no"
-msgstr ""
+msgstr "--recurse-submodules=check|on-demand|only|no"
 
 #. type: Plain text
 #: en/git-push.txt:416
@@ -45398,9 +45385,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:179
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--glob=pattern"
-msgstr ""
+msgstr "--glob=pattern"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:185
@@ -45458,9 +45445,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:215
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--path-format=(absolute|relative)"
-msgstr ""
+msgstr "--path-format=(absolute|relative)"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:220
@@ -45680,15 +45667,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:306
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--since=datestring"
-msgstr ""
+msgstr "--since=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:307
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--after=datestring"
-msgstr ""
+msgstr "--after=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:310
@@ -45698,15 +45685,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:311
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--until=datestring"
-msgstr ""
+msgstr "--until=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:312
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--before=datestring"
-msgstr ""
+msgstr "--before=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:315
@@ -46511,9 +46498,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:140
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
-msgstr ""
+msgstr "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
 
 #. type: Plain text
 #: en/git-send-email.txt:148
@@ -46721,9 +46708,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:258
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--smtp-debug=0|1"
-msgstr ""
+msgstr "--smtp-debug=0|1"
 
 #. type: Plain text
 #: en/git-send-email.txt:262

--- a/po/documentation.es_MX.po
+++ b/po/documentation.es_MX.po
@@ -3906,9 +3906,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:37
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
-msgstr ""
+msgstr "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
 
 #. type: Labeled list
 #: en/diff-options.txt:38
@@ -3924,17 +3924,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:43
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none):"
-msgstr "diffmerge"
+msgstr "--diff-merges=(off|none):"
 
 #. type: Labeled list
 #: en/diff-options.txt:44
-#, fuzzy, no-wrap, priority:280
-#| msgid "--no-diff-merges"
+#, ignore-same, no-wrap, priority:280
 msgid "--no-diff-merges:"
-msgstr "--no-diff-merges"
+msgstr "--no-diff-merges:"
 
 #. type: Plain text
 #: en/diff-options.txt:47
@@ -3944,17 +3942,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:48
-#, fuzzy, no-wrap, priority:280
-#| msgid "--first-parent"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=first-parent:"
-msgstr "--first-parent"
+msgstr "--diff-merges=first-parent:"
 
 #. type: Labeled list
 #: en/diff-options.txt:49
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=1:"
-msgstr "diffmerge"
+msgstr "--diff-merges=1:"
 
 #. type: Plain text
 #: en/diff-options.txt:52
@@ -3964,24 +3960,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:53
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=separate:"
-msgstr "diffmerge"
+msgstr "--diff-merges=separate:"
 
 #. type: Labeled list
 #: en/diff-options.txt:54
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=m:"
-msgstr "diffmerge"
+msgstr "--diff-merges=m:"
 
 #. type: Labeled list
 #: en/diff-options.txt:55
-#, fuzzy, no-wrap, priority:280
-#| msgid "-m"
+#, ignore-same, no-wrap, priority:280
 msgid "-m:"
-msgstr "-m"
+msgstr "-m:"
 
 #. type: Plain text
 #: en/diff-options.txt:59
@@ -3991,24 +3984,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:60
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:61
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=c:"
-msgstr "diffmerge"
+msgstr "--diff-merges=c:"
 
 #. type: Labeled list
 #: en/diff-options.txt:62
-#, fuzzy, no-wrap, priority:280
-#| msgid "-c"
+#, ignore-same, no-wrap, priority:280
 msgid "-c:"
-msgstr "-c"
+msgstr "-c:"
 
 #. type: Plain text
 #: en/diff-options.txt:69
@@ -4018,24 +4008,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:70
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=dense-combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=dense-combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:71
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=cc:"
-msgstr "diffmerge"
+msgstr "--diff-merges=cc:"
 
 #. type: Labeled list
 #: en/diff-options.txt:72
-#, fuzzy, no-wrap, priority:280
-#| msgid "--cc"
+#, ignore-same, no-wrap, priority:280
 msgid "--cc:"
-msgstr "--cc"
+msgstr "--cc:"
 
 #. type: Plain text
 #: en/diff-options.txt:78
@@ -20597,9 +20584,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:30
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
-msgstr ""
+msgstr "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:34
@@ -20615,9 +20602,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:42
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--tag-of-filtered-object=(abort|drop|rewrite)"
-msgstr ""
+msgstr "--tag-of-filtered-object=(abort|drop|rewrite)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:46
@@ -20783,9 +20770,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:146
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--reencode=(yes|no|abort)"
-msgstr ""
+msgstr "--reencode=(yes|no|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:152
@@ -35470,9 +35457,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-p4.txt:352
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--conflict=(ask|skip|quit)"
-msgstr ""
+msgstr "--conflict=(ask|skip|quit)"
 
 #. type: Plain text
 #: en/git-p4.txt:358
@@ -37791,9 +37778,9 @@ msgstr "--[no-]signed"
 
 #. type: Labeled list
 #: en/git-push.txt:200 en/git-send-pack.txt:74
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--signed=(true|false|if-asked)"
-msgstr ""
+msgstr "--signed=(true|false|if-asked)"
 
 #. type: Plain text
 #: en/git-push.txt:209 en/git-send-pack.txt:83
@@ -38067,9 +38054,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:402
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--recurse-submodules=check|on-demand|only|no"
-msgstr ""
+msgstr "--recurse-submodules=check|on-demand|only|no"
 
 #. type: Plain text
 #: en/git-push.txt:416
@@ -45378,9 +45365,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:179
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--glob=pattern"
-msgstr ""
+msgstr "--glob=pattern"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:185
@@ -45438,9 +45425,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:215
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--path-format=(absolute|relative)"
-msgstr ""
+msgstr "--path-format=(absolute|relative)"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:220
@@ -45660,15 +45647,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:306
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--since=datestring"
-msgstr ""
+msgstr "--since=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:307
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--after=datestring"
-msgstr ""
+msgstr "--after=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:310
@@ -45678,15 +45665,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:311
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--until=datestring"
-msgstr ""
+msgstr "--until=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:312
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--before=datestring"
-msgstr ""
+msgstr "--before=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:315
@@ -46488,9 +46475,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:140
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
-msgstr ""
+msgstr "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
 
 #. type: Plain text
 #: en/git-send-email.txt:148
@@ -46698,9 +46685,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:258
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--smtp-debug=0|1"
-msgstr ""
+msgstr "--smtp-debug=0|1"
 
 #. type: Plain text
 #: en/git-send-email.txt:262

--- a/po/documentation.fr.po
+++ b/po/documentation.fr.po
@@ -3,7 +3,19 @@
 # This file is distributed under the same license as the Git package.
 # Jean-Noël Avila <jn.avila@free.fr>, 2019.
 msgid ""
-msgstr "Project-Id-Version: git documentation\nReport-Msgid-Bugs-To: jn.avila@free.fr\nPOT-Creation-Date: 2021-02-27 18:16+0100\nPO-Revision-Date: 2021-04-07 20:25+0000\nLast-Translator: Jean-Noël Avila <jn.avila@free.fr>\nLanguage-Team: Jean-Noël Avila <jn.avila@free.fr>\nLanguage: fr\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=2; plural=n > 1;\nX-Generator: Weblate 4.6-dev\n"
+msgstr ""
+"Project-Id-Version: git documentation\n"
+"Report-Msgid-Bugs-To: jn.avila@free.fr\n"
+"POT-Creation-Date: 2021-02-27 18:16+0100\n"
+"PO-Revision-Date: 2021-04-07 20:25+0000\n"
+"Last-Translator: Jean-Noël Avila <jn.avila@free.fr>\n"
+"Language-Team: Jean-Noël Avila <jn.avila@free.fr>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+"X-Generator: Weblate 4.6-dev\n"
 
 #. type: Labeled list
 #: en/blame-options.txt:1 en/diff-options.txt:738 en/git-instaweb.txt:45 en/git-mailinfo.txt:47 en/git-mailsplit.txt:35 en/git-repack.txt:126 en/git-status.txt:31
@@ -3991,7 +4003,7 @@ msgstr "Supprimer la sortie diff. Utile pour les commandes telles que `git show`
 
 #. type: Labeled list
 #: en/diff-options.txt:37
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
 msgstr "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
 
@@ -4009,13 +4021,13 @@ msgstr "Préciser le format de diff à utiliser pour les commits de fusion. La v
 
 #. type: Labeled list
 #: en/diff-options.txt:43
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none):"
 msgstr "--diff-merges=(off|none):"
 
 #. type: Labeled list
 #: en/diff-options.txt:44
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--no-diff-merges:"
 msgstr "--no-diff-merges:"
 
@@ -4027,13 +4039,13 @@ msgstr "Désactive la sortie des diffs pour des commits de fusion. Utile pour pa
 
 #. type: Labeled list
 #: en/diff-options.txt:48
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=first-parent:"
 msgstr "--diff-merges=first-parent:"
 
 #. type: Labeled list
 #: en/diff-options.txt:49
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=1:"
 msgstr "--diff-merges=1:"
 
@@ -4045,19 +4057,19 @@ msgstr "Cette option fait en sorte que les commits de fusion montrent les diffé
 
 #. type: Labeled list
 #: en/diff-options.txt:53
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=separate:"
 msgstr "--diff-merges=separate:"
 
 #. type: Labeled list
 #: en/diff-options.txt:54
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=m:"
 msgstr "--diff-merges=m:"
 
 #. type: Labeled list
 #: en/diff-options.txt:55
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "-m:"
 msgstr "-m:"
 
@@ -4069,19 +4081,19 @@ msgstr "Cela fait que les commits de fusion montrent la différence complète pa
 
 #. type: Labeled list
 #: en/diff-options.txt:60
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=combined:"
 msgstr "--diff-merges=combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:61
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=c:"
 msgstr "--diff-merges=c:"
 
 #. type: Labeled list
 #: en/diff-options.txt:62
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "-c:"
 msgstr "-c:"
 
@@ -4093,19 +4105,19 @@ msgstr "Avec cette option, la sortie de diff pour un commit de fusion montre les
 
 #. type: Labeled list
 #: en/diff-options.txt:70
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=dense-combined:"
 msgstr "--diff-merges=dense-combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:71
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=cc:"
 msgstr "--diff-merges=cc:"
 
 #. type: Labeled list
 #: en/diff-options.txt:72
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--cc:"
 msgstr "--cc:"
 
@@ -21006,9 +21018,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:30
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
-msgstr ""
+msgstr "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:34
@@ -21024,9 +21036,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:42
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--tag-of-filtered-object=(abort|drop|rewrite)"
-msgstr ""
+msgstr "--tag-of-filtered-object=(abort|drop|rewrite)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:46
@@ -21192,9 +21204,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:146
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--reencode=(yes|no|abort)"
-msgstr ""
+msgstr "--reencode=(yes|no|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:152
@@ -35955,9 +35967,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-p4.txt:352
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--conflict=(ask|skip|quit)"
-msgstr ""
+msgstr "--conflict=(ask|skip|quit)"
 
 #. type: Plain text
 #: en/git-p4.txt:358
@@ -38292,7 +38304,7 @@ msgstr "--[no-]signed"
 
 #. type: Labeled list
 #: en/git-push.txt:200 en/git-send-pack.txt:74
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--signed=(true|false|if-asked)"
 msgstr "--signed=(true|false|if-asked)"
 
@@ -38574,7 +38586,7 @@ msgstr "Supprimer toutes les sorties, y compris la liste des références mises 
 
 #. type: Labeled list
 #: en/git-push.txt:402
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--recurse-submodules=check|on-demand|only|no"
 msgstr "--recurse-submodules=check|on-demand|only|no"
 
@@ -46081,9 +46093,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:179
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--glob=pattern"
-msgstr ""
+msgstr "--glob=pattern"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:185
@@ -46141,9 +46153,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:215
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--path-format=(absolute|relative)"
-msgstr ""
+msgstr "--path-format=(absolute|relative)"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:220
@@ -46363,15 +46375,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:306
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--since=datestring"
-msgstr ""
+msgstr "--since=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:307
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--after=datestring"
-msgstr ""
+msgstr "--after=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:310
@@ -46381,13 +46393,13 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:311
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--until=datestring"
-msgstr ""
+msgstr "--until=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:312
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--before=datestring"
 msgstr "--before=datestring"
 
@@ -47194,9 +47206,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:140
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
-msgstr ""
+msgstr "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
 
 #. type: Plain text
 #: en/git-send-email.txt:148
@@ -47404,9 +47416,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:258
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--smtp-debug=0|1"
-msgstr ""
+msgstr "--smtp-debug=0|1"
 
 #. type: Plain text
 #: en/git-send-email.txt:262

--- a/po/documentation.hu.po
+++ b/po/documentation.hu.po
@@ -3906,9 +3906,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:37
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
-msgstr ""
+msgstr "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
 
 #. type: Labeled list
 #: en/diff-options.txt:38
@@ -3924,17 +3924,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:43
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none):"
-msgstr "diffmerge"
+msgstr "--diff-merges=(off|none):"
 
 #. type: Labeled list
 #: en/diff-options.txt:44
-#, fuzzy, no-wrap, priority:280
-#| msgid "--no-diff-merges"
+#, ignore-same, no-wrap, priority:280
 msgid "--no-diff-merges:"
-msgstr "--no-diff-merges"
+msgstr "--no-diff-merges:"
 
 #. type: Plain text
 #: en/diff-options.txt:47
@@ -3944,17 +3942,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:48
-#, fuzzy, no-wrap, priority:280
-#| msgid "--first-parent"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=first-parent:"
-msgstr "--first-parent"
+msgstr "--diff-merges=first-parent:"
 
 #. type: Labeled list
 #: en/diff-options.txt:49
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=1:"
-msgstr "diffmerge"
+msgstr "--diff-merges=1:"
 
 #. type: Plain text
 #: en/diff-options.txt:52
@@ -3964,24 +3960,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:53
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=separate:"
-msgstr "diffmerge"
+msgstr "--diff-merges=separate:"
 
 #. type: Labeled list
 #: en/diff-options.txt:54
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=m:"
-msgstr "diffmerge"
+msgstr "--diff-merges=m:"
 
 #. type: Labeled list
 #: en/diff-options.txt:55
-#, fuzzy, no-wrap, priority:280
-#| msgid "-m"
+#, ignore-same, no-wrap, priority:280
 msgid "-m:"
-msgstr "-m"
+msgstr "-m:"
 
 #. type: Plain text
 #: en/diff-options.txt:59
@@ -3991,24 +3984,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:60
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:61
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=c:"
-msgstr "diffmerge"
+msgstr "--diff-merges=c:"
 
 #. type: Labeled list
 #: en/diff-options.txt:62
-#, fuzzy, no-wrap, priority:280
-#| msgid "-c"
+#, ignore-same, no-wrap, priority:280
 msgid "-c:"
-msgstr "-c"
+msgstr "-c:"
 
 #. type: Plain text
 #: en/diff-options.txt:69
@@ -4018,24 +4008,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:70
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=dense-combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=dense-combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:71
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=cc:"
-msgstr "diffmerge"
+msgstr "--diff-merges=cc:"
 
 #. type: Labeled list
 #: en/diff-options.txt:72
-#, fuzzy, no-wrap, priority:280
-#| msgid "--cc"
+#, ignore-same, no-wrap, priority:280
 msgid "--cc:"
-msgstr "--cc"
+msgstr "--cc:"
 
 #. type: Plain text
 #: en/diff-options.txt:78
@@ -20587,9 +20574,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:30
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
-msgstr ""
+msgstr "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:34
@@ -20605,9 +20592,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:42
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--tag-of-filtered-object=(abort|drop|rewrite)"
-msgstr ""
+msgstr "--tag-of-filtered-object=(abort|drop|rewrite)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:46
@@ -20773,9 +20760,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:146
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--reencode=(yes|no|abort)"
-msgstr ""
+msgstr "--reencode=(yes|no|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:152
@@ -35455,9 +35442,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-p4.txt:352
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--conflict=(ask|skip|quit)"
-msgstr ""
+msgstr "--conflict=(ask|skip|quit)"
 
 #. type: Plain text
 #: en/git-p4.txt:358
@@ -37776,9 +37763,9 @@ msgstr "--[no-]signed"
 
 #. type: Labeled list
 #: en/git-push.txt:200 en/git-send-pack.txt:74
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--signed=(true|false|if-asked)"
-msgstr ""
+msgstr "--signed=(true|false|if-asked)"
 
 #. type: Plain text
 #: en/git-push.txt:209 en/git-send-pack.txt:83
@@ -38052,9 +38039,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:402
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--recurse-submodules=check|on-demand|only|no"
-msgstr ""
+msgstr "--recurse-submodules=check|on-demand|only|no"
 
 #. type: Plain text
 #: en/git-push.txt:416
@@ -45363,9 +45350,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:179
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--glob=pattern"
-msgstr ""
+msgstr "--glob=pattern"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:185
@@ -45423,9 +45410,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:215
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--path-format=(absolute|relative)"
-msgstr ""
+msgstr "--path-format=(absolute|relative)"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:220
@@ -45645,15 +45632,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:306
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--since=datestring"
-msgstr ""
+msgstr "--since=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:307
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--after=datestring"
-msgstr ""
+msgstr "--after=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:310
@@ -45663,15 +45650,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:311
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--until=datestring"
-msgstr ""
+msgstr "--until=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:312
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--before=datestring"
-msgstr ""
+msgstr "--before=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:315
@@ -46473,9 +46460,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:140
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
-msgstr ""
+msgstr "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
 
 #. type: Plain text
 #: en/git-send-email.txt:148
@@ -46683,9 +46670,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:258
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--smtp-debug=0|1"
-msgstr ""
+msgstr "--smtp-debug=0|1"
 
 #. type: Plain text
 #: en/git-send-email.txt:262

--- a/po/documentation.id.po
+++ b/po/documentation.id.po
@@ -3907,9 +3907,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:37
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
-msgstr ""
+msgstr "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
 
 #. type: Labeled list
 #: en/diff-options.txt:38
@@ -3925,17 +3925,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:43
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none):"
-msgstr "diffmerge"
+msgstr "--diff-merges=(off|none):"
 
 #. type: Labeled list
 #: en/diff-options.txt:44
-#, fuzzy, no-wrap, priority:280
-#| msgid "--no-diff-merges"
+#, ignore-same, no-wrap, priority:280
 msgid "--no-diff-merges:"
-msgstr "--no-diff-merges"
+msgstr "--no-diff-merges:"
 
 #. type: Plain text
 #: en/diff-options.txt:47
@@ -3945,17 +3943,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:48
-#, fuzzy, no-wrap, priority:280
-#| msgid "--first-parent"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=first-parent:"
-msgstr "--first-parent"
+msgstr "--diff-merges=first-parent:"
 
 #. type: Labeled list
 #: en/diff-options.txt:49
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=1:"
-msgstr "diffmerge"
+msgstr "--diff-merges=1:"
 
 #. type: Plain text
 #: en/diff-options.txt:52
@@ -3965,24 +3961,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:53
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=separate:"
-msgstr "diffmerge"
+msgstr "--diff-merges=separate:"
 
 #. type: Labeled list
 #: en/diff-options.txt:54
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=m:"
-msgstr "diffmerge"
+msgstr "--diff-merges=m:"
 
 #. type: Labeled list
 #: en/diff-options.txt:55
-#, fuzzy, no-wrap, priority:280
-#| msgid "-m"
+#, ignore-same, no-wrap, priority:280
 msgid "-m:"
-msgstr "-m"
+msgstr "-m:"
 
 #. type: Plain text
 #: en/diff-options.txt:59
@@ -3992,24 +3985,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:60
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:61
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=c:"
-msgstr "diffmerge"
+msgstr "--diff-merges=c:"
 
 #. type: Labeled list
 #: en/diff-options.txt:62
-#, fuzzy, no-wrap, priority:280
-#| msgid "-c"
+#, ignore-same, no-wrap, priority:280
 msgid "-c:"
-msgstr "-c"
+msgstr "-c:"
 
 #. type: Plain text
 #: en/diff-options.txt:69
@@ -4019,24 +4009,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:70
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=dense-combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=dense-combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:71
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=cc:"
-msgstr "diffmerge"
+msgstr "--diff-merges=cc:"
 
 #. type: Labeled list
 #: en/diff-options.txt:72
-#, fuzzy, no-wrap, priority:280
-#| msgid "--cc"
+#, ignore-same, no-wrap, priority:280
 msgid "--cc:"
-msgstr "--cc"
+msgstr "--cc:"
 
 #. type: Plain text
 #: en/diff-options.txt:78
@@ -20588,9 +20575,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:30
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
-msgstr ""
+msgstr "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:34
@@ -20606,9 +20593,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:42
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--tag-of-filtered-object=(abort|drop|rewrite)"
-msgstr ""
+msgstr "--tag-of-filtered-object=(abort|drop|rewrite)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:46
@@ -20774,9 +20761,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:146
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--reencode=(yes|no|abort)"
-msgstr ""
+msgstr "--reencode=(yes|no|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:152
@@ -35456,9 +35443,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-p4.txt:352
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--conflict=(ask|skip|quit)"
-msgstr ""
+msgstr "--conflict=(ask|skip|quit)"
 
 #. type: Plain text
 #: en/git-p4.txt:358
@@ -37777,9 +37764,9 @@ msgstr "--[no-]signed"
 
 #. type: Labeled list
 #: en/git-push.txt:200 en/git-send-pack.txt:74
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--signed=(true|false|if-asked)"
-msgstr ""
+msgstr "--signed=(true|false|if-asked)"
 
 #. type: Plain text
 #: en/git-push.txt:209 en/git-send-pack.txt:83
@@ -38053,9 +38040,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:402
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--recurse-submodules=check|on-demand|only|no"
-msgstr ""
+msgstr "--recurse-submodules=check|on-demand|only|no"
 
 #. type: Plain text
 #: en/git-push.txt:416
@@ -45364,9 +45351,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:179
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--glob=pattern"
-msgstr ""
+msgstr "--glob=pattern"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:185
@@ -45424,9 +45411,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:215
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--path-format=(absolute|relative)"
-msgstr ""
+msgstr "--path-format=(absolute|relative)"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:220
@@ -45646,15 +45633,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:306
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--since=datestring"
-msgstr ""
+msgstr "--since=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:307
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--after=datestring"
-msgstr ""
+msgstr "--after=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:310
@@ -45664,15 +45651,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:311
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--until=datestring"
-msgstr ""
+msgstr "--until=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:312
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--before=datestring"
-msgstr ""
+msgstr "--before=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:315
@@ -46474,9 +46461,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:140
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
-msgstr ""
+msgstr "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
 
 #. type: Plain text
 #: en/git-send-email.txt:148
@@ -46684,9 +46671,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:258
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--smtp-debug=0|1"
-msgstr ""
+msgstr "--smtp-debug=0|1"
 
 #. type: Plain text
 #: en/git-send-email.txt:262

--- a/po/documentation.is.po
+++ b/po/documentation.is.po
@@ -3908,9 +3908,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:37
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
-msgstr ""
+msgstr "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
 
 #. type: Labeled list
 #: en/diff-options.txt:38
@@ -3926,17 +3926,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:43
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none):"
-msgstr "diffmerge"
+msgstr "--diff-merges=(off|none):"
 
 #. type: Labeled list
 #: en/diff-options.txt:44
-#, fuzzy, no-wrap, priority:280
-#| msgid "--no-diff-merges"
+#, ignore-same, no-wrap, priority:280
 msgid "--no-diff-merges:"
-msgstr "--no-diff-merges"
+msgstr "--no-diff-merges:"
 
 #. type: Plain text
 #: en/diff-options.txt:47
@@ -3946,17 +3944,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:48
-#, fuzzy, no-wrap, priority:280
-#| msgid "--first-parent"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=first-parent:"
-msgstr "--first-parent"
+msgstr "--diff-merges=first-parent:"
 
 #. type: Labeled list
 #: en/diff-options.txt:49
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=1:"
-msgstr "diffmerge"
+msgstr "--diff-merges=1:"
 
 #. type: Plain text
 #: en/diff-options.txt:52
@@ -3966,24 +3962,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:53
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=separate:"
-msgstr "diffmerge"
+msgstr "--diff-merges=separate:"
 
 #. type: Labeled list
 #: en/diff-options.txt:54
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=m:"
-msgstr "diffmerge"
+msgstr "--diff-merges=m:"
 
 #. type: Labeled list
 #: en/diff-options.txt:55
-#, fuzzy, no-wrap, priority:280
-#| msgid "-m"
+#, ignore-same, no-wrap, priority:280
 msgid "-m:"
-msgstr "-m"
+msgstr "-m:"
 
 #. type: Plain text
 #: en/diff-options.txt:59
@@ -3993,24 +3986,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:60
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:61
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=c:"
-msgstr "diffmerge"
+msgstr "--diff-merges=c:"
 
 #. type: Labeled list
 #: en/diff-options.txt:62
-#, fuzzy, no-wrap, priority:280
-#| msgid "-c"
+#, ignore-same, no-wrap, priority:280
 msgid "-c:"
-msgstr "-c"
+msgstr "-c:"
 
 #. type: Plain text
 #: en/diff-options.txt:69
@@ -4020,24 +4010,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:70
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=dense-combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=dense-combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:71
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=cc:"
-msgstr "diffmerge"
+msgstr "--diff-merges=cc:"
 
 #. type: Labeled list
 #: en/diff-options.txt:72
-#, fuzzy, no-wrap, priority:280
-#| msgid "--cc"
+#, ignore-same, no-wrap, priority:280
 msgid "--cc:"
-msgstr "--cc"
+msgstr "--cc:"
 
 #. type: Plain text
 #: en/diff-options.txt:78
@@ -20658,9 +20645,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:30
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
-msgstr ""
+msgstr "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:34
@@ -20676,9 +20663,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:42
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--tag-of-filtered-object=(abort|drop|rewrite)"
-msgstr ""
+msgstr "--tag-of-filtered-object=(abort|drop|rewrite)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:46
@@ -20844,9 +20831,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:146
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--reencode=(yes|no|abort)"
-msgstr ""
+msgstr "--reencode=(yes|no|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:152
@@ -35537,9 +35524,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-p4.txt:352
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--conflict=(ask|skip|quit)"
-msgstr ""
+msgstr "--conflict=(ask|skip|quit)"
 
 #. type: Plain text
 #: en/git-p4.txt:358
@@ -37856,9 +37843,9 @@ msgstr "--[no-]signed"
 
 #. type: Labeled list
 #: en/git-push.txt:200 en/git-send-pack.txt:74
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--signed=(true|false|if-asked)"
-msgstr ""
+msgstr "--signed=(true|false|if-asked)"
 
 #. type: Plain text
 #: en/git-push.txt:209 en/git-send-pack.txt:83
@@ -38132,9 +38119,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:402
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--recurse-submodules=check|on-demand|only|no"
-msgstr ""
+msgstr "--recurse-submodules=check|on-demand|only|no"
 
 #. type: Plain text
 #: en/git-push.txt:416
@@ -45438,9 +45425,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:179
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--glob=pattern"
-msgstr ""
+msgstr "--glob=pattern"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:185
@@ -45498,9 +45485,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:215
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--path-format=(absolute|relative)"
-msgstr ""
+msgstr "--path-format=(absolute|relative)"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:220
@@ -45720,15 +45707,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:306
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--since=datestring"
-msgstr ""
+msgstr "--since=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:307
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--after=datestring"
-msgstr ""
+msgstr "--after=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:310
@@ -45738,15 +45725,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:311
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--until=datestring"
-msgstr ""
+msgstr "--until=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:312
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--before=datestring"
-msgstr ""
+msgstr "--before=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:315
@@ -46548,9 +46535,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:140
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
-msgstr ""
+msgstr "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
 
 #. type: Plain text
 #: en/git-send-email.txt:148
@@ -46758,9 +46745,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:258
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--smtp-debug=0|1"
-msgstr ""
+msgstr "--smtp-debug=0|1"
 
 #. type: Plain text
 #: en/git-send-email.txt:262

--- a/po/documentation.it.po
+++ b/po/documentation.it.po
@@ -3919,9 +3919,9 @@ msgstr "Sopprime l'output differente. Utile per comandi come `git show` che most
 
 #. type: Labeled list
 #: en/diff-options.txt:37
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
-msgstr ""
+msgstr "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
 
 #. type: Labeled list
 #: en/diff-options.txt:38
@@ -3937,17 +3937,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:43
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none):"
-msgstr "diffmerge"
+msgstr "--diff-merges=(off|none):"
 
 #. type: Labeled list
 #: en/diff-options.txt:44
-#, fuzzy, no-wrap, priority:280
-#| msgid "--no-diff-merges"
+#, ignore-same, no-wrap, priority:280
 msgid "--no-diff-merges:"
-msgstr "--no-diff-merges"
+msgstr "--no-diff-merges:"
 
 #. type: Plain text
 #: en/diff-options.txt:47
@@ -3957,17 +3955,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:48
-#, fuzzy, no-wrap, priority:280
-#| msgid "--first-parent"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=first-parent:"
-msgstr "--first-parent"
+msgstr "--diff-merges=first-parent:"
 
 #. type: Labeled list
 #: en/diff-options.txt:49
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=1:"
-msgstr "diffmerge"
+msgstr "--diff-merges=1:"
 
 #. type: Plain text
 #: en/diff-options.txt:52
@@ -3977,24 +3973,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:53
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=separate:"
-msgstr "diffmerge"
+msgstr "--diff-merges=separate:"
 
 #. type: Labeled list
 #: en/diff-options.txt:54
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=m:"
-msgstr "diffmerge"
+msgstr "--diff-merges=m:"
 
 #. type: Labeled list
 #: en/diff-options.txt:55
-#, fuzzy, no-wrap, priority:280
-#| msgid "-m"
+#, ignore-same, no-wrap, priority:280
 msgid "-m:"
-msgstr "-m"
+msgstr "-m:"
 
 #. type: Plain text
 #: en/diff-options.txt:59
@@ -4004,24 +3997,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:60
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:61
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=c:"
-msgstr "diffmerge"
+msgstr "--diff-merges=c:"
 
 #. type: Labeled list
 #: en/diff-options.txt:62
-#, fuzzy, no-wrap, priority:280
-#| msgid "-c"
+#, ignore-same, no-wrap, priority:280
 msgid "-c:"
-msgstr "-c"
+msgstr "-c:"
 
 #. type: Plain text
 #: en/diff-options.txt:69
@@ -4031,24 +4021,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:70
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=dense-combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=dense-combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:71
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=cc:"
-msgstr "diffmerge"
+msgstr "--diff-merges=cc:"
 
 #. type: Labeled list
 #: en/diff-options.txt:72
-#, fuzzy, no-wrap, priority:280
-#| msgid "--cc"
+#, ignore-same, no-wrap, priority:280
 msgid "--cc:"
-msgstr "--cc"
+msgstr "--cc:"
 
 #. type: Plain text
 #: en/diff-options.txt:78
@@ -20677,9 +20664,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:30
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
-msgstr ""
+msgstr "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:34
@@ -20695,9 +20682,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:42
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--tag-of-filtered-object=(abort|drop|rewrite)"
-msgstr ""
+msgstr "--tag-of-filtered-object=(abort|drop|rewrite)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:46
@@ -20863,9 +20850,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:146
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--reencode=(yes|no|abort)"
-msgstr ""
+msgstr "--reencode=(yes|no|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:152
@@ -35553,9 +35540,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-p4.txt:352
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--conflict=(ask|skip|quit)"
-msgstr ""
+msgstr "--conflict=(ask|skip|quit)"
 
 #. type: Plain text
 #: en/git-p4.txt:358
@@ -37874,9 +37861,9 @@ msgstr "--[no-]signed"
 
 #. type: Labeled list
 #: en/git-push.txt:200 en/git-send-pack.txt:74
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--signed=(true|false|if-asked)"
-msgstr ""
+msgstr "--signed=(true|false|if-asked)"
 
 #. type: Plain text
 #: en/git-push.txt:209 en/git-send-pack.txt:83
@@ -38150,9 +38137,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:402
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--recurse-submodules=check|on-demand|only|no"
-msgstr ""
+msgstr "--recurse-submodules=check|on-demand|only|no"
 
 #. type: Plain text
 #: en/git-push.txt:416
@@ -45459,9 +45446,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:179
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--glob=pattern"
-msgstr ""
+msgstr "--glob=pattern"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:185
@@ -45519,9 +45506,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:215
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--path-format=(absolute|relative)"
-msgstr ""
+msgstr "--path-format=(absolute|relative)"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:220
@@ -45741,15 +45728,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:306
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--since=datestring"
-msgstr ""
+msgstr "--since=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:307
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--after=datestring"
-msgstr ""
+msgstr "--after=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:310
@@ -45759,15 +45746,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:311
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--until=datestring"
-msgstr ""
+msgstr "--until=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:312
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--before=datestring"
-msgstr ""
+msgstr "--before=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:315
@@ -46569,9 +46556,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:140
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
-msgstr ""
+msgstr "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
 
 #. type: Plain text
 #: en/git-send-email.txt:148
@@ -46779,9 +46766,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:258
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--smtp-debug=0|1"
-msgstr ""
+msgstr "--smtp-debug=0|1"
 
 #. type: Plain text
 #: en/git-send-email.txt:262

--- a/po/documentation.ja.po
+++ b/po/documentation.ja.po
@@ -3909,9 +3909,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:37
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
-msgstr ""
+msgstr "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
 
 #. type: Labeled list
 #: en/diff-options.txt:38
@@ -3927,17 +3927,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:43
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none):"
-msgstr "diffmerge"
+msgstr "--diff-merges=(off|none):"
 
 #. type: Labeled list
 #: en/diff-options.txt:44
-#, fuzzy, no-wrap, priority:280
-#| msgid "--no-diff-merges"
+#, ignore-same, no-wrap, priority:280
 msgid "--no-diff-merges:"
-msgstr "--no-diff-merges"
+msgstr "--no-diff-merges:"
 
 #. type: Plain text
 #: en/diff-options.txt:47
@@ -3947,17 +3945,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:48
-#, fuzzy, no-wrap, priority:280
-#| msgid "--first-parent"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=first-parent:"
-msgstr "--first-parent"
+msgstr "--diff-merges=first-parent:"
 
 #. type: Labeled list
 #: en/diff-options.txt:49
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=1:"
-msgstr "diffmerge"
+msgstr "--diff-merges=1:"
 
 #. type: Plain text
 #: en/diff-options.txt:52
@@ -3967,24 +3963,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:53
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=separate:"
-msgstr "diffmerge"
+msgstr "--diff-merges=separate:"
 
 #. type: Labeled list
 #: en/diff-options.txt:54
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=m:"
-msgstr "diffmerge"
+msgstr "--diff-merges=m:"
 
 #. type: Labeled list
 #: en/diff-options.txt:55
-#, fuzzy, no-wrap, priority:280
-#| msgid "-m"
+#, ignore-same, no-wrap, priority:280
 msgid "-m:"
-msgstr "-m"
+msgstr "-m:"
 
 #. type: Plain text
 #: en/diff-options.txt:59
@@ -3994,24 +3987,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:60
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:61
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=c:"
-msgstr "diffmerge"
+msgstr "--diff-merges=c:"
 
 #. type: Labeled list
 #: en/diff-options.txt:62
-#, fuzzy, no-wrap, priority:280
-#| msgid "-c"
+#, ignore-same, no-wrap, priority:280
 msgid "-c:"
-msgstr "-c"
+msgstr "-c:"
 
 #. type: Plain text
 #: en/diff-options.txt:69
@@ -4021,24 +4011,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:70
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=dense-combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=dense-combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:71
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=cc:"
-msgstr "diffmerge"
+msgstr "--diff-merges=cc:"
 
 #. type: Labeled list
 #: en/diff-options.txt:72
-#, fuzzy, no-wrap, priority:280
-#| msgid "--cc"
+#, ignore-same, no-wrap, priority:280
 msgid "--cc:"
-msgstr "--cc"
+msgstr "--cc:"
 
 #. type: Plain text
 #: en/diff-options.txt:78
@@ -20582,9 +20569,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:30
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
-msgstr ""
+msgstr "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:34
@@ -20600,9 +20587,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:42
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--tag-of-filtered-object=(abort|drop|rewrite)"
-msgstr ""
+msgstr "--tag-of-filtered-object=(abort|drop|rewrite)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:46
@@ -20768,9 +20755,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:146
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--reencode=(yes|no|abort)"
-msgstr ""
+msgstr "--reencode=(yes|no|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:152
@@ -35449,9 +35436,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-p4.txt:352
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--conflict=(ask|skip|quit)"
-msgstr ""
+msgstr "--conflict=(ask|skip|quit)"
 
 #. type: Plain text
 #: en/git-p4.txt:358
@@ -37768,9 +37755,9 @@ msgstr "--[no-]signed"
 
 #. type: Labeled list
 #: en/git-push.txt:200 en/git-send-pack.txt:74
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--signed=(true|false|if-asked)"
-msgstr ""
+msgstr "--signed=(true|false|if-asked)"
 
 #. type: Plain text
 #: en/git-push.txt:209 en/git-send-pack.txt:83
@@ -38044,9 +38031,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:402
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--recurse-submodules=check|on-demand|only|no"
-msgstr ""
+msgstr "--recurse-submodules=check|on-demand|only|no"
 
 #. type: Plain text
 #: en/git-push.txt:416
@@ -45350,9 +45337,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:179
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--glob=pattern"
-msgstr ""
+msgstr "--glob=pattern"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:185
@@ -45410,9 +45397,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:215
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--path-format=(absolute|relative)"
-msgstr ""
+msgstr "--path-format=(absolute|relative)"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:220
@@ -45632,15 +45619,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:306
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--since=datestring"
-msgstr ""
+msgstr "--since=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:307
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--after=datestring"
-msgstr ""
+msgstr "--after=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:310
@@ -45650,15 +45637,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:311
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--until=datestring"
-msgstr ""
+msgstr "--until=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:312
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--before=datestring"
-msgstr ""
+msgstr "--before=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:315
@@ -46460,9 +46447,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:140
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
-msgstr ""
+msgstr "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
 
 #. type: Plain text
 #: en/git-send-email.txt:148
@@ -46670,9 +46657,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:258
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--smtp-debug=0|1"
-msgstr ""
+msgstr "--smtp-debug=0|1"
 
 #. type: Plain text
 #: en/git-send-email.txt:262

--- a/po/documentation.ko.po
+++ b/po/documentation.ko.po
@@ -3907,9 +3907,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:37
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
-msgstr ""
+msgstr "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
 
 #. type: Labeled list
 #: en/diff-options.txt:38
@@ -3925,17 +3925,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:43
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none):"
-msgstr "diffmerge"
+msgstr "--diff-merges=(off|none):"
 
 #. type: Labeled list
 #: en/diff-options.txt:44
-#, fuzzy, no-wrap, priority:280
-#| msgid "--no-diff-merges"
+#, ignore-same, no-wrap, priority:280
 msgid "--no-diff-merges:"
-msgstr "--no-diff-merges"
+msgstr "--no-diff-merges:"
 
 #. type: Plain text
 #: en/diff-options.txt:47
@@ -3945,17 +3943,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:48
-#, fuzzy, no-wrap, priority:280
-#| msgid "--first-parent"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=first-parent:"
-msgstr "--first-parent"
+msgstr "--diff-merges=first-parent:"
 
 #. type: Labeled list
 #: en/diff-options.txt:49
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=1:"
-msgstr "diffmerge"
+msgstr "--diff-merges=1:"
 
 #. type: Plain text
 #: en/diff-options.txt:52
@@ -3965,24 +3961,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:53
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=separate:"
-msgstr "diffmerge"
+msgstr "--diff-merges=separate:"
 
 #. type: Labeled list
 #: en/diff-options.txt:54
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=m:"
-msgstr "diffmerge"
+msgstr "--diff-merges=m:"
 
 #. type: Labeled list
 #: en/diff-options.txt:55
-#, fuzzy, no-wrap, priority:280
-#| msgid "-m"
+#, ignore-same, no-wrap, priority:280
 msgid "-m:"
-msgstr "-m"
+msgstr "-m:"
 
 #. type: Plain text
 #: en/diff-options.txt:59
@@ -3992,24 +3985,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:60
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:61
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=c:"
-msgstr "diffmerge"
+msgstr "--diff-merges=c:"
 
 #. type: Labeled list
 #: en/diff-options.txt:62
-#, fuzzy, no-wrap, priority:280
-#| msgid "-c"
+#, ignore-same, no-wrap, priority:280
 msgid "-c:"
-msgstr "-c"
+msgstr "-c:"
 
 #. type: Plain text
 #: en/diff-options.txt:69
@@ -4019,24 +4009,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:70
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=dense-combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=dense-combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:71
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=cc:"
-msgstr "diffmerge"
+msgstr "--diff-merges=cc:"
 
 #. type: Labeled list
 #: en/diff-options.txt:72
-#, fuzzy, no-wrap, priority:280
-#| msgid "--cc"
+#, ignore-same, no-wrap, priority:280
 msgid "--cc:"
-msgstr "--cc"
+msgstr "--cc:"
 
 #. type: Plain text
 #: en/diff-options.txt:78
@@ -20591,9 +20578,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:30
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
-msgstr ""
+msgstr "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:34
@@ -20609,9 +20596,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:42
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--tag-of-filtered-object=(abort|drop|rewrite)"
-msgstr ""
+msgstr "--tag-of-filtered-object=(abort|drop|rewrite)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:46
@@ -20777,9 +20764,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:146
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--reencode=(yes|no|abort)"
-msgstr ""
+msgstr "--reencode=(yes|no|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:152
@@ -35456,9 +35443,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-p4.txt:352
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--conflict=(ask|skip|quit)"
-msgstr ""
+msgstr "--conflict=(ask|skip|quit)"
 
 #. type: Plain text
 #: en/git-p4.txt:358
@@ -37777,9 +37764,9 @@ msgstr "--[no-]signed"
 
 #. type: Labeled list
 #: en/git-push.txt:200 en/git-send-pack.txt:74
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--signed=(true|false|if-asked)"
-msgstr ""
+msgstr "--signed=(true|false|if-asked)"
 
 #. type: Plain text
 #: en/git-push.txt:209 en/git-send-pack.txt:83
@@ -38053,9 +38040,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:402
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--recurse-submodules=check|on-demand|only|no"
-msgstr ""
+msgstr "--recurse-submodules=check|on-demand|only|no"
 
 #. type: Plain text
 #: en/git-push.txt:416
@@ -45362,9 +45349,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:179
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--glob=pattern"
-msgstr ""
+msgstr "--glob=pattern"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:185
@@ -45422,9 +45409,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:215
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--path-format=(absolute|relative)"
-msgstr ""
+msgstr "--path-format=(absolute|relative)"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:220
@@ -45644,15 +45631,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:306
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--since=datestring"
-msgstr ""
+msgstr "--since=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:307
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--after=datestring"
-msgstr ""
+msgstr "--after=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:310
@@ -45662,15 +45649,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:311
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--until=datestring"
-msgstr ""
+msgstr "--until=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:312
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--before=datestring"
-msgstr ""
+msgstr "--before=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:315
@@ -46472,9 +46459,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:140
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
-msgstr ""
+msgstr "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
 
 #. type: Plain text
 #: en/git-send-email.txt:148
@@ -46682,9 +46669,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:258
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--smtp-debug=0|1"
-msgstr ""
+msgstr "--smtp-debug=0|1"
 
 #. type: Plain text
 #: en/git-send-email.txt:262

--- a/po/documentation.mr.po
+++ b/po/documentation.mr.po
@@ -3907,9 +3907,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:37
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
-msgstr ""
+msgstr "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
 
 #. type: Labeled list
 #: en/diff-options.txt:38
@@ -3925,17 +3925,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:43
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none):"
-msgstr "diffmerge"
+msgstr "--diff-merges=(off|none):"
 
 #. type: Labeled list
 #: en/diff-options.txt:44
-#, fuzzy, no-wrap, priority:280
-#| msgid "--no-diff-merges"
+#, ignore-same, no-wrap, priority:280
 msgid "--no-diff-merges:"
-msgstr "--no-diff-merges"
+msgstr "--no-diff-merges:"
 
 #. type: Plain text
 #: en/diff-options.txt:47
@@ -3945,17 +3943,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:48
-#, fuzzy, no-wrap, priority:280
-#| msgid "--first-parent"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=first-parent:"
-msgstr "--first-parent"
+msgstr "--diff-merges=first-parent:"
 
 #. type: Labeled list
 #: en/diff-options.txt:49
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=1:"
-msgstr "diffmerge"
+msgstr "--diff-merges=1:"
 
 #. type: Plain text
 #: en/diff-options.txt:52
@@ -3965,24 +3961,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:53
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=separate:"
-msgstr "diffmerge"
+msgstr "--diff-merges=separate:"
 
 #. type: Labeled list
 #: en/diff-options.txt:54
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=m:"
-msgstr "diffmerge"
+msgstr "--diff-merges=m:"
 
 #. type: Labeled list
 #: en/diff-options.txt:55
-#, fuzzy, no-wrap, priority:280
-#| msgid "-m"
+#, ignore-same, no-wrap, priority:280
 msgid "-m:"
-msgstr "-m"
+msgstr "-m:"
 
 #. type: Plain text
 #: en/diff-options.txt:59
@@ -3992,24 +3985,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:60
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:61
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=c:"
-msgstr "diffmerge"
+msgstr "--diff-merges=c:"
 
 #. type: Labeled list
 #: en/diff-options.txt:62
-#, fuzzy, no-wrap, priority:280
-#| msgid "-c"
+#, ignore-same, no-wrap, priority:280
 msgid "-c:"
-msgstr "-c"
+msgstr "-c:"
 
 #. type: Plain text
 #: en/diff-options.txt:69
@@ -4019,24 +4009,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:70
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=dense-combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=dense-combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:71
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=cc:"
-msgstr "diffmerge"
+msgstr "--diff-merges=cc:"
 
 #. type: Labeled list
 #: en/diff-options.txt:72
-#, fuzzy, no-wrap, priority:280
-#| msgid "--cc"
+#, ignore-same, no-wrap, priority:280
 msgid "--cc:"
-msgstr "--cc"
+msgstr "--cc:"
 
 #. type: Plain text
 #: en/diff-options.txt:78
@@ -20586,9 +20573,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:30
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
-msgstr ""
+msgstr "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:34
@@ -20604,9 +20591,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:42
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--tag-of-filtered-object=(abort|drop|rewrite)"
-msgstr ""
+msgstr "--tag-of-filtered-object=(abort|drop|rewrite)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:46
@@ -20772,9 +20759,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:146
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--reencode=(yes|no|abort)"
-msgstr ""
+msgstr "--reencode=(yes|no|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:152
@@ -35451,9 +35438,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-p4.txt:352
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--conflict=(ask|skip|quit)"
-msgstr ""
+msgstr "--conflict=(ask|skip|quit)"
 
 #. type: Plain text
 #: en/git-p4.txt:358
@@ -37772,9 +37759,9 @@ msgstr "--[no-]signed"
 
 #. type: Labeled list
 #: en/git-push.txt:200 en/git-send-pack.txt:74
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--signed=(true|false|if-asked)"
-msgstr ""
+msgstr "--signed=(true|false|if-asked)"
 
 #. type: Plain text
 #: en/git-push.txt:209 en/git-send-pack.txt:83
@@ -38048,9 +38035,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:402
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--recurse-submodules=check|on-demand|only|no"
-msgstr ""
+msgstr "--recurse-submodules=check|on-demand|only|no"
 
 #. type: Plain text
 #: en/git-push.txt:416
@@ -45357,9 +45344,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:179
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--glob=pattern"
-msgstr ""
+msgstr "--glob=pattern"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:185
@@ -45417,9 +45404,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:215
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--path-format=(absolute|relative)"
-msgstr ""
+msgstr "--path-format=(absolute|relative)"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:220
@@ -45639,15 +45626,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:306
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--since=datestring"
-msgstr ""
+msgstr "--since=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:307
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--after=datestring"
-msgstr ""
+msgstr "--after=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:310
@@ -45657,15 +45644,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:311
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--until=datestring"
-msgstr ""
+msgstr "--until=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:312
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--before=datestring"
-msgstr ""
+msgstr "--before=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:315
@@ -46467,9 +46454,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:140
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
-msgstr ""
+msgstr "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
 
 #. type: Plain text
 #: en/git-send-email.txt:148
@@ -46677,9 +46664,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:258
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--smtp-debug=0|1"
-msgstr ""
+msgstr "--smtp-debug=0|1"
 
 #. type: Plain text
 #: en/git-send-email.txt:262

--- a/po/documentation.nb_NO.po
+++ b/po/documentation.nb_NO.po
@@ -3905,9 +3905,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:37
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
-msgstr ""
+msgstr "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
 
 #. type: Labeled list
 #: en/diff-options.txt:38
@@ -3923,17 +3923,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:43
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none):"
-msgstr "diffmerge"
+msgstr "--diff-merges=(off|none):"
 
 #. type: Labeled list
 #: en/diff-options.txt:44
-#, fuzzy, no-wrap, priority:280
-#| msgid "--no-diff-merges"
+#, ignore-same, no-wrap, priority:280
 msgid "--no-diff-merges:"
-msgstr "--no-diff-merges"
+msgstr "--no-diff-merges:"
 
 #. type: Plain text
 #: en/diff-options.txt:47
@@ -3943,17 +3941,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:48
-#, fuzzy, no-wrap, priority:280
-#| msgid "--first-parent"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=first-parent:"
-msgstr "--first-parent"
+msgstr "--diff-merges=first-parent:"
 
 #. type: Labeled list
 #: en/diff-options.txt:49
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=1:"
-msgstr "diffmerge"
+msgstr "--diff-merges=1:"
 
 #. type: Plain text
 #: en/diff-options.txt:52
@@ -3963,24 +3959,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:53
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=separate:"
-msgstr "diffmerge"
+msgstr "--diff-merges=separate:"
 
 #. type: Labeled list
 #: en/diff-options.txt:54
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=m:"
-msgstr "diffmerge"
+msgstr "--diff-merges=m:"
 
 #. type: Labeled list
 #: en/diff-options.txt:55
-#, fuzzy, no-wrap, priority:280
-#| msgid "-m"
+#, ignore-same, no-wrap, priority:280
 msgid "-m:"
-msgstr "-m"
+msgstr "-m:"
 
 #. type: Plain text
 #: en/diff-options.txt:59
@@ -3990,24 +3983,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:60
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:61
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=c:"
-msgstr "diffmerge"
+msgstr "--diff-merges=c:"
 
 #. type: Labeled list
 #: en/diff-options.txt:62
-#, fuzzy, no-wrap, priority:280
-#| msgid "-c"
+#, ignore-same, no-wrap, priority:280
 msgid "-c:"
-msgstr "-c"
+msgstr "-c:"
 
 #. type: Plain text
 #: en/diff-options.txt:69
@@ -4017,24 +4007,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:70
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=dense-combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=dense-combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:71
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=cc:"
-msgstr "diffmerge"
+msgstr "--diff-merges=cc:"
 
 #. type: Labeled list
 #: en/diff-options.txt:72
-#, fuzzy, no-wrap, priority:280
-#| msgid "--cc"
+#, ignore-same, no-wrap, priority:280
 msgid "--cc:"
-msgstr "--cc"
+msgstr "--cc:"
 
 #. type: Plain text
 #: en/diff-options.txt:78
@@ -20588,9 +20575,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:30
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
-msgstr ""
+msgstr "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:34
@@ -20606,9 +20593,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:42
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--tag-of-filtered-object=(abort|drop|rewrite)"
-msgstr ""
+msgstr "--tag-of-filtered-object=(abort|drop|rewrite)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:46
@@ -20774,9 +20761,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:146
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--reencode=(yes|no|abort)"
-msgstr ""
+msgstr "--reencode=(yes|no|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:152
@@ -35458,9 +35445,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-p4.txt:352
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--conflict=(ask|skip|quit)"
-msgstr ""
+msgstr "--conflict=(ask|skip|quit)"
 
 #. type: Plain text
 #: en/git-p4.txt:358
@@ -37779,9 +37766,9 @@ msgstr "--[no-]signed"
 
 #. type: Labeled list
 #: en/git-push.txt:200 en/git-send-pack.txt:74
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--signed=(true|false|if-asked)"
-msgstr ""
+msgstr "--signed=(true|false|if-asked)"
 
 #. type: Plain text
 #: en/git-push.txt:209 en/git-send-pack.txt:83
@@ -38055,9 +38042,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:402
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--recurse-submodules=check|on-demand|only|no"
-msgstr ""
+msgstr "--recurse-submodules=check|on-demand|only|no"
 
 #. type: Plain text
 #: en/git-push.txt:416
@@ -45367,9 +45354,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:179
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--glob=pattern"
-msgstr ""
+msgstr "--glob=pattern"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:185
@@ -45427,9 +45414,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:215
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--path-format=(absolute|relative)"
-msgstr ""
+msgstr "--path-format=(absolute|relative)"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:220
@@ -45649,15 +45636,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:306
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--since=datestring"
-msgstr ""
+msgstr "--since=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:307
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--after=datestring"
-msgstr ""
+msgstr "--after=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:310
@@ -45667,15 +45654,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:311
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--until=datestring"
-msgstr ""
+msgstr "--until=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:312
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--before=datestring"
-msgstr ""
+msgstr "--before=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:315
@@ -46477,9 +46464,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:140
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
-msgstr ""
+msgstr "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
 
 #. type: Plain text
 #: en/git-send-email.txt:148
@@ -46687,9 +46674,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:258
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--smtp-debug=0|1"
-msgstr ""
+msgstr "--smtp-debug=0|1"
 
 #. type: Plain text
 #: en/git-send-email.txt:262

--- a/po/documentation.nl.po
+++ b/po/documentation.nl.po
@@ -3906,9 +3906,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:37
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
-msgstr ""
+msgstr "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
 
 #. type: Labeled list
 #: en/diff-options.txt:38
@@ -3924,17 +3924,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:43
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none):"
-msgstr "diffmerge"
+msgstr "--diff-merges=(off|none):"
 
 #. type: Labeled list
 #: en/diff-options.txt:44
-#, fuzzy, no-wrap, priority:280
-#| msgid "--no-diff-merges"
+#, ignore-same, no-wrap, priority:280
 msgid "--no-diff-merges:"
-msgstr "--no-diff-merges"
+msgstr "--no-diff-merges:"
 
 #. type: Plain text
 #: en/diff-options.txt:47
@@ -3944,17 +3942,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:48
-#, fuzzy, no-wrap, priority:280
-#| msgid "--first-parent"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=first-parent:"
-msgstr "--first-parent"
+msgstr "--diff-merges=first-parent:"
 
 #. type: Labeled list
 #: en/diff-options.txt:49
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=1:"
-msgstr "diffmerge"
+msgstr "--diff-merges=1:"
 
 #. type: Plain text
 #: en/diff-options.txt:52
@@ -3964,24 +3960,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:53
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=separate:"
-msgstr "diffmerge"
+msgstr "--diff-merges=separate:"
 
 #. type: Labeled list
 #: en/diff-options.txt:54
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=m:"
-msgstr "diffmerge"
+msgstr "--diff-merges=m:"
 
 #. type: Labeled list
 #: en/diff-options.txt:55
-#, fuzzy, no-wrap, priority:280
-#| msgid "-m"
+#, ignore-same, no-wrap, priority:280
 msgid "-m:"
-msgstr "-m"
+msgstr "-m:"
 
 #. type: Plain text
 #: en/diff-options.txt:59
@@ -3991,24 +3984,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:60
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:61
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=c:"
-msgstr "diffmerge"
+msgstr "--diff-merges=c:"
 
 #. type: Labeled list
 #: en/diff-options.txt:62
-#, fuzzy, no-wrap, priority:280
-#| msgid "-c"
+#, ignore-same, no-wrap, priority:280
 msgid "-c:"
-msgstr "-c"
+msgstr "-c:"
 
 #. type: Plain text
 #: en/diff-options.txt:69
@@ -4018,24 +4008,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:70
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=dense-combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=dense-combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:71
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=cc:"
-msgstr "diffmerge"
+msgstr "--diff-merges=cc:"
 
 #. type: Labeled list
 #: en/diff-options.txt:72
-#, fuzzy, no-wrap, priority:280
-#| msgid "--cc"
+#, ignore-same, no-wrap, priority:280
 msgid "--cc:"
-msgstr "--cc"
+msgstr "--cc:"
 
 #. type: Plain text
 #: en/diff-options.txt:78
@@ -20595,9 +20582,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:30
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
-msgstr ""
+msgstr "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:34
@@ -20613,9 +20600,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:42
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--tag-of-filtered-object=(abort|drop|rewrite)"
-msgstr ""
+msgstr "--tag-of-filtered-object=(abort|drop|rewrite)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:46
@@ -20781,9 +20768,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:146
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--reencode=(yes|no|abort)"
-msgstr ""
+msgstr "--reencode=(yes|no|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:152
@@ -35466,9 +35453,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-p4.txt:352
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--conflict=(ask|skip|quit)"
-msgstr ""
+msgstr "--conflict=(ask|skip|quit)"
 
 #. type: Plain text
 #: en/git-p4.txt:358
@@ -37791,9 +37778,9 @@ msgstr "--[no-]signed"
 
 #. type: Labeled list
 #: en/git-push.txt:200 en/git-send-pack.txt:74
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--signed=(true|false|if-asked)"
-msgstr ""
+msgstr "--signed=(true|false|if-asked)"
 
 #. type: Plain text
 #: en/git-push.txt:209 en/git-send-pack.txt:83
@@ -38069,10 +38056,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:402
-#, fuzzy, no-wrap, priority:220
-#| msgid "--recurse-submodules"
+#, ignore-same, no-wrap, priority:220
 msgid "--recurse-submodules=check|on-demand|only|no"
-msgstr "--recurse-submodules"
+msgstr "--recurse-submodules=check|on-demand|only|no"
 
 #. type: Plain text
 #: en/git-push.txt:416
@@ -45412,10 +45398,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:179
-#, fuzzy, no-wrap, priority:100
-#| msgid "--global"
+#, ignore-same, no-wrap, priority:100
 msgid "--glob=pattern"
-msgstr "--global"
+msgstr "--glob=pattern"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:185
@@ -45473,9 +45458,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:215
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--path-format=(absolute|relative)"
-msgstr ""
+msgstr "--path-format=(absolute|relative)"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:220
@@ -45695,17 +45680,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:306
-#, fuzzy, no-wrap, priority:100
-#| msgid "--fixed-strings"
+#, ignore-same, no-wrap, priority:100
 msgid "--since=datestring"
-msgstr "--fixed-strings"
+msgstr "--since=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:307
-#, fuzzy, no-wrap, priority:100
-#| msgid "--fixed-strings"
+#, ignore-same, no-wrap, priority:100
 msgid "--after=datestring"
-msgstr "--fixed-strings"
+msgstr "--after=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:310
@@ -45715,17 +45698,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:311
-#, fuzzy, no-wrap, priority:100
-#| msgid "--fixed-strings"
+#, ignore-same, no-wrap, priority:100
 msgid "--until=datestring"
-msgstr "--fixed-strings"
+msgstr "--until=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:312
-#, fuzzy, no-wrap, priority:100
-#| msgid "--fixed-strings"
+#, ignore-same, no-wrap, priority:100
 msgid "--before=datestring"
-msgstr "--fixed-strings"
+msgstr "--before=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:315
@@ -46531,9 +46512,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:140
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
-msgstr ""
+msgstr "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
 
 #. type: Plain text
 #: en/git-send-email.txt:148
@@ -46743,10 +46724,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:258
-#, fuzzy, no-wrap, priority:100
-#| msgid "--score-debug"
+#, ignore-same, no-wrap, priority:100
 msgid "--smtp-debug=0|1"
-msgstr "--score-debug"
+msgstr "--smtp-debug=0|1"
 
 #. type: Plain text
 #: en/git-send-email.txt:262

--- a/po/documentation.pl.po
+++ b/po/documentation.pl.po
@@ -3906,9 +3906,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:37
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
-msgstr ""
+msgstr "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
 
 #. type: Labeled list
 #: en/diff-options.txt:38
@@ -3924,17 +3924,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:43
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none):"
-msgstr "diffmerge"
+msgstr "--diff-merges=(off|none):"
 
 #. type: Labeled list
 #: en/diff-options.txt:44
-#, fuzzy, no-wrap, priority:280
-#| msgid "--no-diff-merges"
+#, ignore-same, no-wrap, priority:280
 msgid "--no-diff-merges:"
-msgstr "--no-diff-merges"
+msgstr "--no-diff-merges:"
 
 #. type: Plain text
 #: en/diff-options.txt:47
@@ -3944,17 +3942,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:48
-#, fuzzy, no-wrap, priority:280
-#| msgid "--first-parent"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=first-parent:"
-msgstr "--first-parent"
+msgstr "--diff-merges=first-parent:"
 
 #. type: Labeled list
 #: en/diff-options.txt:49
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=1:"
-msgstr "diffmerge"
+msgstr "--diff-merges=1:"
 
 #. type: Plain text
 #: en/diff-options.txt:52
@@ -3964,24 +3960,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:53
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=separate:"
-msgstr "diffmerge"
+msgstr "--diff-merges=separate:"
 
 #. type: Labeled list
 #: en/diff-options.txt:54
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=m:"
-msgstr "diffmerge"
+msgstr "--diff-merges=m:"
 
 #. type: Labeled list
 #: en/diff-options.txt:55
-#, fuzzy, no-wrap, priority:280
-#| msgid "-m"
+#, ignore-same, no-wrap, priority:280
 msgid "-m:"
-msgstr "-m"
+msgstr "-m:"
 
 #. type: Plain text
 #: en/diff-options.txt:59
@@ -3991,24 +3984,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:60
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:61
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=c:"
-msgstr "diffmerge"
+msgstr "--diff-merges=c:"
 
 #. type: Labeled list
 #: en/diff-options.txt:62
-#, fuzzy, no-wrap, priority:280
-#| msgid "-c"
+#, ignore-same, no-wrap, priority:280
 msgid "-c:"
-msgstr "-c"
+msgstr "-c:"
 
 #. type: Plain text
 #: en/diff-options.txt:69
@@ -4018,24 +4008,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:70
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=dense-combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=dense-combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:71
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=cc:"
-msgstr "diffmerge"
+msgstr "--diff-merges=cc:"
 
 #. type: Labeled list
 #: en/diff-options.txt:72
-#, fuzzy, no-wrap, priority:280
-#| msgid "--cc"
+#, ignore-same, no-wrap, priority:280
 msgid "--cc:"
-msgstr "--cc"
+msgstr "--cc:"
 
 #. type: Plain text
 #: en/diff-options.txt:78
@@ -20604,9 +20591,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:30
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
-msgstr ""
+msgstr "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:34
@@ -20622,9 +20609,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:42
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--tag-of-filtered-object=(abort|drop|rewrite)"
-msgstr ""
+msgstr "--tag-of-filtered-object=(abort|drop|rewrite)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:46
@@ -20790,9 +20777,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:146
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--reencode=(yes|no|abort)"
-msgstr ""
+msgstr "--reencode=(yes|no|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:152
@@ -35473,9 +35460,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-p4.txt:352
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--conflict=(ask|skip|quit)"
-msgstr ""
+msgstr "--conflict=(ask|skip|quit)"
 
 #. type: Plain text
 #: en/git-p4.txt:358
@@ -37796,9 +37783,9 @@ msgstr "--[no-]signed"
 
 #. type: Labeled list
 #: en/git-push.txt:200 en/git-send-pack.txt:74
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--signed=(true|false|if-asked)"
-msgstr ""
+msgstr "--signed=(true|false|if-asked)"
 
 #. type: Plain text
 #: en/git-push.txt:209 en/git-send-pack.txt:83
@@ -38072,9 +38059,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:402
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--recurse-submodules=check|on-demand|only|no"
-msgstr ""
+msgstr "--recurse-submodules=check|on-demand|only|no"
 
 #. type: Plain text
 #: en/git-push.txt:416
@@ -45411,9 +45398,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:179
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--glob=pattern"
-msgstr ""
+msgstr "--glob=pattern"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:185
@@ -45471,9 +45458,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:215
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--path-format=(absolute|relative)"
-msgstr ""
+msgstr "--path-format=(absolute|relative)"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:220
@@ -45693,15 +45680,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:306
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--since=datestring"
-msgstr ""
+msgstr "--since=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:307
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--after=datestring"
-msgstr ""
+msgstr "--after=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:310
@@ -45711,15 +45698,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:311
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--until=datestring"
-msgstr ""
+msgstr "--until=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:312
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--before=datestring"
-msgstr ""
+msgstr "--before=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:315
@@ -46521,9 +46508,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:140
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
-msgstr ""
+msgstr "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
 
 #. type: Plain text
 #: en/git-send-email.txt:148
@@ -46731,9 +46718,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:258
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--smtp-debug=0|1"
-msgstr ""
+msgstr "--smtp-debug=0|1"
 
 #. type: Plain text
 #: en/git-send-email.txt:262

--- a/po/documentation.pt_BR.po
+++ b/po/documentation.pt_BR.po
@@ -4002,7 +4002,7 @@ msgstr "Suprime a saída diff. Útil para comandos como `git show` que por prede
 
 #. type: Labeled list
 #: en/diff-options.txt:37
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
 msgstr "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
 
@@ -4020,13 +4020,13 @@ msgstr "Define o formato diff que será usado para a mesclagem dos commits. A pr
 
 #. type: Labeled list
 #: en/diff-options.txt:43
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none):"
 msgstr "--diff-merges=(off|none):"
 
 #. type: Labeled list
 #: en/diff-options.txt:44
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--no-diff-merges:"
 msgstr "--no-diff-merges:"
 
@@ -4038,13 +4038,13 @@ msgstr "Desativa a saída dos diffs para a mesclagem dos commits. Útil para sub
 
 #. type: Labeled list
 #: en/diff-options.txt:48
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=first-parent:"
 msgstr "--diff-merges=first-parent:"
 
 #. type: Labeled list
 #: en/diff-options.txt:49
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=1:"
 msgstr "--diff-merges=1:"
 
@@ -4056,19 +4056,19 @@ msgstr "Esta opção faz com que os commits mesclados mostrem a diferença total
 
 #. type: Labeled list
 #: en/diff-options.txt:53
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=separate:"
 msgstr "--diff-merges=separate:"
 
 #. type: Labeled list
 #: en/diff-options.txt:54
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=m:"
 msgstr "--diff-merges=m:"
 
 #. type: Labeled list
 #: en/diff-options.txt:55
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "-m:"
 msgstr "-m:"
 
@@ -4080,19 +4080,19 @@ msgstr "Faz com que os commits mesclados mostrem a diferença total com relaçã
 
 #. type: Labeled list
 #: en/diff-options.txt:60
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=combined:"
 msgstr "--diff-merges=combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:61
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=c:"
 msgstr "--diff-merges=c:"
 
 #. type: Labeled list
 #: en/diff-options.txt:62
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "-c:"
 msgstr "-c:"
 
@@ -4104,19 +4104,19 @@ msgstr "Com esta opção, a saída \"diff\" para um commit de mesclagem exibe as
 
 #. type: Labeled list
 #: en/diff-options.txt:70
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=dense-combined:"
 msgstr "--diff-merges=dense-combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:71
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=cc:"
 msgstr "--diff-merges=cc:"
 
 #. type: Labeled list
 #: en/diff-options.txt:72
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--cc:"
 msgstr "--cc:"
 
@@ -21320,7 +21320,7 @@ msgstr "Insira instruções de 'progresso' em todos os objetos `<n>` a serem exi
 
 #. type: Labeled list
 #: en/git-fast-export.txt:30
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
 msgstr "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
 
@@ -21338,7 +21338,7 @@ msgstr "Ao pedir para abortar 'abort' (que é o padrão), este programa será te
 
 #. type: Labeled list
 #: en/git-fast-export.txt:42
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--tag-of-filtered-object=(abort|drop|rewrite)"
 msgstr "--tag-of-filtered-object=(abort|drop|rewrite)"
 
@@ -21506,7 +21506,7 @@ msgstr "Inclua uma diretiva extra para os commits que forem gerados e as bolhas,
 
 #. type: Labeled list
 #: en/git-fast-export.txt:146
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--reencode=(yes|no|abort)"
 msgstr "--reencode=(yes|no|abort)"
 
@@ -36924,7 +36924,7 @@ msgstr "Atualize uma lista de alterações existentes que foram arquivadas com e
 
 #. type: Labeled list
 #: en/git-p4.txt:352
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--conflict=(ask|skip|quit)"
 msgstr "--conflict=(ask|skip|quit)"
 
@@ -39282,7 +39282,7 @@ msgstr "--[no-]signed"
 
 #. type: Labeled list
 #: en/git-push.txt:200 en/git-send-pack.txt:74
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--signed=(true|false|if-asked)"
 msgstr "--signed=(true|false|if-asked)"
 
@@ -39564,7 +39564,7 @@ msgstr "Suprima tudo o que for gerado, incluindo a listagem das atualizações d
 
 #. type: Labeled list
 #: en/git-push.txt:402
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--recurse-submodules=check|on-demand|only|no"
 msgstr "--recurse-submodules=check|on-demand|only|no"
 
@@ -47352,7 +47352,7 @@ msgstr "Caso um `padrão` seja informado, apenas as refs coincidentes com o \"sh
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:179
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--glob=pattern"
 msgstr "--glob=pattern"
 
@@ -47412,7 +47412,7 @@ msgstr "Liste as variável de ambiente do GIT_* que são locais no repositório 
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:215
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--path-format=(absolute|relative)"
 msgstr "--path-format=(absolute|relative)"
 
@@ -47634,13 +47634,13 @@ msgstr "Outras Opções"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:306
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--since=datestring"
 msgstr "--since=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:307
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--after=datestring"
 msgstr "--after=datestring"
 
@@ -47652,13 +47652,13 @@ msgstr "Analise a cadeia de caracteres da data e exiba o parâmetro --max-age= c
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:311
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--until=datestring"
 msgstr "--until=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:312
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--before=datestring"
 msgstr "--before=datestring"
 
@@ -48498,7 +48498,7 @@ msgstr "Define a codificação da mensagem que será escrita. A predefinição �
 
 #. type: Labeled list
 #: en/git-send-email.txt:140
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
 msgstr "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
 
@@ -48708,7 +48708,7 @@ msgstr "O nome do usuário para o SMTP-AUTH. A predefinição é o valor da opç
 
 #. type: Labeled list
 #: en/git-send-email.txt:258
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--smtp-debug=0|1"
 msgstr "--smtp-debug=0|1"
 

--- a/po/documentation.pt_PT.po
+++ b/po/documentation.pt_PT.po
@@ -3903,9 +3903,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:37
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
-msgstr ""
+msgstr "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
 
 #. type: Labeled list
 #: en/diff-options.txt:38
@@ -3921,17 +3921,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:43
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none):"
-msgstr "diffmerge"
+msgstr "--diff-merges=(off|none):"
 
 #. type: Labeled list
 #: en/diff-options.txt:44
-#, fuzzy, no-wrap, priority:280
-#| msgid "--no-diff-merges"
+#, ignore-same, no-wrap, priority:280
 msgid "--no-diff-merges:"
-msgstr "--no-diff-merges"
+msgstr "--no-diff-merges:"
 
 #. type: Plain text
 #: en/diff-options.txt:47
@@ -3941,17 +3939,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:48
-#, fuzzy, no-wrap, priority:280
-#| msgid "--first-parent"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=first-parent:"
-msgstr "--first-parent"
+msgstr "--diff-merges=first-parent:"
 
 #. type: Labeled list
 #: en/diff-options.txt:49
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=1:"
-msgstr "diffmerge"
+msgstr "--diff-merges=1:"
 
 #. type: Plain text
 #: en/diff-options.txt:52
@@ -3961,24 +3957,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:53
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=separate:"
-msgstr "diffmerge"
+msgstr "--diff-merges=separate:"
 
 #. type: Labeled list
 #: en/diff-options.txt:54
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=m:"
-msgstr "diffmerge"
+msgstr "--diff-merges=m:"
 
 #. type: Labeled list
 #: en/diff-options.txt:55
-#, fuzzy, no-wrap, priority:280
-#| msgid "-m"
+#, ignore-same, no-wrap, priority:280
 msgid "-m:"
-msgstr "-m"
+msgstr "-m:"
 
 #. type: Plain text
 #: en/diff-options.txt:59
@@ -3988,24 +3981,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:60
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:61
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=c:"
-msgstr "diffmerge"
+msgstr "--diff-merges=c:"
 
 #. type: Labeled list
 #: en/diff-options.txt:62
-#, fuzzy, no-wrap, priority:280
-#| msgid "-c"
+#, ignore-same, no-wrap, priority:280
 msgid "-c:"
-msgstr "-c"
+msgstr "-c:"
 
 #. type: Plain text
 #: en/diff-options.txt:69
@@ -4015,24 +4005,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:70
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=dense-combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=dense-combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:71
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=cc:"
-msgstr "diffmerge"
+msgstr "--diff-merges=cc:"
 
 #. type: Labeled list
 #: en/diff-options.txt:72
-#, fuzzy, no-wrap, priority:280
-#| msgid "--cc"
+#, ignore-same, no-wrap, priority:280
 msgid "--cc:"
-msgstr "--cc"
+msgstr "--cc:"
 
 #. type: Plain text
 #: en/diff-options.txt:78
@@ -20580,9 +20567,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:30
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
-msgstr ""
+msgstr "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:34
@@ -20598,9 +20585,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:42
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--tag-of-filtered-object=(abort|drop|rewrite)"
-msgstr ""
+msgstr "--tag-of-filtered-object=(abort|drop|rewrite)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:46
@@ -20766,9 +20753,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:146
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--reencode=(yes|no|abort)"
-msgstr ""
+msgstr "--reencode=(yes|no|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:152
@@ -35448,9 +35435,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-p4.txt:352
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--conflict=(ask|skip|quit)"
-msgstr ""
+msgstr "--conflict=(ask|skip|quit)"
 
 #. type: Plain text
 #: en/git-p4.txt:358
@@ -37769,9 +37756,9 @@ msgstr "--[no-]signed"
 
 #. type: Labeled list
 #: en/git-push.txt:200 en/git-send-pack.txt:74
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--signed=(true|false|if-asked)"
-msgstr ""
+msgstr "--signed=(true|false|if-asked)"
 
 #. type: Plain text
 #: en/git-push.txt:209 en/git-send-pack.txt:83
@@ -38045,9 +38032,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:402
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--recurse-submodules=check|on-demand|only|no"
-msgstr ""
+msgstr "--recurse-submodules=check|on-demand|only|no"
 
 #. type: Plain text
 #: en/git-push.txt:416
@@ -45354,9 +45341,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:179
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--glob=pattern"
-msgstr ""
+msgstr "--glob=pattern"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:185
@@ -45414,9 +45401,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:215
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--path-format=(absolute|relative)"
-msgstr ""
+msgstr "--path-format=(absolute|relative)"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:220
@@ -45636,15 +45623,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:306
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--since=datestring"
-msgstr ""
+msgstr "--since=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:307
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--after=datestring"
-msgstr ""
+msgstr "--after=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:310
@@ -45654,15 +45641,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:311
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--until=datestring"
-msgstr ""
+msgstr "--until=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:312
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--before=datestring"
-msgstr ""
+msgstr "--before=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:315
@@ -46464,9 +46451,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:140
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
-msgstr ""
+msgstr "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
 
 #. type: Plain text
 #: en/git-send-email.txt:148
@@ -46674,9 +46661,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:258
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--smtp-debug=0|1"
-msgstr ""
+msgstr "--smtp-debug=0|1"
 
 #. type: Plain text
 #: en/git-send-email.txt:262

--- a/po/documentation.ru.po
+++ b/po/documentation.ru.po
@@ -3907,9 +3907,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:37
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
-msgstr ""
+msgstr "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
 
 #. type: Labeled list
 #: en/diff-options.txt:38
@@ -3925,17 +3925,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:43
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none):"
-msgstr "diffmerge"
+msgstr "--diff-merges=(off|none):"
 
 #. type: Labeled list
 #: en/diff-options.txt:44
-#, fuzzy, no-wrap, priority:280
-#| msgid "--no-diff-merges"
+#, ignore-same, no-wrap, priority:280
 msgid "--no-diff-merges:"
-msgstr "--no-diff-merges"
+msgstr "--no-diff-merges:"
 
 #. type: Plain text
 #: en/diff-options.txt:47
@@ -3945,17 +3943,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:48
-#, fuzzy, no-wrap, priority:280
-#| msgid "--first-parent"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=first-parent:"
-msgstr "--first-parent"
+msgstr "--diff-merges=first-parent:"
 
 #. type: Labeled list
 #: en/diff-options.txt:49
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=1:"
-msgstr "diffmerge"
+msgstr "--diff-merges=1:"
 
 #. type: Plain text
 #: en/diff-options.txt:52
@@ -3965,24 +3961,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:53
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=separate:"
-msgstr "diffmerge"
+msgstr "--diff-merges=separate:"
 
 #. type: Labeled list
 #: en/diff-options.txt:54
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=m:"
-msgstr "diffmerge"
+msgstr "--diff-merges=m:"
 
 #. type: Labeled list
 #: en/diff-options.txt:55
-#, fuzzy, no-wrap, priority:280
-#| msgid "-m"
+#, ignore-same, no-wrap, priority:280
 msgid "-m:"
-msgstr "-m"
+msgstr "-m:"
 
 #. type: Plain text
 #: en/diff-options.txt:59
@@ -3992,24 +3985,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:60
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:61
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=c:"
-msgstr "diffmerge"
+msgstr "--diff-merges=c:"
 
 #. type: Labeled list
 #: en/diff-options.txt:62
-#, fuzzy, no-wrap, priority:280
-#| msgid "-c"
+#, ignore-same, no-wrap, priority:280
 msgid "-c:"
-msgstr "-c"
+msgstr "-c:"
 
 #. type: Plain text
 #: en/diff-options.txt:69
@@ -4019,24 +4009,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:70
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=dense-combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=dense-combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:71
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=cc:"
-msgstr "diffmerge"
+msgstr "--diff-merges=cc:"
 
 #. type: Labeled list
 #: en/diff-options.txt:72
-#, fuzzy, no-wrap, priority:280
-#| msgid "--cc"
+#, ignore-same, no-wrap, priority:280
 msgid "--cc:"
-msgstr "--cc"
+msgstr "--cc:"
 
 #. type: Plain text
 #: en/diff-options.txt:78
@@ -20668,9 +20655,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:30
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
-msgstr ""
+msgstr "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:34
@@ -20686,9 +20673,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:42
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--tag-of-filtered-object=(abort|drop|rewrite)"
-msgstr ""
+msgstr "--tag-of-filtered-object=(abort|drop|rewrite)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:46
@@ -20854,9 +20841,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:146
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--reencode=(yes|no|abort)"
-msgstr ""
+msgstr "--reencode=(yes|no|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:152
@@ -35559,9 +35546,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-p4.txt:352
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--conflict=(ask|skip|quit)"
-msgstr ""
+msgstr "--conflict=(ask|skip|quit)"
 
 #. type: Plain text
 #: en/git-p4.txt:358
@@ -37892,9 +37879,9 @@ msgstr "--[no-]signed"
 
 #. type: Labeled list
 #: en/git-push.txt:200 en/git-send-pack.txt:74
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--signed=(true|false|if-asked)"
-msgstr ""
+msgstr "--signed=(true|false|if-asked)"
 
 #. type: Plain text
 #: en/git-push.txt:209 en/git-send-pack.txt:83
@@ -38168,9 +38155,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:402
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--recurse-submodules=check|on-demand|only|no"
-msgstr ""
+msgstr "--recurse-submodules=check|on-demand|only|no"
 
 #. type: Plain text
 #: en/git-push.txt:416
@@ -45480,9 +45467,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:179
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--glob=pattern"
-msgstr ""
+msgstr "--glob=pattern"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:185
@@ -45540,9 +45527,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:215
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--path-format=(absolute|relative)"
-msgstr ""
+msgstr "--path-format=(absolute|relative)"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:220
@@ -45762,15 +45749,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:306
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--since=datestring"
-msgstr ""
+msgstr "--since=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:307
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--after=datestring"
-msgstr ""
+msgstr "--after=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:310
@@ -45780,15 +45767,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:311
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--until=datestring"
-msgstr ""
+msgstr "--until=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:312
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--before=datestring"
-msgstr ""
+msgstr "--before=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:315
@@ -46590,9 +46577,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:140
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
-msgstr ""
+msgstr "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
 
 #. type: Plain text
 #: en/git-send-email.txt:148
@@ -46800,9 +46787,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:258
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--smtp-debug=0|1"
-msgstr ""
+msgstr "--smtp-debug=0|1"
 
 #. type: Plain text
 #: en/git-send-email.txt:262

--- a/po/documentation.sk.po
+++ b/po/documentation.sk.po
@@ -3903,9 +3903,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:37
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
-msgstr ""
+msgstr "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
 
 #. type: Labeled list
 #: en/diff-options.txt:38
@@ -3921,15 +3921,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:43
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none):"
-msgstr ""
+msgstr "--diff-merges=(off|none):"
 
 #. type: Labeled list
 #: en/diff-options.txt:44
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--no-diff-merges:"
-msgstr ""
+msgstr "--no-diff-merges:"
 
 #. type: Plain text
 #: en/diff-options.txt:47
@@ -3939,15 +3939,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:48
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=first-parent:"
-msgstr ""
+msgstr "--diff-merges=first-parent:"
 
 #. type: Labeled list
 #: en/diff-options.txt:49
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=1:"
-msgstr ""
+msgstr "--diff-merges=1:"
 
 #. type: Plain text
 #: en/diff-options.txt:52
@@ -3957,21 +3957,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:53
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=separate:"
-msgstr ""
+msgstr "--diff-merges=separate:"
 
 #. type: Labeled list
 #: en/diff-options.txt:54
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=m:"
-msgstr ""
+msgstr "--diff-merges=m:"
 
 #. type: Labeled list
 #: en/diff-options.txt:55
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "-m:"
-msgstr ""
+msgstr "-m:"
 
 #. type: Plain text
 #: en/diff-options.txt:59
@@ -3981,21 +3981,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:60
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=combined:"
-msgstr ""
+msgstr "--diff-merges=combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:61
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=c:"
-msgstr ""
+msgstr "--diff-merges=c:"
 
 #. type: Labeled list
 #: en/diff-options.txt:62
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "-c:"
-msgstr ""
+msgstr "-c:"
 
 #. type: Plain text
 #: en/diff-options.txt:69
@@ -4005,21 +4005,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:70
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=dense-combined:"
-msgstr ""
+msgstr "--diff-merges=dense-combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:71
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=cc:"
-msgstr ""
+msgstr "--diff-merges=cc:"
 
 #. type: Labeled list
 #: en/diff-options.txt:72
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--cc:"
-msgstr ""
+msgstr "--cc:"
 
 #. type: Plain text
 #: en/diff-options.txt:78
@@ -20557,9 +20557,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:30
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
-msgstr ""
+msgstr "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:34
@@ -20575,9 +20575,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:42
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--tag-of-filtered-object=(abort|drop|rewrite)"
-msgstr ""
+msgstr "--tag-of-filtered-object=(abort|drop|rewrite)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:46
@@ -20743,9 +20743,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:146
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--reencode=(yes|no|abort)"
-msgstr ""
+msgstr "--reencode=(yes|no|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:152
@@ -35418,9 +35418,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-p4.txt:352
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--conflict=(ask|skip|quit)"
-msgstr ""
+msgstr "--conflict=(ask|skip|quit)"
 
 #. type: Plain text
 #: en/git-p4.txt:358
@@ -37737,9 +37737,9 @@ msgstr "--[no-]signed"
 
 #. type: Labeled list
 #: en/git-push.txt:200 en/git-send-pack.txt:74
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--signed=(true|false|if-asked)"
-msgstr ""
+msgstr "--signed=(true|false|if-asked)"
 
 #. type: Plain text
 #: en/git-push.txt:209 en/git-send-pack.txt:83
@@ -38013,9 +38013,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:402
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--recurse-submodules=check|on-demand|only|no"
-msgstr ""
+msgstr "--recurse-submodules=check|on-demand|only|no"
 
 #. type: Plain text
 #: en/git-push.txt:416
@@ -45312,9 +45312,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:179
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--glob=pattern"
-msgstr ""
+msgstr "--glob=pattern"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:185
@@ -45372,9 +45372,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:215
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--path-format=(absolute|relative)"
-msgstr ""
+msgstr "--path-format=(absolute|relative)"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:220
@@ -45594,15 +45594,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:306
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--since=datestring"
-msgstr ""
+msgstr "--since=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:307
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--after=datestring"
-msgstr ""
+msgstr "--after=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:310
@@ -45612,15 +45612,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:311
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--until=datestring"
-msgstr ""
+msgstr "--until=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:312
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--before=datestring"
-msgstr ""
+msgstr "--before=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:315
@@ -46422,9 +46422,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:140
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
-msgstr ""
+msgstr "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
 
 #. type: Plain text
 #: en/git-send-email.txt:148
@@ -46632,9 +46632,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:258
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--smtp-debug=0|1"
-msgstr ""
+msgstr "--smtp-debug=0|1"
 
 #. type: Plain text
 #: en/git-send-email.txt:262

--- a/po/documentation.tr.po
+++ b/po/documentation.tr.po
@@ -3910,9 +3910,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:37
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
-msgstr ""
+msgstr "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
 
 #. type: Labeled list
 #: en/diff-options.txt:38
@@ -3928,17 +3928,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:43
-#, fuzzy, no-wrap, priority:280
-#| msgid "--diff-merges=off"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none):"
-msgstr "--diff-merges=off"
+msgstr "--diff-merges=(off|none):"
 
 #. type: Labeled list
 #: en/diff-options.txt:44
-#, fuzzy, no-wrap, priority:280
-#| msgid "--no-diff-merges"
+#, ignore-same, no-wrap, priority:280
 msgid "--no-diff-merges:"
-msgstr "--no-diff-merges"
+msgstr "--no-diff-merges:"
 
 #. type: Plain text
 #: en/diff-options.txt:47
@@ -3948,17 +3946,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:48
-#, fuzzy, no-wrap, priority:280
-#| msgid "--first-parent"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=first-parent:"
-msgstr "--first-parent"
+msgstr "--diff-merges=first-parent:"
 
 #. type: Labeled list
 #: en/diff-options.txt:49
-#, fuzzy, no-wrap, priority:280
-#| msgid "--diff-merges=off"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=1:"
-msgstr "--diff-merges=off"
+msgstr "--diff-merges=1:"
 
 #. type: Plain text
 #: en/diff-options.txt:52
@@ -3968,24 +3964,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:53
-#, fuzzy, no-wrap, priority:280
-#| msgid "--diff-merges=off"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=separate:"
-msgstr "--diff-merges=off"
+msgstr "--diff-merges=separate:"
 
 #. type: Labeled list
 #: en/diff-options.txt:54
-#, fuzzy, no-wrap, priority:280
-#| msgid "--diff-merges=off"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=m:"
-msgstr "--diff-merges=off"
+msgstr "--diff-merges=m:"
 
 #. type: Labeled list
 #: en/diff-options.txt:55
-#, fuzzy, no-wrap, priority:280
-#| msgid "-m"
+#, ignore-same, no-wrap, priority:280
 msgid "-m:"
-msgstr "-m"
+msgstr "-m:"
 
 #. type: Plain text
 #: en/diff-options.txt:59
@@ -3995,24 +3988,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:60
-#, fuzzy, no-wrap, priority:280
-#| msgid "--diff-merges=off"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=combined:"
-msgstr "--diff-merges=off"
+msgstr "--diff-merges=combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:61
-#, fuzzy, no-wrap, priority:280
-#| msgid "--diff-merges=off"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=c:"
-msgstr "--diff-merges=off"
+msgstr "--diff-merges=c:"
 
 #. type: Labeled list
 #: en/diff-options.txt:62
-#, fuzzy, no-wrap, priority:280
-#| msgid "-c"
+#, ignore-same, no-wrap, priority:280
 msgid "-c:"
-msgstr "-c"
+msgstr "-c:"
 
 #. type: Plain text
 #: en/diff-options.txt:69
@@ -4022,24 +4012,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:70
-#, fuzzy, no-wrap, priority:280
-#| msgid "--diff-merges=off"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=dense-combined:"
-msgstr "--diff-merges=off"
+msgstr "--diff-merges=dense-combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:71
-#, fuzzy, no-wrap, priority:280
-#| msgid "--diff-merges=off"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=cc:"
-msgstr "--diff-merges=off"
+msgstr "--diff-merges=cc:"
 
 #. type: Labeled list
 #: en/diff-options.txt:72
-#, fuzzy, no-wrap, priority:280
-#| msgid "--cc"
+#, ignore-same, no-wrap, priority:280
 msgid "--cc:"
-msgstr "--cc"
+msgstr "--cc:"
 
 #. type: Plain text
 #: en/diff-options.txt:78
@@ -20588,9 +20575,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:30
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
-msgstr ""
+msgstr "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:34
@@ -20606,9 +20593,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:42
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--tag-of-filtered-object=(abort|drop|rewrite)"
-msgstr ""
+msgstr "--tag-of-filtered-object=(abort|drop|rewrite)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:46
@@ -20774,9 +20761,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:146
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--reencode=(yes|no|abort)"
-msgstr ""
+msgstr "--reencode=(yes|no|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:152
@@ -35450,9 +35437,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-p4.txt:352
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--conflict=(ask|skip|quit)"
-msgstr ""
+msgstr "--conflict=(ask|skip|quit)"
 
 #. type: Plain text
 #: en/git-p4.txt:358
@@ -37769,9 +37756,9 @@ msgstr "--[no-]signed"
 
 #. type: Labeled list
 #: en/git-push.txt:200 en/git-send-pack.txt:74
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--signed=(true|false|if-asked)"
-msgstr ""
+msgstr "--signed=(true|false|if-asked)"
 
 #. type: Plain text
 #: en/git-push.txt:209 en/git-send-pack.txt:83
@@ -38045,9 +38032,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:402
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--recurse-submodules=check|on-demand|only|no"
-msgstr ""
+msgstr "--recurse-submodules=check|on-demand|only|no"
 
 #. type: Plain text
 #: en/git-push.txt:416
@@ -45350,9 +45337,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:179
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--glob=pattern"
-msgstr ""
+msgstr "--glob=pattern"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:185
@@ -45410,9 +45397,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:215
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--path-format=(absolute|relative)"
-msgstr ""
+msgstr "--path-format=(absolute|relative)"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:220
@@ -45632,15 +45619,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:306
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--since=datestring"
-msgstr ""
+msgstr "--since=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:307
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--after=datestring"
-msgstr ""
+msgstr "--after=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:310
@@ -45650,15 +45637,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:311
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--until=datestring"
-msgstr ""
+msgstr "--until=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:312
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--before=datestring"
-msgstr ""
+msgstr "--before=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:315
@@ -46460,9 +46447,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:140
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
-msgstr ""
+msgstr "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
 
 #. type: Plain text
 #: en/git-send-email.txt:148
@@ -46670,9 +46657,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:258
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--smtp-debug=0|1"
-msgstr ""
+msgstr "--smtp-debug=0|1"
 
 #. type: Plain text
 #: en/git-send-email.txt:262

--- a/po/documentation.zh_HANS-CN.po
+++ b/po/documentation.zh_HANS-CN.po
@@ -3932,7 +3932,7 @@ msgstr "不输出差异（diff）。对于显示修补程序的 `git show` 等�
 
 #. type: Labeled list
 #: en/diff-options.txt:37
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
 msgstr "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
 
@@ -3950,17 +3950,15 @@ msgstr "指定合并提交时使用的差异格式。默认为 {diff-merges-defa
 
 #. type: Labeled list
 #: en/diff-options.txt:43
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none):"
-msgstr "diffmerge"
+msgstr "--diff-merges=(off|none):"
 
 #. type: Labeled list
 #: en/diff-options.txt:44
-#, fuzzy, no-wrap, priority:280
-#| msgid "--no-diff-merges"
+#, ignore-same, no-wrap, priority:280
 msgid "--no-diff-merges:"
-msgstr "--no-diff-merges"
+msgstr "--no-diff-merges:"
 
 #. type: Plain text
 #: en/diff-options.txt:47
@@ -3970,17 +3968,15 @@ msgstr "禁用合并提交时的差异输出。对覆盖隐含值很有用。"
 
 #. type: Labeled list
 #: en/diff-options.txt:48
-#, fuzzy, no-wrap, priority:280
-#| msgid "--first-parent"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=first-parent:"
-msgstr "--first-parent"
+msgstr "--diff-merges=first-parent:"
 
 #. type: Labeled list
 #: en/diff-options.txt:49
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=1:"
-msgstr "diffmerge"
+msgstr "--diff-merges=1:"
 
 #. type: Plain text
 #: en/diff-options.txt:52
@@ -3990,24 +3986,21 @@ msgstr "此选项使合并提交只显示与第一个父提交之间的完整差
 
 #. type: Labeled list
 #: en/diff-options.txt:53
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=separate:"
-msgstr "diffmerge"
+msgstr "--diff-merges=separate:"
 
 #. type: Labeled list
 #: en/diff-options.txt:54
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=m:"
-msgstr "diffmerge"
+msgstr "--diff-merges=m:"
 
 #. type: Labeled list
 #: en/diff-options.txt:55
-#, fuzzy, no-wrap, priority:280
-#| msgid "-m"
+#, ignore-same, no-wrap, priority:280
 msgid "-m:"
-msgstr "-m"
+msgstr "-m:"
 
 #. type: Plain text
 #: en/diff-options.txt:59
@@ -4017,24 +4010,21 @@ msgstr "这使得合并提交显示了每个父提交之间的完整差异。每
 
 #. type: Labeled list
 #: en/diff-options.txt:60
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:61
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=c:"
-msgstr "diffmerge"
+msgstr "--diff-merges=c:"
 
 #. type: Labeled list
 #: en/diff-options.txt:62
-#, fuzzy, no-wrap, priority:280
-#| msgid "-c"
+#, ignore-same, no-wrap, priority:280
 msgid "-c:"
-msgstr "-c"
+msgstr "-c:"
 
 #. type: Plain text
 #: en/diff-options.txt:69
@@ -4044,24 +4034,21 @@ msgstr "使用此选项，合并提交的差异输出将同时显示每个父提
 
 #. type: Labeled list
 #: en/diff-options.txt:70
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=dense-combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=dense-combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:71
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=cc:"
-msgstr "diffmerge"
+msgstr "--diff-merges=cc:"
 
 #. type: Labeled list
 #: en/diff-options.txt:72
-#, fuzzy, no-wrap, priority:280
-#| msgid "--cc"
+#, ignore-same, no-wrap, priority:280
 msgid "--cc:"
-msgstr "--cc"
+msgstr "--cc:"
 
 #. type: Plain text
 #: en/diff-options.txt:78
@@ -20916,9 +20903,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:30
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
-msgstr ""
+msgstr "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:34
@@ -20934,7 +20921,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:42
-#, fuzzy, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--tag-of-filtered-object=(abort|drop|rewrite)"
 msgstr "--tag-of-filtered-object=(abort|drop|rewrite)"
 
@@ -21102,7 +21089,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:146
-#, fuzzy, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--reencode=(yes|no|abort)"
 msgstr "--reencode=(yes|no|abort)"
 
@@ -36028,7 +36015,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-p4.txt:352
-#, fuzzy, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--conflict=(ask|skip|quit)"
 msgstr "--conflict=(ask|skip|quit)"
 
@@ -38364,7 +38351,7 @@ msgstr "--[no-]signed"
 
 #. type: Labeled list
 #: en/git-push.txt:200 en/git-send-pack.txt:74
-#, fuzzy, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--signed=(true|false|if-asked)"
 msgstr "--signed=(true|false|if-asked)"
 
@@ -38640,7 +38627,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:402
-#, fuzzy, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--recurse-submodules=check|on-demand|only|no"
 msgstr "--recurse-submodules=check|on-demand|only|no"
 
@@ -46107,7 +46094,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:179
-#, fuzzy, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--glob=pattern"
 msgstr "--glob=pattern"
 
@@ -46167,9 +46154,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:215
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--path-format=(absolute|relative)"
-msgstr ""
+msgstr "--path-format=(absolute|relative)"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:220
@@ -46389,13 +46376,13 @@ msgstr "其他选项"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:306
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--since=datestring"
-msgstr ""
+msgstr "--since=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:307
-#, fuzzy, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--after=datestring"
 msgstr "--after=datestring"
 
@@ -46407,15 +46394,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:311
-#, fuzzy, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--until=datestring"
 msgstr "--until=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:312
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--before=datestring"
-msgstr ""
+msgstr "--before=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:315
@@ -47227,7 +47214,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:140
-#, fuzzy, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
 msgstr "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
 
@@ -47437,7 +47424,7 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:258
-#, fuzzy, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--smtp-debug=0|1"
 msgstr "--smtp-debug=0|1"
 

--- a/po/documentation.zh_HANT.po
+++ b/po/documentation.zh_HANT.po
@@ -3908,9 +3908,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:37
-#, no-wrap, priority:280
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
-msgstr ""
+msgstr "--diff-merges=(off|none|first-parent|1|separate|m|combined|c|dense-combined|cc)"
 
 #. type: Labeled list
 #: en/diff-options.txt:38
@@ -3926,17 +3926,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:43
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=(off|none):"
-msgstr "diffmerge"
+msgstr "--diff-merges=(off|none):"
 
 #. type: Labeled list
 #: en/diff-options.txt:44
-#, fuzzy, no-wrap, priority:280
-#| msgid "--no-diff-merges"
+#, ignore-same, no-wrap, priority:280
 msgid "--no-diff-merges:"
-msgstr "--no-diff-merges"
+msgstr "--no-diff-merges:"
 
 #. type: Plain text
 #: en/diff-options.txt:47
@@ -3946,17 +3944,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:48
-#, fuzzy, no-wrap, priority:280
-#| msgid "--first-parent"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=first-parent:"
-msgstr "--first-parent"
+msgstr "--diff-merges=first-parent:"
 
 #. type: Labeled list
 #: en/diff-options.txt:49
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=1:"
-msgstr "diffmerge"
+msgstr "--diff-merges=1:"
 
 #. type: Plain text
 #: en/diff-options.txt:52
@@ -3966,24 +3962,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:53
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=separate:"
-msgstr "diffmerge"
+msgstr "--diff-merges=separate:"
 
 #. type: Labeled list
 #: en/diff-options.txt:54
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=m:"
-msgstr "diffmerge"
+msgstr "--diff-merges=m:"
 
 #. type: Labeled list
 #: en/diff-options.txt:55
-#, fuzzy, no-wrap, priority:280
-#| msgid "-m"
+#, ignore-same, no-wrap, priority:280
 msgid "-m:"
-msgstr "-m"
+msgstr "-m:"
 
 #. type: Plain text
 #: en/diff-options.txt:59
@@ -3993,24 +3986,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:60
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:61
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=c:"
-msgstr "diffmerge"
+msgstr "--diff-merges=c:"
 
 #. type: Labeled list
 #: en/diff-options.txt:62
-#, fuzzy, no-wrap, priority:280
-#| msgid "-c"
+#, ignore-same, no-wrap, priority:280
 msgid "-c:"
-msgstr "-c"
+msgstr "-c:"
 
 #. type: Plain text
 #: en/diff-options.txt:69
@@ -4020,24 +4010,21 @@ msgstr ""
 
 #. type: Labeled list
 #: en/diff-options.txt:70
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=dense-combined:"
-msgstr "diffmerge"
+msgstr "--diff-merges=dense-combined:"
 
 #. type: Labeled list
 #: en/diff-options.txt:71
-#, fuzzy, no-wrap, priority:280
-#| msgid "diffmerge"
+#, ignore-same, no-wrap, priority:280
 msgid "--diff-merges=cc:"
-msgstr "diffmerge"
+msgstr "--diff-merges=cc:"
 
 #. type: Labeled list
 #: en/diff-options.txt:72
-#, fuzzy, no-wrap, priority:280
-#| msgid "--cc"
+#, ignore-same, no-wrap, priority:280
 msgid "--cc:"
-msgstr "--cc"
+msgstr "--cc:"
 
 #. type: Plain text
 #: en/diff-options.txt:78
@@ -20595,9 +20582,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:30
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
-msgstr ""
+msgstr "--signed-tags=(verbatim|warn|warn-strip|strip|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:34
@@ -20613,9 +20600,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:42
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--tag-of-filtered-object=(abort|drop|rewrite)"
-msgstr ""
+msgstr "--tag-of-filtered-object=(abort|drop|rewrite)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:46
@@ -20781,9 +20768,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-fast-export.txt:146
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--reencode=(yes|no|abort)"
-msgstr ""
+msgstr "--reencode=(yes|no|abort)"
 
 #. type: Plain text
 #: en/git-fast-export.txt:152
@@ -35476,9 +35463,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-p4.txt:352
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--conflict=(ask|skip|quit)"
-msgstr ""
+msgstr "--conflict=(ask|skip|quit)"
 
 #. type: Plain text
 #: en/git-p4.txt:358
@@ -37797,9 +37784,9 @@ msgstr "--[no-]signed"
 
 #. type: Labeled list
 #: en/git-push.txt:200 en/git-send-pack.txt:74
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--signed=(true|false|if-asked)"
-msgstr ""
+msgstr "--signed=(true|false|if-asked)"
 
 #. type: Plain text
 #: en/git-push.txt:209 en/git-send-pack.txt:83
@@ -38073,9 +38060,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-push.txt:402
-#, no-wrap, priority:220
+#, ignore-same, no-wrap, priority:220
 msgid "--recurse-submodules=check|on-demand|only|no"
-msgstr ""
+msgstr "--recurse-submodules=check|on-demand|only|no"
 
 #. type: Plain text
 #: en/git-push.txt:416
@@ -45386,9 +45373,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:179
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--glob=pattern"
-msgstr ""
+msgstr "--glob=pattern"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:185
@@ -45446,9 +45433,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:215
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--path-format=(absolute|relative)"
-msgstr ""
+msgstr "--path-format=(absolute|relative)"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:220
@@ -45668,15 +45655,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:306
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--since=datestring"
-msgstr ""
+msgstr "--since=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:307
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--after=datestring"
-msgstr ""
+msgstr "--after=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:310
@@ -45686,15 +45673,15 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:311
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--until=datestring"
-msgstr ""
+msgstr "--until=datestring"
 
 #. type: Labeled list
 #: en/git-rev-parse.txt:312
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--before=datestring"
-msgstr ""
+msgstr "--before=datestring"
 
 #. type: Plain text
 #: en/git-rev-parse.txt:315
@@ -46496,9 +46483,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:140
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
-msgstr ""
+msgstr "--transfer-encoding=(7bit|8bit|quoted-printable|base64|auto)"
 
 #. type: Plain text
 #: en/git-send-email.txt:148
@@ -46706,9 +46693,9 @@ msgstr ""
 
 #. type: Labeled list
 #: en/git-send-email.txt:258
-#, no-wrap, priority:100
+#, ignore-same, no-wrap, priority:100
 msgid "--smtp-debug=0|1"
-msgstr ""
+msgstr "--smtp-debug=0|1"
 
 #. type: Plain text
 #: en/git-send-email.txt:262

--- a/scripts/pre-translate-po
+++ b/scripts/pre-translate-po
@@ -6,7 +6,7 @@ import sys
 
 def main (f, d=None):
     po = polib.pofile(f, wrapwidth=0)
-    option_re = re.compile(r'-[-a-z0-9[\]]+|--exec=<git-upload-archive>')
+    option_re = re.compile(r'-[-a-z0-9[\]]+(=\(?[-a-z0-9\|]+\)?)?:?|--exec=<git-upload-archive>')
     linkgit_re = re.compile(r'((linkgit:)?(git[-a-z0-9[\]]+|mail)(\[[157]\]|\([157]\))(,|;)?(\n| )?)+\.?')
     quoted_re = re.compile(r'\'?%[a-zA-Z]+\'?|(`[a-zA-Z-_]+`(, )?)+|\'(oneline|short|medium|full(er)?|email|raw|(un)?set|unspecified|init|fetch|clone|rebase|dcommit|branch|tag|log|blame|find-rev|set-tree|(create|show)-ignore|mkdirs|commit-diff)\'|(user|transfer|submodule|stash|status|splitIndex|showbranch|sendemail|repack|remote|receive|push|merge(tool)?|mailinfo|log|interactive|instaweb|i18n|help|gui|gitweb|fastimport|format|fetch|diff(tool)?|credential|commit|column|core|branch|apply|color|git-p4)\.[a-zA-Z_.]+|araxis|bc[34]?|codecompare|deltawalker|guiffy|meld|diff(use|merge)|(exam|[gn]?vim|t?k|open|xx)?diff[123]?|(ec?|p4|s|tortoise|win)merge|update|create|delete|verify|option|resolve|recursive|octopus|ours|subtree|theirs|patience|diff-algorithm=\[[a-z\|]+\]|ignore-(space-change|all-space|(cr|space)-at-eol)|(no-)?renormalize|no-renames|no|default|plain|blocks|(dimmed-)?zebra|allow-indentation-change|color|porcelain|none|list|(un)?lock|(re)?move|prune|die|usage|set_reflog_action|git_editor|cd_to_toplevel|require_work_tree(_exists)?|get_author_ident_from_commit|create_virtual_base|add|copy|append|edit|show|merge|get-ref')
     env_var_re = re.compile(r'`?GIT_[A-Z_\d]+`?')


### PR DESCRIPTION
I've only noticed this after #59 was merged, or I would've lumped them together as one PR

I'm not sure about the `--glob=pattern` and the various `--foo=datestring` messages that I caught. I think they should be `<pattern>` and `<datestring>` in the original docs. I'll probably amend this commit to exclude those and submit a patch to the mailing list.