### PR TITLE
Add UK translations: git-annotate and related

### DIFF
--- a/po/documentation.uk.po
+++ b/po/documentation.uk.po
@@ -65008,49 +65008,49 @@ msgstr ""
 #: en/line-range-format.txt:2
 #, priority:260
 msgid "'<start>' and '<end>' can take one of these forms:"
-msgstr ""
+msgstr "'<початок>' та '<кінець>' можуть мати один з наступних форматів:"
 
 #. type: Plain text
 #: en/line-range-format.txt:4
 #, priority:260
 msgid "number"
-msgstr ""
+msgstr "число"
 
 #. type: Plain text
 #: en/line-range-format.txt:7
 #, priority:260
 msgid "If '<start>' or '<end>' is a number, it specifies an absolute line number (lines count from 1)."
-msgstr ""
+msgstr "Якщо '<початок>' або '<кінець>' є числом, то вони позначають номер рядка (починаючи з 1)."
 
 #. type: Plain text
 #: en/line-range-format.txt:10
 #, priority:260
 msgid "`/regex/`"
-msgstr ""
+msgstr "`/регулярний_вираз/`"
 
 #. type: Plain text
 #: en/line-range-format.txt:17
 #, placeholders:'`-L`', priority:260
 msgid "This form will use the first line matching the given POSIX regex. If '<start>' is a regex, it will search from the end of the previous `-L` range, if any, otherwise from the start of file. If '<start>' is `^/regex/`, it will search from the start of file. If '<end>' is a regex, it will search starting at the line given by '<start>'."
-msgstr ""
+msgstr "Ця форма буде використовувати перший рядок, що відповідає вказаному регулярному виразу POSIX. Якщо '<початок>' є регулярним виразом, то пошук розпочнеться з кінця попереднього проміжку `-L`, якщо такий існує, або ж з початку файлу. Якщо '<початок>' є `^/регулярним_виразом/`, то пошук розпочнеться з початку файлу. Якщо '<кінець>' є регулярним виразом, то пошук розпочнеться з рядка, заданого '<початком>'."
 
 #. type: Plain text
 #: en/line-range-format.txt:20
 #, priority:260
 msgid "+offset or -offset"
-msgstr ""
+msgstr "+зсув або -зсув"
 
 #. type: Plain text
 #: en/line-range-format.txt:23
 #, priority:260
 msgid "This is only valid for '<end>' and will specify a number of lines before or after the line given by '<start>'."
-msgstr ""
+msgstr "Це стосується лише '<кінця>' і визначає кількість рядків до чи після рядка, заданого '<початком>'."
 
 #. type: Plain text
 #: en/line-range-format.txt:32
 #, placeholders:'`-L`':'linkgit:gitattributes[5]', priority:260
 msgid "If `:<funcname>` is given in place of '<start>' and '<end>', it is a regular expression that denotes the range from the first funcname line that matches '<funcname>', up to the next funcname line. `:<funcname>` searches from the end of the previous `-L` range, if any, otherwise from the start of file. `^:<funcname>` searches from the start of file. The function names are determined in the same way as `git diff` works out patch hunk headers (see 'Defining a custom hunk-header' in linkgit:gitattributes[5])."
-msgstr ""
+msgstr "Якщо `:<ім'я_функції>` надано замість '<початку>' та '<кінця>', то це є регулярним виразом, що визначатиме проміжок від першого рядка з назвою функції, що відповідає '<імені функції>', до наступного рядка з назвою функції. Пошук за `:<іменем_функції>` розпочнеться з кінця попереднього проміжку `-L`, якщо такий існує, або ж з початку файлу. Пошук за `^:<іменем_функції>` розпочнеться з початку файлу. Імена функцій визначаються так само, як `git diff` опрацьовує заголовки шматків латок (дивіться 'Визначення власних заголовків шматків' у linkgit:gitattributes[5])."
 
 #. type: Labeled list
 #: en/line-range-options.txt:1

--- a/po/documentation.uk.po
+++ b/po/documentation.uk.po
@@ -28,7 +28,7 @@ msgstr "-b"
 #: en/blame-options.txt:4
 #, placeholders:'blame.blankBoundary', priority:100
 msgid "Show blank SHA-1 for boundary commits. This can also be controlled via the `blame.blankBoundary` config option."
-msgstr "Показує порожній SHA-1 для граничних комітів. Поведінка також можу бути задана за допомогою параметра конфігурації `blame.blankBoundary`."
+msgstr "Показує порожній SHA-1 для граничних комітів. Поведінка також може бути задана за допомогою параметра конфігурації `blame.blankBoundary`."
 
 #. type: Labeled list
 #: en/blame-options.txt:5 en/git-diff-tree.txt:42 en/git-format-patch.txt:421 en/git-fsck.txt:38 en/git-rebase.txt:591
@@ -70,7 +70,7 @@ msgstr "-L :<ім'я_функції>"
 #: en/blame-options.txt:17
 #, priority:100
 msgid "Annotate only the line range given by '<start>,<end>', or by the function name regex '<funcname>'. May be specified multiple times. Overlapping ranges are allowed."
-msgstr "Анотує лише проміжок рядків, заданий за допомогою '<початок>,<кінець>' або за регулярним виразом '<ім'я_функції>' назви функції. Може бути задано декілька разів. Допускається накладання проміжків."
+msgstr "Анотує лише проміжок рядків, заданий за допомогою '<початку>,<кінця>' або за регулярним виразом '<ім'я_функції>' назви функції. Може бути задано декілька разів. Допускається накладання проміжків."
 
 #. type: Plain text
 #: en/blame-options.txt:20
@@ -88,7 +88,7 @@ msgstr "-l"
 #: en/blame-options.txt:25
 #, priority:100
 msgid "Show long rev (Default: off)."
