### PR TITLE
Add files via upload

### DIFF
--- a/.github/workflows/ads.txt
+++ b/.github/workflows/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-2597191697610969, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
This pull request adds a new entry to the `.github/workflows/ads.txt` file to include a Google advertising publisher ID.

- Added a Google AdSense publisher entry to `ads.txt` for ad verification and authorization.[Copilot is generating a summary...]