### PR TITLE
git-svn(zh_HANS-CN): avoid bogus `file://` link

### DIFF
--- a/po/documentation.zh_HANS-CN.po
+++ b/po/documentation.zh_HANS-CN.po
@@ -58615,7 +58615,7 @@ msgstr "svn-remote.<名称>.rewriteRoot"
 #: en/git-svn.txt:803
 #, priority:100
 msgid "This allows users to create repositories from alternate URLs. For example, an administrator could run 'git svn' on the server locally (accessing via file://) but wish to distribute the repository with a public http:// or svn:// URL in the metadata so users of it will see the public URL."
-msgstr "这样，用户就可以通过其他 URL 创建仓库。 例如，管理员可以在本地服务器上运行 'git svn'（通过 file://访问），但希望在元数据中发布带有公共 http:// 或 svn:// URL 的仓库，这样用户就能看到公共 URL。"
+msgstr "这样，用户就可以通过其他 URL 创建仓库。 例如，管理员可以在本地服务器上运行 'git svn'（通过 file:// 访问），但希望在元数据中发布带有公共 http:// 或 svn:// URL 的仓库，这样用户就能看到公共 URL。"
 
 #. type: Labeled list
 #: en/git-svn.txt:804


### PR DESCRIPTION
The way the description is currently written, there is no space after the `file://` in the translation, even if there is a space there in the original.

This is important because the way AsciiDoc is parsed, a missing space will mistake the text for being an actual hyperlink, see e.g. [here](https://github.com/jnavila/git-html-l10n/blob/171352a71363/zh_HANS-CN/git-svn.html#L1198). At the time of writing, this bogus link can be experienced [on Git's home page](https://git-scm.com/docs/git-svn/zh_HANS-CN#git-svn-svn-remoteltgtrewriteRoot):

![image](https://github.com/jnavila/git-manpages-l10n/assets/127790/7bb9f3b6-7cdc-4e8b-9bcd-9c5ea8084b8a)

However, the "domain name" is quite bogus seeing as it reads, according to Bing Translate:

> access), but want to publish in metadata with public

which is obviously not a valid domain name.

Firefox is smart enough to realize that this is not a valid domain name, and "auto-fixes" it to `file:///`. However, Edge (and therefore most likely Chrome, too), as well as link checkers such as [Lychee](https://lychee.cli.rs/) translate this into [an internationalized domain name]((https://en.wikipedia.org/wiki/Internationalized_domain_name)) starting with the "ASCII-Compatible Encoding" prefix "xn--" which is immediately followed by a closing parenthesis, i.e. an invalid character in internet host/domain names, but at least Lychee tries to follow it nevertheless:

file://xn--),-ry2c56bzyech9a071b11ispsycrp191dutgptg8hx808c0kpb/

Let's clearly separate `file://` from the next word and avoid letting AsciiDoc mark this as a hyperlink.