-msgstr "Показує повні значення ревізії (Типово: вимкнено)."
+msgstr "Показує повне значення ревізії (Типово: вимкнено)."
 
 #. type: Labeled list
 #: en/blame-options.txt:26 en/diff-options.txt:163 en/fetch-options.txt:196 en/git-branch.txt:217 en/git-cat-file.txt:40 en/git-checkout.txt:164 en/git-diff-tree.txt:39 en/git-ls-files.txt:142 en/git-ls-remote.txt:26 en/git-ls-tree.txt:47 en/git-svn.txt:312 en/git-switch.txt:158
@@ -100,7 +100,7 @@ msgstr "-t"
 #: en/blame-options.txt:28
 #, priority:100
 msgid "Show raw timestamp (Default: off)."
-msgstr "Показувати необроблену мітку часу (Типово: вимкнено)."
+msgstr "Показує необроблену мітку часу (Типово: вимкнено)."
 
 #. type: Labeled list
 #: en/blame-options.txt:29
@@ -118,13 +118,13 @@ msgstr "Використовує ревізії із вказаного файл
 #: en/blame-options.txt:32
 #, no-wrap, placeholders:'--reverse', priority:100
 msgid "--reverse <rev>..<rev>"
-msgstr "—reverse <ревізія>..<ревізія>"
+msgstr "--reverse <ревізія>..<ревізія>"
 
 #. type: Plain text
 #: en/blame-options.txt:39
 #, placeholders:'--reverse':'--reverse':'HEAD`', priority:100
 msgid "Walk history forward instead of backward. Instead of showing the revision in which a line appeared, this shows the last revision in which a line has existed. This requires a range of revision like START..END where the path to blame exists in START. `git blame --reverse START` is taken as `git blame --reverse START..HEAD` for convenience."
-msgstr "Рухає історію вперед, а не назад. Замість відображення ревізії, у якій рядок з'явився, відображає останню ревізію у якій він існував. Для цього потрібно вказати проміжок ревізій, наприклад, ПОЧАТОК..КІНЕЦЬ, де рядок, який ви шукаєте, повинен існувати у ПОЧАТКУ. `git blame —reverse START` є скороченням для `git blame —reverse START..HEAD`."
+msgstr "Рухає історію вперед, а не назад. Замість відображення ревізії, у якій рядок з'явився, відображає останню ревізію у якій він існував. Для цього потрібно вказати проміжок ревізій, наприклад, ПОЧАТОК..КІНЕЦЬ, де рядок, який ви шукаєте, повинен існувати у ПОЧАТКУ. `git blame --reverse ПОЧАТОК` є скороченням для `git blame --reverse ПОЧАТОК..HEAD`."
 
 #. type: Labeled list
 #: en/blame-options.txt:40 en/git-bisect.txt:375 en/git-describe.txt:122 en/rev-list-options.txt:129
@@ -136,7 +136,7 @@ msgstr "--first-parent"
 #: en/blame-options.txt:45
 #, priority:100
 msgid "Follow only the first parent commit upon seeing a merge commit. This option can be used to determine when a line was introduced to a particular integration branch, rather than when it was introduced to the history overall."
-msgstr "Слідує лише за першим батьківським комітом після того, як побачить коміт злиття. Ця опція може бути використана для визначення коли рядок з'явився саме у певній гілці, а не коли його в цілому було додано."
+msgstr "Слідує лише за першим батьківським комітом після того, як побачить коміт злиття. Ця опція може бути використана для визначення, коли рядок з'явився саме у певній гілці, а не коли його в цілому було додано."
 
 #. type: Labeled list
 #: en/blame-options.txt:46 en/diff-options.txt:16 en/diff-options.txt:22 en/fetch-options.txt:137 en/git-add.txt:96 en/git-cat-file.txt:55 en/git-checkout.txt:278 en/git-commit.txt:73 en/git-cvsexportcommit.txt:41 en/git-grep.txt:217 en/git-instaweb.txt:41 en/git-merge-file.txt:76 en/git-request-pull.txt:29 en/git-restore.txt:48 en/git-stash.txt:196 en/git-svn.txt:535 en/git-svn.txt:679 en/git.txt:129
@@ -166,7 +166,7 @@ msgstr "--line-porcelain"
 #: en/blame-options.txt:54
 #, placeholders:'--porcelain', priority:100
 msgid "Show the porcelain format, but output commit information for each line, not just the first time a commit is referenced. Implies --porcelain."
-msgstr "Показує у \"порцеляновому\" форматі (як за використання --porcelain), але виводить інформацію про коміт для кожного рядка, а не лише за першої згадки про коміт."
+msgstr "Показує у \"порцеляновому\" форматі (як за використання `--porcelain`), але виводить інформацію про коміт для кожного рядка, а не лише за першої згадки про коміт."
 
 #. type: Labeled list
 #: en/blame-options.txt:55 en/git-pack-objects.txt:176 en/git-svn.txt:373
@@ -202,7 +202,7 @@ msgstr "--contents <файл>"
 #: en/blame-options.txt:70
 #, priority:100
 msgid "Annotate using the contents from the named file, starting from <rev> if it is specified, and HEAD otherwise. You may specify '-' to make the command read from the standard input for the file contents."
-msgstr "Анотує використовуючи вміст вказаного файлу, починаючи з <ревізії>, якщо її визначено, або ж з HEAD. Ви можете вказати '-' аби команда зчитувала контент файлу зі стандартного вводу."
+msgstr "Анотує використовуючи вміст вказаного файлу, починаючи з '<ревізії>', якщо її визначено, або ж з HEAD. Ви можете вказати `-` аби команда зчитувала контент файлу зі стандартного вводу."
 
 #. type: Labeled list
 #: en/blame-options.txt:71
