### PR TITLE
Fix some typos in Git command

### DIFF
--- a/po/documentation.fr.po
+++ b/po/documentation.fr.po
@@ -36604,7 +36604,7 @@ msgstr "NOTES D'UTILISATION"
 #: en/git-merge-tree.txt:205
 #, priority:100
 msgid "This command is intended as low-level plumbing, similar to linkgit:git-hash-object[1], linkgit:git-mktree[1], linkgit:git-commit-tree[1], linkgit:git-write-tree[1], linkgit:git-update-ref[1], and linkgit:git-mktag[1].  Thus, it can be used as a part of a series of steps such as:"
-msgstr "Cette commande est destinée à la plomberie de bas niveau, semblable à linkgit:git-hash[1], linkgit:git-mktree[1], linkgit:git-commit-tree[1], linkgit:git-write-tree[1], linkgit:git-update-ref[1], et linkgit:git-mktag[1]. Ainsi, elle peut être utilisée comme partie d'une série d'étapes telles que :"
+msgstr "Cette commande est destinée à la plomberie de bas niveau, semblable à linkgit:git-hash-object[1], linkgit:git-mktree[1], linkgit:git-commit-tree[1], linkgit:git-write-tree[1], linkgit:git-update-ref[1], et linkgit:git-mktag[1]. Ainsi, elle peut être utilisée comme partie d'une série d'étapes telles que :"
 
 #. type: Plain text
 #: en/git-merge-tree.txt:210

--- a/po/documentation.fr.po
+++ b/po/documentation.fr.po
@@ -50229,7 +50229,7 @@ msgstr "Un sous-module est considéré à jour quand la HEAD est identique à ce
 #: en/git-rm.txt:173
 #, priority:280
 msgid "If you only want to remove the local checkout of a submodule from your work tree without committing the removal, use linkgit:git-submodule[1] `deinit` instead. Also see linkgit:gitsubmodules[7] for details on submodule removal."
-msgstr "Si vous voulez seulement supprimer une extraction locale d'un sous-module de votre arbre de travail sans valider la suppression, utilisez linkgit:git-submodules[1] `deinit` à la place. Voir aussi linkgit:gitsubmodules[7] pour des détails sur la suppression de sous-modules."
+msgstr "Si vous voulez seulement supprimer une extraction locale d'un sous-module de votre arbre de travail sans valider la suppression, utilisez linkgit:git-submodule[1] `deinit` à la place. Voir aussi linkgit:gitsubmodules[7] pour des détails sur la suppression de sous-modules."
 
 #. type: Labeled list
 #: en/git-rm.txt:176

--- a/po/documentation.is.po
+++ b/po/documentation.is.po
@@ -14881,7 +14881,7 @@ msgstr ""
 "aðra Git skipun sem gerir það að verkum að tilvísanir í innlegg sem eru til hverfa) í \n"
 "upprunahirslunni, geta sum viðföng týnt tilvísunum sínum (þau lafa). \n"
 "Þessi viðföng er hægt að fjarlægja með venjulegum Git aðgerðum (svo sem `git commit`(git inlegg))\n"
-"sem sjálfkrafa kallar á `git maintainance run --auto` (git viðhald sjálfkrafa). (Sjá linkgit:git-maintainance[1].)\n"
+"sem sjálfkrafa kallar á `git maintenance run --auto` (git viðhald sjálfkrafa). (Sjá linkgit:git-maintenance[1].)\n"
 "Ef þessi viðföng eru fjarlægð og hafa tilvísun í afrituðu hirslunni \n"
 "þá skrumskælist afritaða hirslan.\n"
 


### PR DESCRIPTION
The links to the manual pages need to use the actual Git command names (which are not translated: when running Git in French, the `git commit` command does not magically become the `git enregistrer` command, for example, the command still needs to be invoked using its English name).

There are a couple of translations where such links were modified by mistake, as pointed out as part of https://lore.kernel.org/git/ZWVIRXodL9pQZbtj@pobox.com/. This PR intends to fix those.