@@ -226,7 +226,7 @@ msgstr "--[no-]progress"
 #: en/blame-options.txt:84
 #, placeholders:'`--progress`':'`--porcelain`':'`--incremental`', priority:100
 msgid "Progress status is reported on the standard error stream by default when it is attached to a terminal. This flag enables progress reporting even if not attached to a terminal. Can't use `--progress` together with `--porcelain` or `--incremental`."
-msgstr "Типово, статус виконання виводиться у стандартному потоці помилок, коли він підключений до терміналу. Цей прапорець дозволяє виводити прогрес навіть коли такий потік не підключено. Не може використовуватися разом з `--porcelain` чи `--incremental`."
+msgstr "Типово, статус виконання виводиться у стандартному потоці помилок, коли він підключений до терміналу. Цей прапорець дозволяє виводити прогрес навіть коли такий потік не підключено. `--progress` не може використовуватися разом з `--porcelain` чи `--incremental`."
 
 #. type: Labeled list
 #: en/blame-options.txt:85
@@ -244,7 +244,7 @@ msgstr "Виявляє переміщені чи скопійовані рядк
 #: en/blame-options.txt:100
 #, priority:100
 msgid "<num> is optional but it is the lower bound on the number of alphanumeric characters that Git must detect as moving/copying within a file for it to associate those lines with the parent commit. The default value is 20."
-msgstr "<число> необов'язкове. Це нижня межа кількості буквено-цифрових символів, які Git має визначити як переміщені/скопійовані всередині файлу, щоб пов'язати ці рядки із батьківським комітом. Типово дорівнює 20."
+msgstr "'<число>' необов'язкове. Це нижня межа кількості буквено-цифрових символів, які Git має визначити як переміщені/скопійовані всередині файлу, щоб пов'язати ці рядки із батьківським комітом. Типово дорівнює 20."
 
 #. type: Labeled list
 #: en/blame-options.txt:101
@@ -256,13 +256,13 @@ msgstr "-C[<число>]"
 #: en/blame-options.txt:110
 #, placeholders:'`-M`', priority:100
 msgid "In addition to `-M`, detect lines moved or copied from other files that were modified in the same commit. This is useful when you reorganize your program and move code around across files. When this option is given twice, the command additionally looks for copies from other files in the commit that creates the file. When this option is given three times, the command additionally looks for copies from other files in any commit."
-msgstr "На додачу до `-M` визначає переміщені або скопійовані рядки з інших файлів, що були змінені у тому самому коміті. Це корисно коли ви реорганізовуєте вашу програму та переміщуєте код між файлами. Коли цей параметр вказано двічі, команда додатково шукає копії з інших файлів у коміті в якому файл було створено. Якщо ж його вказано тричі, то команда додатково шукає копії з інших файлів у будь-якому коміті."
+msgstr "На додачу до `-M` визначає переміщені або скопійовані рядки з інших файлів, що були змінені у тому самому коміті. Це корисно коли ви реорганізовуєте вашу програму та переміщуєте код між файлами. Коли цей параметр вказано двічі, команда додатково шукає копії з інших файлів у коміті, в якому файл було створено. Якщо ж його вказано тричі, то команда додатково шукає копії з інших файлів у будь-якому коміті."
 
 #. type: Plain text
 #: en/blame-options.txt:117
 #, placeholders:'`-C`':'`-C`', priority:100
 msgid "<num> is optional but it is the lower bound on the number of alphanumeric characters that Git must detect as moving/copying between files for it to associate those lines with the parent commit. And the default value is 40. If there are more than one `-C` options given, the <num> argument of the last `-C` will take effect."
-msgstr "<число> необов'язкове. Це нижня межа кількості буквено-цифрових символів, які Git має визначити як переміщені/скопійовані між файлами, аби пов'язати ці рядки із батьківським комітом. Типово дорівнює 40. Якщо вказано більше одного параметру `-C`, то буде використано <число> останнього з них."
+msgstr "'<число>' необов'язкове. Це нижня межа кількості буквено-цифрових символів, які Git має визначити як переміщені/скопійовані між файлами, аби пов'язати ці рядки із батьківським комітом. Типово дорівнює 40. Якщо вказано більше одного параметру `-C`, то буде використано '<число>' останнього з них."
 
 #. type: Labeled list
 #: en/blame-options.txt:118
@@ -274,7 +274,7 @@ msgstr "--ignore-rev <ревізія>"
 #: en/blame-options.txt:129
 #, placeholders:'blame.markIgnoredLines':'blame.markUnblamableLines', priority:100
 msgid "Ignore changes made by the revision when assigning blame, as if the change never happened. Lines that were changed or added by an ignored commit will be blamed on the previous commit that changed that line or nearby lines. This option may be specified multiple times to ignore more than one revision. If the `blame.markIgnoredLines` config option is set, then lines that were changed by an ignored commit and attributed to another commit will be marked with a `?` in the blame output. If the `blame.markUnblamableLines` config option is set, then those lines touched by an ignored commit that we could not attribute to another revision are marked with a '*'."
-msgstr "Нехтує змінами, що зроблені ревізією, коли призначає авторство, так, ніби змін ніколи не існувало. Рядки, що були змінені чи додані знехтуваним комітом, будуть приписані до попереднього коміту, який змінював ці чи найближчі рядки. Цей параметр може бути вказаним декілька разів для нехтування декількома ревізіями. Якщо налаштовано параметр конфігурації `blame.markIgnoredLines`, рядки, які були змінені знехтуваним комітом та приписано до іншого, буде позначено символом `?` у інформації про авторство. Якщо налаштовано параметр конфігурації `blame.markUnblamableLines`, то рядки, на які вплинув знехтуваний коміт, але які не були приписані до іншого, будуть позначені символом `*`."
+msgstr "Нехтує змінами, що зроблені ревізією, коли призначає авторство, так, ніби змін ніколи не існувало. Рядки, що були змінені чи додані знехтуваним комітом, будуть приписані до попереднього коміту, який змінював ці чи найближчі рядки. Параметр може бути вказано декілька разів для нехтування декількома ревізіями. Якщо налаштовано параметр конфігурації `blame.markIgnoredLines`, рядки, які були змінені знехтуваним комітом та приписані до іншого, буде позначено символом `?` у інформації про авторство. Якщо налаштовано параметр конфігурації `blame.markUnblamableLines`, то рядки, на які вплинув знехтуваний коміт, але які не були приписані до іншого, будуть позначені символом `*`."
 
 #. type: Labeled list
 #: en/blame-options.txt:130
@@ -286,7 +286,7 @@ msgstr "--ignore-revs-file <файл>"
 #: en/blame-options.txt:136
 #, placeholders:'fsck.skipList':'blame.ignoreRevsFile', priority:100
 msgid "Ignore revisions listed in `file`, which must be in the same format as an `fsck.skipList`. This option may be repeated, and these files will be processed after any files specified with the `blame.ignoreRevsFile` config option. An empty file name, `\"\"`, will clear the list of revs from previously processed files."
-msgstr "Нехтує ревізіями, що перелічені у `файлі`, який має бути в тому ж форматі що й `fsck.skipList`. Цей параметр може бути вказано декілька разів. Ці файли будуть опрацьовані після усіх файлів, що визначені параметром конфігурації `blame.ignoreRevsFile`. Порожнє ім'я файлу (`""`) очищає перелік ревізій з попередніх опрацьованих файлів."
+msgstr "Нехтує ревізіями, що перелічені у '<файлі>', який має бути в тому ж форматі що й `fsck.skipList`. Цей параметр може бути вказано декілька разів. Ці файли будуть опрацьовані після усіх файлів, що визначені параметром конфігурації `blame.ignoreRevsFile`. Порожнє ім'я файлу (`\"\"`) очищає перелік ревізій з попередніх опрацьованих файлів."
 
 #. type: Labeled list
 #: en/blame-options.txt:137
@@ -310,7 +310,7 @@ msgstr "--color-by-age"
 #: en/blame-options.txt:147
 #, placeholders:'color.blame.highlightRecent', priority:100
 msgid "Color line annotations depending on the age of the line in the default format. The `color.blame.highlightRecent` config option controls what color is used for each range of age."
-msgstr "Забарвлює анотації до рядків у типовому форматі залежно від віку рядка. Параметр конфігурації `color.blame.highlightRecent` визначає який колір вживати для кожного вікового проміжку."
+msgstr "Забарвлює анотації до рядків у типовому форматі залежно від віку рядка. Параметр конфігурації `color.blame.highlightRecent` визначає який колір застосовувати для кожного вікового проміжку."
 
 #. type: Labeled list
 #: en/blame-options.txt:148 en/git-archimport.txt:71 en/git-cvsimport.txt:184 en/git-cvsserver.txt:60 en/git-grep.txt:122 en/git.txt:50

--- a/po/documentation.uk.po
+++ b/po/documentation.uk.po
@@ -8935,25 +8935,25 @@ msgstr "git-annotate(1)"
 #: en/git-annotate.txt:7
 #, placeholders:'git-annotate', priority:100
 msgid "git-annotate - Annotate file lines with commit information"
-msgstr ""
+msgstr "git-annotate - Анотує рядки файлу інформацією про коміт"
 
 #. type: Plain text
 #: en/git-annotate.txt:12
 #, no-wrap, priority:100
 msgid "'git annotate' [<options>] [<rev-opts>] [<rev>] [--] <file>\n"
-msgstr ""
+msgstr "'git annotate' [<опції>] [<опції-ревізії>] [<ревізія>] [--] <файл>\n"
 
 #. type: Plain text
 #: en/git-annotate.txt:17
 #, priority:100
 msgid "Annotates each line in the given file with information from the commit which introduced the line. Optionally annotates from a given revision."
-msgstr ""
+msgstr "Анотує кожен рядок у вказаному файлі інформацією про коміт, у якому рядок було додано. За бажанням, анотує з вказаної ревізії."
 
 #. type: Plain text
 #: en/git-annotate.txt:22
 #, placeholders:'linkgit:git-blame[1]', priority:100
 msgid "The only difference between this command and linkgit:git-blame[1] is that they use slightly different output formats, and this command exists only for backward compatibility to support existing scripts, and provide a more familiar command name for people coming from other SCM systems."
-msgstr ""
+msgstr "Єдина різниця між цією командою та linkgit:git-blame[1] у використанні дещо різних форматів виводу і ця команда існує лише задля підтримки зворотньої сумісності зі скриптами, що вже існують, та надання звичнішої назви команди для людей, що приходять з інших систем управління вихідним кодом."
 
 #. type: Title =
 #: en/git-apply.txt:2

--- a/po/documentation.uk.po
+++ b/po/documentation.uk.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: git-manpages-l 10n\n"
 "Report-Msgid-Bugs-To: jn.avila@free.fr\n"
 "POT-Creation-Date: 2024-09-29 21:35+0200\n"
-"PO-Revision-Date: 2022-06-19 08:17+0000\n"
+"PO-Revision-Date: 2024-10-04 16:02+0300\n"
 "Last-Translator: Andrij Mizyk <andmiz@proton.me>\n"
 "Language-Team: Ukrainian <trans-uk@lists.fedoraproject.org>\n"
 "Language: uk\n"
@@ -28,7 +28,7 @@ msgstr "-b"
 #: en/blame-options.txt:4
 #, placeholders:'blame.blankBoundary', priority:100
 msgid "Show blank SHA-1 for boundary commits. This can also be controlled via the `blame.blankBoundary` config option."
-msgstr ""
+msgstr "Показує порожній SHA-1 для граничних комітів. Поведінка також можу бути задана за допомогою параметра конфігурації `blame.blankBoundary`."
 
 #. type: Labeled list
 #: en/blame-options.txt:5 en/git-diff-tree.txt:42 en/git-format-patch.txt:421 en/git-fsck.txt:38 en/git-rebase.txt:591
@@ -40,7 +40,7 @@ msgstr "--root"
 #: en/blame-options.txt:8
 #, placeholders:'blame.showRoot', priority:100
 msgid "Do not treat root commits as boundaries. This can also be controlled via the `blame.showRoot` config option."
-msgstr ""
+msgstr "Не розглядає кореневі коміти як межі. Поведінка також може бути задана за допомогою параметра конфігурації `blame.showRoot`."
 
 #. type: Labeled list
 #: en/blame-options.txt:9
@@ -52,31 +52,31 @@ msgstr "--show-stats"
 #: en/blame-options.txt:11
 #, priority:100
 msgid "Include additional statistics at the end of blame output."
-msgstr ""
+msgstr "Подає додаткову статистику наприкінці інформації про авторство."
 
 #. type: Labeled list
 #: en/blame-options.txt:12
 #, no-wrap, priority:100
 msgid "-L <start>,<end>"
-msgstr ""
+msgstr "-L <початок>,<кінець>"
 
 #. type: Labeled list
 #: en/blame-options.txt:13
 #, no-wrap, priority:100
 msgid "-L :<funcname>"
-msgstr ""
+msgstr "-L :<ім'я_функції>"
 
 #. type: Plain text
 #: en/blame-options.txt:17
 #, priority:100
 msgid "Annotate only the line range given by '<start>,<end>', or by the function name regex '<funcname>'. May be specified multiple times. Overlapping ranges are allowed."
-msgstr ""
+msgstr "Анотовує лише проміжок рядків, заданий за допомогою '<початок>,<кінець>' або за регулярним виразом імені функції '<ім'я_функції>'. Може бути задано декілька разів. Допускається накладання проміжків."
 
 #. type: Plain text
 #: en/blame-options.txt:20
 #, priority:100
 msgid "'<start>' and '<end>' are optional. `-L <start>` or `-L <start>,` spans from '<start>' to end of file. `-L ,<end>` spans from start of file to '<end>'."
-msgstr ""
+msgstr "'<початок>' та '<кінець>' необов'язкові. `-L <початок>` або `-L <початок>,` охоплює рядки від '<початок>' до кінця файлу. `-L ,<кінець>` - від початку файлу до '<кінець>'."
 
 #. type: Labeled list
 #: en/blame-options.txt:23 en/git-archive.txt:45 en/git-branch.txt:181 en/git-checkout.txt:207 en/git-config.txt:304 en/git-grep.txt:164 en/git-instaweb.txt:23 en/git-ls-tree.txt:51 en/git-repack.txt:94 en/git-svn.txt:244 en/git-tag.txt:100 en/git-var.txt:21
@@ -88,7 +88,7 @@ msgstr "-l"
 #: en/blame-options.txt:25
 #, priority:100
 msgid "Show long rev (Default: off)."
-msgstr ""
+msgstr "Показує повні значення ревізії (Типово: вимкнено)."
 
 #. type: Labeled list
 #: en/blame-options.txt:26 en/diff-options.txt:163 en/fetch-options.txt:196 en/git-branch.txt:217 en/git-cat-file.txt:40 en/git-checkout.txt:164 en/git-diff-tree.txt:39 en/git-ls-files.txt:142 en/git-ls-remote.txt:26 en/git-ls-tree.txt:47 en/git-svn.txt:312 en/git-switch.txt:158
@@ -100,31 +100,31 @@ msgstr "-t"
 #: en/blame-options.txt:28
 #, priority:100
 msgid "Show raw timestamp (Default: off)."
-msgstr ""
+msgstr "Показувати необроблену мітку часу (Типово: вимкнено)."
 
 #. type: Labeled list
 #: en/blame-options.txt:29
 #, no-wrap, priority:100
 msgid "-S <revs-file>"
-msgstr ""
+msgstr "-S <файл_ревізій>"
 
 #. type: Plain text
 #: en/blame-options.txt:31
 #, placeholders:'linkgit:git-rev-list[1]', priority:100
 msgid "Use revisions from revs-file instead of calling linkgit:git-rev-list[1]."
-msgstr ""
+msgstr "Використовує ревізії із вказаного файлу ревізій замість виклику linkgit:git-rev-list[1]."
 
 #. type: Labeled list
 #: en/blame-options.txt:32
 #, no-wrap, placeholders:'--reverse', priority:100
 msgid "--reverse <rev>..<rev>"
-msgstr ""
+msgstr "—reverse <ревізія>..<ревізія>"
 
 #. type: Plain text
 #: en/blame-options.txt:39
 #, placeholders:'--reverse':'--reverse':'HEAD`', priority:100
 msgid "Walk history forward instead of backward. Instead of showing the revision in which a line appeared, this shows the last revision in which a line has existed. This requires a range of revision like START..END where the path to blame exists in START. `git blame --reverse START` is taken as `git blame --reverse START..HEAD` for convenience."
-msgstr ""
+msgstr "Рухає історію вперед, а не назад. Замість відображення ревізії, у якій рядок з'явився, відображає останню ревізію у якій він існував. Для цього потрібно вказати проміжок ревізій, наприклад, ПОЧАТОК..КІНЕЦЬ, де рядок, який ви шукаєте, повинен існувати у ПОЧАТКУ. `git blame —reverse START` є скороченням для `git blame —reverse START..HEAD`."
 
 #. type: Labeled list
 #: en/blame-options.txt:40 en/git-bisect.txt:375 en/git-describe.txt:122 en/rev-list-options.txt:129
@@ -136,7 +136,7 @@ msgstr "--first-parent"
 #: en/blame-options.txt:45
 #, priority:100
 msgid "Follow only the first parent commit upon seeing a merge commit. This option can be used to determine when a line was introduced to a particular integration branch, rather than when it was introduced to the history overall."
-msgstr ""
+msgstr "Слідує лише за першим батьківським комітом після того, як побачить коміт злиття. Ця опція може бути використана для визначення коли рядок з'явився саме у певній гілці, а не коли його в цілому було додано."
 
 #. type: Labeled list
 #: en/blame-options.txt:46 en/diff-options.txt:16 en/diff-options.txt:22 en/fetch-options.txt:137 en/git-add.txt:96 en/git-cat-file.txt:55 en/git-checkout.txt:278 en/git-commit.txt:73 en/git-cvsexportcommit.txt:41 en/git-grep.txt:217 en/git-instaweb.txt:41 en/git-merge-file.txt:76 en/git-request-pull.txt:29 en/git-restore.txt:48 en/git-stash.txt:196 en/git-svn.txt:535 en/git-svn.txt:679 en/git.txt:129
@@ -154,7 +154,7 @@ msgstr "--porcelain"
 #: en/blame-options.txt:49
 #, priority:100
 msgid "Show in a format designed for machine consumption."
-msgstr ""
+msgstr "Показує у форматі, призначеному для машинного використання."
 
 #. type: Labeled list
 #: en/blame-options.txt:50
@@ -166,7 +166,7 @@ msgstr "--line-porcelain"
 #: en/blame-options.txt:54
 #, placeholders:'--porcelain', priority:100
 msgid "Show the porcelain format, but output commit information for each line, not just the first time a commit is referenced. Implies --porcelain."
-msgstr ""
+msgstr "Показує у \"порцеляновому\" форматі (як за використання --porcelain), але виводить інформацію про коміт для кожного рядка, а не лише за першої згадки про коміт."
 
 #. type: Labeled list
 #: en/blame-options.txt:55 en/git-pack-objects.txt:176 en/git-svn.txt:373
@@ -178,43 +178,43 @@ msgstr "--incremental"
 #: en/blame-options.txt:58
 #, priority:100
 msgid "Show the result incrementally in a format designed for machine consumption."
-msgstr ""
+msgstr "Показує результати покроково у форматі, призначеному для машинного використання."
 
 #. type: Labeled list
 #: en/blame-options.txt:59 en/git-mailinfo.txt:64 en/pretty-options.txt:35
 #, no-wrap, placeholders:'--encoding=', priority:260
 msgid "--encoding=<encoding>"
-msgstr ""
+msgstr "--encoding=<кодування>"
 
 #. type: Plain text
 #: en/blame-options.txt:65
 #, placeholders:'linkgit:git-log[1]', priority:100
 msgid "Specifies the encoding used to output author names and commit summaries. Setting it to `none` makes blame output unconverted data. For more information see the discussion about encoding in the linkgit:git-log[1] manual page."
-msgstr ""
+msgstr "Визначає кодування для виводу імені автора та заголовку коміту. Встановлення значення `none` призводить до виводу неконвертованих даних. Детальніше дивіться обговорення кодування на сторінці посібника linkgit:git-log[1]."
 
 #. type: Labeled list
 #: en/blame-options.txt:66
 #, no-wrap, placeholders:'--contents', priority:100
 msgid "--contents <file>"
-msgstr ""
+msgstr "--contents <файл>"
 
 #. type: Plain text
 #: en/blame-options.txt:70
 #, priority:100
 msgid "Annotate using the contents from the named file, starting from <rev> if it is specified, and HEAD otherwise. You may specify '-' to make the command read from the standard input for the file contents."
-msgstr ""
+msgstr "Анотовує використовуючи вміст вказаного файлу, починаючи з <ревізії>, якщо її визначено, або ж з HEAD. Ви можете вказати '-' аби команда зчитувала контент файлу зі стандартного вводу."
 
 #. type: Labeled list
 #: en/blame-options.txt:71
 #, no-wrap, placeholders:'--date', priority:100
 msgid "--date <format>"
-msgstr ""
+msgstr "--date <формат>"
 
 #. type: Plain text
 #: en/blame-options.txt:77
 #, placeholders:'--date':'blame.date':'blame.date':'--date':'linkgit:git-log[1]', priority:100
 msgid "Specifies the format used to output dates. If --date is not provided, the value of the blame.date config variable is used. If the blame.date config variable is also not set, the iso format is used. For supported values, see the discussion of the --date option at linkgit:git-log[1]."
-msgstr ""
+msgstr "Визначає формат виводу дати. Якщо цей параметр відсутній, буде використано значення параметру конфігурації `blame.date`. Якщо ж і його немає, то буде використано формат ISO. Задля ознайомлення із підтримуваними значенням дивіться обговорення параметру `--date` у linkgit:git-log[1]."
 
 #. type: Labeled list
 #: en/blame-options.txt:78 en/git-fsck.txt:100
@@ -226,67 +226,67 @@ msgstr "--[no-]progress"
 #: en/blame-options.txt:84
 #, placeholders:'`--progress`':'`--porcelain`':'`--incremental`', priority:100
 msgid "Progress status is reported on the standard error stream by default when it is attached to a terminal. This flag enables progress reporting even if not attached to a terminal. Can't use `--progress` together with `--porcelain` or `--incremental`."
-msgstr ""
+msgstr "Типово, статус виконання виводиться у стандартному потоці помилок, коли він підключений до терміналу. Цей прапорець дозволяє виводити прогрес навіть коли такий потік не підключено. Не може використовуватися разом з `--porcelain` чи `--incremental`."
 
 #. type: Labeled list
 #: en/blame-options.txt:85
 #, no-wrap, priority:100
 msgid "-M[<num>]"
-msgstr ""
+msgstr "-M[<число>]"
 
 #. type: Plain text
 #: en/blame-options.txt:95
 #, priority:100
 msgid "Detect moved or copied lines within a file. When a commit moves or copies a block of lines (e.g. the original file has A and then B, and the commit changes it to B and then A), the traditional 'blame' algorithm notices only half of the movement and typically blames the lines that were moved up (i.e. B) to the parent and assigns blame to the lines that were moved down (i.e. A) to the child commit. With this option, both groups of lines are blamed on the parent by running extra passes of inspection."
-msgstr ""
+msgstr "Виявляє переміщені чи скопійовані рядки всередині файлу. Коли коміт переміщує чи копіює сукупність рядків (наприклад, коли вихідний файл містить рядок А і потім Б, а коміт переставляє спочатку Б, а тоді А), традиційний алгоритм розпізнає лише половину руху і, зазвичай, приписує рядки, що були переміщені вгору (тобто Б), батьківському коміту, а рядки, що були переміщені вниз (тобто А), - дочірньому. Із цим параметром, обидві групи рядків приписуються батьківському шляхом виконання додаткових перевірок."
 
 #. type: Plain text
 #: en/blame-options.txt:100
 #, priority:100
 msgid "<num> is optional but it is the lower bound on the number of alphanumeric characters that Git must detect as moving/copying within a file for it to associate those lines with the parent commit. The default value is 20."
-msgstr ""
+msgstr "<число> необов'язкове. Це нижня межа кількості буквено-цифрових символів, які Git має визначити як переміщені/скопійовані всередині файлу, щоб пов'язати ці рядки із батьківським комітом. Типово дорівнює 20."
 
 #. type: Labeled list
 #: en/blame-options.txt:101
 #, no-wrap, priority:100
 msgid "-C[<num>]"
-msgstr ""
+msgstr "-C[<число>]"
 
 #. type: Plain text
 #: en/blame-options.txt:110
 #, placeholders:'`-M`', priority:100
 msgid "In addition to `-M`, detect lines moved or copied from other files that were modified in the same commit. This is useful when you reorganize your program and move code around across files. When this option is given twice, the command additionally looks for copies from other files in the commit that creates the file. When this option is given three times, the command additionally looks for copies from other files in any commit."
-msgstr ""
+msgstr "На додачу до `-M` визначає переміщені або скопійовані рядки з інших файлів, що були змінені у тому самому коміті. Це корисно коли ви реорганізовуєте вашу програму та переміщуєте код між файлами. Коли цей параметр вказано двічі, команда додатково шукає копії з інших файлів у коміті в якому файл було створено. Якщо ж його вказано тричі, то команда додатково шукає копії з інших файлів у будь-якому коміті."
 
 #. type: Plain text
 #: en/blame-options.txt:117
 #, placeholders:'`-C`':'`-C`', priority:100
 msgid "<num> is optional but it is the lower bound on the number of alphanumeric characters that Git must detect as moving/copying between files for it to associate those lines with the parent commit. And the default value is 40. If there are more than one `-C` options given, the <num> argument of the last `-C` will take effect."
-msgstr ""
+msgstr "<число> необов'язкове. Це нижня межа кількості буквено-цифрових символів, які Git має визначити як переміщені/скопійовані між файлами, аби пов'язати ці рядки із батьківським комітом. Типово дорівнює 40. Якщо вказано більше одного параметру `-C`, то буде використано <число> останнього з них."
 
 #. type: Labeled list
 #: en/blame-options.txt:118
 #, no-wrap, placeholders:'--ignore-rev', priority:100
 msgid "--ignore-rev <rev>"
-msgstr ""
+msgstr "--ignore-rev <ревізія>"
 
 #. type: Plain text
 #: en/blame-options.txt:129
 #, placeholders:'blame.markIgnoredLines':'blame.markUnblamableLines', priority:100
 msgid "Ignore changes made by the revision when assigning blame, as if the change never happened. Lines that were changed or added by an ignored commit will be blamed on the previous commit that changed that line or nearby lines. This option may be specified multiple times to ignore more than one revision. If the `blame.markIgnoredLines` config option is set, then lines that were changed by an ignored commit and attributed to another commit will be marked with a `?` in the blame output. If the `blame.markUnblamableLines` config option is set, then those lines touched by an ignored commit that we could not attribute to another revision are marked with a '*'."
-msgstr ""
+msgstr "Нехтує змінами, що зроблені ревізією, коли призначає авторство, так, ніби змін ніколи не існувало. Рядки, що були змінені чи додані знехтуваним комітом, будуть приписані до попереднього коміту, який змінював ці чи найближчі рядки. Цей параметр може бути вказаним декілька разів для нехтування декількома ревізіями. Якщо налаштовано параметр конфігурації `blame.markIgnoredLines`, рядки, які були змінені знехтуваним комітом та приписано до іншого, буде позначено символом `?` у інформації про авторство. Якщо налаштовано параметр конфігурації `blame.markUnblamableLines`, то рядки, на які вплинув знехтуваний коміт, але які не були приписані до іншого, будуть позначені символом `*`."
 
 #. type: Labeled list
 #: en/blame-options.txt:130
 #, no-wrap, placeholders:'--ignore-revs-file', priority:100
 msgid "--ignore-revs-file <file>"
-msgstr ""
+msgstr "--ignore-revs-file <файл>"
 
 #. type: Plain text
 #: en/blame-options.txt:136
 #, placeholders:'fsck.skipList':'blame.ignoreRevsFile', priority:100
 msgid "Ignore revisions listed in `file`, which must be in the same format as an `fsck.skipList`. This option may be repeated, and these files will be processed after any files specified with the `blame.ignoreRevsFile` config option. An empty file name, `\"\"`, will clear the list of revs from previously processed files."
-msgstr ""
+msgstr "Нехтує ревізіями, що перелічені у `файлі`, який має бути в тому ж форматі що й `fsck.skipList`. Цей параметр може бути вказано декілька разів. Ці файли будуть опрацьовані після усіх файлів, що визначені параметром конфігурації `blame.ignoreRevsFile`. Порожнє ім'я файлу (`""`) очищає перелік ревізій з попередніх опрацьованих файлів."
 
 #. type: Labeled list
 #: en/blame-options.txt:137
@@ -298,7 +298,7 @@ msgstr "--color-lines"
 #: en/blame-options.txt:142
 #, placeholders:'color.blame.repeatedLines', priority:100
 msgid "Color line annotations in the default format differently if they come from the same commit as the preceding line. This makes it easier to distinguish code blocks introduced by different commits. The color defaults to cyan and can be adjusted using the `color.blame.repeatedLines` config option."
-msgstr ""
+msgstr "Забарвлює анотації до рядків у типовому форматі в інший колір, якщо зміни походять від того самого коміту, що й попередній рядок. Це полегшує розрізнення блоків коду внесених різними комітами. Типовим кольором є ціановий, який може бути налаштований параметром конфігурації `color.blame.repeatedLines`."
 
 #. type: Labeled list
 #: en/blame-options.txt:143
@@ -310,7 +310,7 @@ msgstr "--color-by-age"
 #: en/blame-options.txt:147
 #, placeholders:'color.blame.highlightRecent', priority:100
 msgid "Color line annotations depending on the age of the line in the default format. The `color.blame.highlightRecent` config option controls what color is used for each range of age."
-msgstr ""
+msgstr "Забарвлює анотації до рядків у типовому форматі залежно від віку рядка. Параметр конфігурації `color.blame.highlightRecent` визначає який колір вживати для кожного вікового проміжку."
 
 #. type: Labeled list
 #: en/blame-options.txt:148 en/git-archimport.txt:71 en/git-cvsimport.txt:184 en/git-cvsserver.txt:60 en/git-grep.txt:122 en/git.txt:50
@@ -322,7 +322,7 @@ msgstr "-h"
 #: en/blame-options.txt:149
 #, priority:100
 msgid "Show help message."
-msgstr ""
+msgstr "Показує підказку."
 
 #. type: Plain text
 #: en/cmds-ancillaryinterrogators.txt:1 en/git-blame.txt:254

--- a/po/documentation.uk.po
+++ b/po/documentation.uk.po
@@ -70,13 +70,13 @@ msgstr "-L :<ім'я_функції>"
 #: en/blame-options.txt:17
 #, priority:100
 msgid "Annotate only the line range given by '<start>,<end>', or by the function name regex '<funcname>'. May be specified multiple times. Overlapping ranges are allowed."
-msgstr "Анотовує лише проміжок рядків, заданий за допомогою '<початок>,<кінець>' або за регулярним виразом імені функції '<ім'я_функції>'. Може бути задано декілька разів. Допускається накладання проміжків."
+msgstr "Анотує лише проміжок рядків, заданий за допомогою '<початок>,<кінець>' або за регулярним виразом '<ім'я_функції>' назви функції. Може бути задано декілька разів. Допускається накладання проміжків."
 
 #. type: Plain text
 #: en/blame-options.txt:20
 #, priority:100
 msgid "'<start>' and '<end>' are optional. `-L <start>` or `-L <start>,` spans from '<start>' to end of file. `-L ,<end>` spans from start of file to '<end>'."
-msgstr "'<початок>' та '<кінець>' необов'язкові. `-L <початок>` або `-L <початок>,` охоплює рядки від '<початок>' до кінця файлу. `-L ,<кінець>` - від початку файлу до '<кінець>'."
+msgstr "'<початок>' та '<кінець>' необов'язкові. `-L <початок>` або `-L <початок>,` охоплює рядки від '<початку>' до кінця файлу. `-L ,<кінець>` - від початку файлу до '<кінця>'."
 
 #. type: Labeled list
 #: en/blame-options.txt:23 en/git-archive.txt:45 en/git-branch.txt:181 en/git-checkout.txt:207 en/git-config.txt:304 en/git-grep.txt:164 en/git-instaweb.txt:23 en/git-ls-tree.txt:51 en/git-repack.txt:94 en/git-svn.txt:244 en/git-tag.txt:100 en/git-var.txt:21
@@ -202,7 +202,7 @@ msgstr "--contents <файл>"
 #: en/blame-options.txt:70
 #, priority:100
 msgid "Annotate using the contents from the named file, starting from <rev> if it is specified, and HEAD otherwise. You may specify '-' to make the command read from the standard input for the file contents."
-msgstr "Анотовує використовуючи вміст вказаного файлу, починаючи з <ревізії>, якщо її визначено, або ж з HEAD. Ви можете вказати '-' аби команда зчитувала контент файлу зі стандартного вводу."
+msgstr "Анотує використовуючи вміст вказаного файлу, починаючи з <ревізії>, якщо її визначено, або ж з HEAD. Ви можете вказати '-' аби команда зчитувала контент файлу зі стандартного вводу."
 
 #. type: Labeled list
 #: en/blame-options.txt:71


### PR DESCRIPTION
Add Ukrainian translation for strings related to `blame-options`, `line-range-format`, and `git-annotate`